### PR TITLE
Reset Block after cleanup

### DIFF
--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -398,8 +398,11 @@ finish as soon as possible. It then lets 3 seconds for all the Blocks to
 finish. If any Block is still alive passed this delay, it is mercilessly
 terminated. Then, the :obj:`~multiprocessing.Process` in charge of the
 :class:`~crappy.tool.ft232h.USBServer` is stopped, if applicable. Same goes for
-the :obj:`~threading.Thread` collecting all the log messages. Finally, an
-exception might be raised in three cases :
+the :obj:`~threading.Thread` collecting all the log messages. Short before
+returning, Crappy is reset by the :meth:`~crappy.blocks.Block.reset` method,
+that re-initializes all the synchronization objects. They are after all not
+needed anymore at that point. Finally, an exception might be raised in three
+cases :
 
 - If all the Blocks are not done running at the end of this phase.
 - If an :exc:`Exception` was caught during Crappy's execution.


### PR DESCRIPTION
With this PR the Block object is now reset (by means of the `Block.reset()` method) at the end of each call to `Block._cleanup()`.
It cleans up all the references to the instantiated Blocks, as well as the synchronization objects and other instantiated multiprocessing objects. 
These references and objects are anyway not of any use at that point anymore.

Users now don't need to manually call `crappy.reset()` before being able to restart a script.