### PR TITLE
Allow custom overlay on Camera Displayer

### DIFF
--- a/docs/source/crappy_docs/tools.rst
+++ b/docs/source/crappy_docs/tools.rst
@@ -67,7 +67,7 @@ Configurator Tools
 Box
 """
 .. autoclass:: crappy.tool.camera_config.config_tools.Box
-   :members: no_points, reset, sorted
+   :members: no_points, reset, sorted, draw
    :special-members: __init__, __post_init__
 
 Histogram Process

--- a/docs/source/crappy_docs/tools.rst
+++ b/docs/source/crappy_docs/tools.rst
@@ -76,6 +76,12 @@ Histogram Process
    :members: run, log
    :special-members: __init__
 
+Overlay
+"""""""
+.. autoclass:: crappy.tool.camera_config.config_tools.Overlay
+   :members: draw, log
+   :special-members: __init__
+
 Spots Boxes
 """""""""""
 .. autoclass:: crappy.tool.camera_config.config_tools.SpotsBoxes

--- a/docs/source/crappy_docs/tools.rst
+++ b/docs/source/crappy_docs/tools.rst
@@ -68,7 +68,7 @@ Box
 """
 .. autoclass:: crappy.tool.camera_config.config_tools.Box
    :members: no_points, reset, sorted
-   :special-members: __init__
+   :special-members: __init__, __post_init__
 
 Histogram Process
 """""""""""""""""

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -389,6 +389,7 @@ class Camera(Block):
                               "image processing process")
       overlay_conn = (self._overlay_conn_in if self._display_proc is not None
                       else None)
+      labels = self.labels if self.labels is not None else None
       self._process_proc.set_shared(array=self._img_array,
                                     data_dict=self._metadata,
                                     lock=self._proc_lock,
@@ -398,7 +399,7 @@ class Camera(Block):
                                     dtype=self._img_dtype,
                                     to_draw_conn=overlay_conn,
                                     outputs=self.outputs,
-                                    labels=list(self.labels))
+                                    labels=labels)
       self.log(logging.INFO, "Starting the image processing process")
       self._process_proc.start()
 

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -101,7 +101,7 @@ class CameraProcess(Process):
                  dtype,
                  to_draw_conn: Optional[Connection],
                  outputs: List[Link],
-                 labels: List[str]) -> None:
+                 labels: Optional[List[str]]) -> None:
     """Method allowing the :class:`~crappy.blocks.Camera` Block to share
     :mod:`multiprocessing` synchronization objects with this class.
     

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -17,7 +17,7 @@ from platform import system
 
 from ...links import Link
 from ..._global import LinkDataError
-from ...tool.camera_config import SpotsBoxes
+from ...tool.camera_config import Overlay
 
 
 class CameraProcess(Process):
@@ -77,7 +77,7 @@ class CameraProcess(Process):
     self._cam_barrier: Optional[Barrier] = None
     self._stop_event: Optional[Event] = None
     self._shape: Optional[Tuple[int, int]] = None
-    self._box_conn: Optional[Connection] = None
+    self._to_draw_conn: Optional[Connection] = None
     self._outputs: List[Link] = list()
     self._labels: List[str] = list()
     self._img: Optional[np.ndarray] = None
@@ -99,7 +99,7 @@ class CameraProcess(Process):
                  event: Event,
                  shape: Tuple[int, int],
                  dtype,
-                 box_conn: Optional[Connection],
+                 to_draw_conn: Optional[Connection],
                  outputs: List[Link],
                  labels: List[str]) -> None:
     """Method allowing the :class:`~crappy.blocks.Camera` Block to share
@@ -123,9 +123,9 @@ class CameraProcess(Process):
         necessary as the frames are shared as a one-dimensional array.
       dtype: The expected dtype of the image. It is necessary for 
         reconstructing the image from the one-dimensional shared array.
-      box_conn: A :obj:`~multiprocessing.Connection` for sending or receiving
-        :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` objects to
-        draw on top of the displayed image.
+      to_draw_conn: A :obj:`~multiprocessing.Connection` for sending or
+        receiving :class:`~crappy.tool.camera_config.config_tools.Overlay`
+        objects to draw on top of the displayed image.
       outputs: The :class:`~crappy.links.Link` objects for sending data to
         downstream Blocks. They are the same as those owned by the Camera 
         Block.
@@ -139,7 +139,7 @@ class CameraProcess(Process):
     self._stop_event = event
     self._shape = shape
     self._dtype = dtype
-    self._box_conn = box_conn
+    self._to_draw_conn = to_draw_conn
     self._outputs = outputs
     self._labels = labels
 
@@ -332,33 +332,33 @@ class CameraProcess(Process):
       self._logger.log(logging.DEBUG, f"Sending {data} to Link {link.name}")
       link.send(data)
 
-  def _send_box(self, boxes: SpotsBoxes) -> None:
-    """This method sends
-    :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` objects to the
+  def _send_to_draw(self, to_draw: Iterable[Overlay]) -> None:
+    """This method sends a collection of
+    :class:`~crappy.tool.camera_config.config_tools.Overlay` objects to the
     :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess.
 
-    The boxes are sent by the CameraProcess performing the image processing, so
-    that the area(s) of interest can be displayed simultaneously.
+    The overlays are sent by the CameraProcess performing the image processing,
+    so that the area(s) of interest can be displayed simultaneously.
     """
 
     # Not sending if there's no Connection to send data through
-    if self._box_conn is None:
+    if self._to_draw_conn is None:
       return
 
-    self._log(logging.DEBUG, "Sending the box(es) to the displayer process")
+    self._log(logging.DEBUG, "Sending the overlays to the displayer process")
 
-    # Sending the boxes
+    # Sending the overlay
     if self._system == 'Linux':
-      if select([], [self._box_conn], [], 0)[1]:
+      if select([], [self._to_draw_conn], [], 0)[1]:
         # Can only check on Linux if a pipe is full
-        self._box_conn.send(boxes)
+        self._to_draw_conn.send(to_draw)
       elif time() - self._last_warn > 1:
         # Warning in case the pipe is full
           self._last_warn = time()
-          self._log(logging.WARNING, f"Cannot send the box(es) to draw to the "
+          self._log(logging.WARNING, f"Cannot send the overlay to draw to the "
                                      f"Displayer process, the Pipe is full !")
     else:
-      self._box_conn.send(boxes)
+      self._to_draw_conn.send(to_draw)
 
   def _set_logger(self) -> None:
     """Initializes the :obj:`~logging.Logger` for the CameraProcess.

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -184,7 +184,7 @@ class DICVEProcess(CameraProcess):
         self._send([self._metadata['t(s)'], self._metadata, *data])
 
         # Sending the patches to the Displayer for display
-        self._send_box(self._disve.patches)
+        self._send_to_draw(self._disve.patches)
 
       # If the patches are lost, deciding whether to raise exception or not
       except RuntimeError as exc:

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -164,4 +164,4 @@ class DISCorrelProcess(CameraProcess):
     self._send([self._metadata['t(s)'], self._metadata, *data])
 
     # Sending the ROI to the Displayer for display
-    self._send_box(SpotsBoxes(self._dis_correl.box))
+    self._send_to_draw(SpotsBoxes(self._dis_correl.box))

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -11,7 +11,7 @@ import logging.handlers
 
 from .camera_process import CameraProcess
 from ..._global import OptionalModule
-from ...tool.camera_config import SpotsBoxes, Box
+from ...tool.camera_config import SpotsBoxes
 
 plt = OptionalModule('matplotlib.pyplot', lazy_import=True)
 
@@ -199,9 +199,9 @@ class Displayer(CameraProcess):
     # Drawing the latest known position of the boxes
     for box in self._boxes:
       if box is not None:
-        self._log(logging.DEBUG, "Drawing boxes on top of the image to "
+        self._log(logging.DEBUG, f"Drawing {box} on top of the image to "
                                  "display")
-        self._draw_box(img, box)
+        box.draw(img)
 
     # Calling the right update method
     if self._backend == 'cv2':
@@ -257,27 +257,6 @@ class Displayer(CameraProcess):
         sleep(0.001)
 
     self._log(logging.INFO, "Thread for receiving the boxes ended")
-
-  def _draw_box(self, img: np.ndarray, box: Box) -> None:
-    """Draws a :class:`~crappy.tool.camera_config.config_tools.Box` on top of 
-    an image."""
-
-    if box.no_points():
-      return
-
-    x_top, x_bottom, y_left, y_right = box.sorted()
-    max_fact = max(img.shape[0] // 480, img.shape[1] // 640, 1)
-
-    try:
-      for line in (line for i in range(max_fact + 1) for line in
-                   ((box.y_start + i, slice(x_top, x_bottom)),
-                    (box.y_end - i, slice(x_top, x_bottom)),
-                    (slice(y_left, y_right), x_top + i),
-                    (slice(y_left, y_right), x_bottom - i))):
-        img[line] = 255 * int(np.mean(img[line]) < 128)
-    except (Exception,) as exc:
-      self._logger.exception("Encountered exception while drawing boxes, "
-                             "ignoring", exc_info=exc)
 
   def _prepare_cv2(self) -> None:
     """Instantiates the display window of :mod:`cv2`."""

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -4,14 +4,14 @@ from multiprocessing.queues import Queue
 from threading import Thread
 from math import log2, ceil
 import numpy as np
-from typing import Optional
+from typing import Optional, Iterable
 from time import time, sleep
 import logging
 import logging.handlers
 
 from .camera_process import CameraProcess
 from ..._global import OptionalModule
-from ...tool.camera_config import SpotsBoxes
+from ...tool.camera_config import Overlay
 
 plt = OptionalModule('matplotlib.pyplot', lazy_import=True)
 
@@ -29,10 +29,10 @@ class Displayer(CameraProcess):
   It is meant to serve as a control or validation feature, its resolution is
   thus limited to `640x480` and it should not be used at high framerates. On
   top of the displayed image, it can also draw 
-  :class:`~crappy.tool.camera_config.config_tools.Box` or 
-  :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` for the Blocks
-  that use them. This way, the user can for example visualize the spots being
-  tracked by the :class:`~crappy.blocks.VideoExtenso` Block.
+  :class:`~crappy.tool.camera_config.config_tools.Overlay` objects sent by
+  other :class:`~crappy.blocks.camera_processes.CameraProcess`. This way, the
+  user can for example visualize the spots being tracked by the
+  :class:`~crappy.blocks.VideoExtenso` Block in real time.
 
   The images can be displayed using two different backends : either using
   :mod:`cv2` (OpenCV), or using :mod:`matplotlib`. OpenCV is by far the fastest
@@ -65,8 +65,8 @@ class Displayer(CameraProcess):
     """
 
     # The thread must be initialized later for compatibility with Windows
-    self._box_thread: Optional[Thread] = None
-    self._boxes: SpotsBoxes = SpotsBoxes()
+    self._overlay_thread: Optional[Thread] = None
+    self._overlay: Iterable[Overlay] = list()
     self._stop_thread = False
 
     super().__init__(log_queue=log_queue,
@@ -102,28 +102,28 @@ class Displayer(CameraProcess):
 
   def __del__(self) -> None:
     """On exit, ensuring that the :obj:`~threading.Thread` in charge of
-    grabbing the :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` to
+    grabbing the :class:`~crappy.tool.camera_config.config_tools.Overlay` to
     display has stopped, otherwise stopping it."""
 
-    if self._box_thread is not None and self._box_thread.is_alive():
+    if self._overlay_thread is not None and self._overlay_thread.is_alive():
       self._stop_thread = True
       try:
-        self._box_thread.join(0.05)
+        self._overlay_thread.join(0.05)
       except RuntimeError:
         pass
 
   def _init(self) -> None:
     """Starts the :obj:`~threading.Thread` for grabbing the
-    :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` to display, and 
+    :class:`~crappy.tool.camera_config.config_tools.Overlay` to display, and
     initializes the Displayer window."""
 
-    # Instantiating and starting the Thread for grabbing the SpotsBoxes
-    self._log(logging.INFO, "Instantiating the thread for getting the boxes "
-                            "to display")
-    self._box_thread = Thread(target=self._thread_target)
-    self._log(logging.INFO, "Starting the thread for getting the boxes to "
+    # Instantiating and starting the Thread for grabbing the Overlays
+    self._log(logging.INFO, "Instantiating the thread for getting the Overlays"
+                            " to display")
+    self._overlay_thread = Thread(target=self._thread_target)
+    self._log(logging.INFO, "Starting the thread for getting the Overlays to "
                             "display")
-    self._box_thread.start()
+    self._overlay_thread.start()
 
     # Preparing the Displayer window
     self._log(logging.INFO, f"Opening the displayer window with the backend "
@@ -174,7 +174,7 @@ class Displayer(CameraProcess):
     and updates the Displayer window to draw it.
     
     It also draws the latest received 
-    :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` on top of the
+    :class:`~crappy.tool.camera_config.config_tools.Overlay` on top of the
     displayed frame.
     """
 
@@ -196,12 +196,12 @@ class Displayer(CameraProcess):
     else:
       img = self._img.copy()
 
-    # Drawing the latest known position of the boxes
-    for box in self._boxes:
-      if box is not None:
-        self._log(logging.DEBUG, f"Drawing {box} on top of the image to "
+    # Drawing the latest known overlay
+    for overlay in self._overlay:
+      if overlay is not None:
+        self._log(logging.DEBUG, f"Drawing {overlay} on top of the image to "
                                  "display")
-        box.draw(img)
+        overlay.draw(img)
 
     # Calling the right update method
     if self._backend == 'cv2':
@@ -211,7 +211,7 @@ class Displayer(CameraProcess):
 
   def _finish(self) -> None:
     """Closes the Displayer window and stops the :obj:`~threading.Thread`
-    grabbing the :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes`"""
+    grabbing the :class:`~crappy.tool.camera_config.config_tools.Overlay`"""
 
     # Closing the Displayer window
     self._log(logging.INFO, "Closing the displayer window")
@@ -220,43 +220,43 @@ class Displayer(CameraProcess):
     elif self._backend == 'mpl':
       self._finish_mpl()
 
-    # Stooping the Thread grabbing the SpotsBoxes to draw
-    if self._box_thread is not None and self._box_thread.is_alive():
+    # Stooping the Thread grabbing the Overlay to draw
+    if self._overlay_thread is not None and self._overlay_thread.is_alive():
       self._stop_thread = True
       try:
-        self._box_thread.join(0.05)
+        self._overlay_thread.join(0.05)
       except RuntimeError:
-        self._log(logging.WARNING, "Thread for receiving the boxes did not "
+        self._log(logging.WARNING, "Thread for receiving the Overlay did not "
                                    "stop as expected")
 
   def _thread_target(self) -> None:
     """This method is the target to the :obj:`~threading.Thread` in charge of
-    grabbing the :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` to
+    grabbing the :class:`~crappy.tool.camera_config.config_tools.Overlay` to
     draw on top of the displayed image.
     
     It repeatedly polls the :obj:`~multiprocessing.Connection` through which
-    the Boxes are received, and stores the last received Boxes.
+    the Overlays are received, and stores the last received Overlays.
     """
 
     # Looping until the entire CameraProcess is told to stop, or the 
     # _stop_thread flag is raised
     while not self._stop_event.is_set() and not self._stop_thread:
 
-      # Receiving the latest Boxes to draw
-      boxes = None
-      while self._box_conn.poll():
-        boxes = self._box_conn.recv()
+      # Receiving the latest Overlay to draw
+      overlay = None
+      while self._to_draw_conn.poll():
+        overlay = self._to_draw_conn.recv()
 
-      # Saving the received Boxes
-      if boxes is not None:
-        self._log(logging.DEBUG, f"Received boxes to display: {boxes}")
-        self._boxes = boxes
+      # Saving the received Overlay
+      if overlay is not None:
+        self._log(logging.DEBUG, f"Received overlay to display: {overlay}")
+        self._overlay = overlay
 
       # To avoid spamming the CPU in vain
       else:
         sleep(0.001)
 
-    self._log(logging.INFO, "Thread for receiving the boxes ended")
+    self._log(logging.INFO, "Thread for receiving the Overlays ended")
 
   def _prepare_cv2(self) -> None:
     """Instantiates the display window of :mod:`cv2`."""

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -176,7 +176,7 @@ class GPUVEProcess(CameraProcess):
     self._send(data)
 
     # Sending the patches to the Displayer for display
-    self._send_box(self._spots)
+    self._send_to_draw(self._spots)
 
   def _finish(self) -> None:
     """Performs cleanup on the several

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -110,7 +110,7 @@ class VideoExtensoProcess(CameraProcess):
           self._send([self._metadata['t(s)'], self._metadata, *data])
 
         # Sending the detected spots to the Displayer for display
-        self._send_box(self._ve.spots)
+        self._send_to_draw(self._ve.spots)
 
       # In case the spots were just lost
       except LostSpotError:

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -304,7 +304,7 @@ class GPUCorrel(Camera):
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
     method of the parent class.
 
-    In addition to that is instantiates the
+    In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.GPUCorrelProcess` object that
     performs the GPU-accelerated image correlation.
     """

--- a/src/crappy/tool/camera_config/__init__.py
+++ b/src/crappy/tool/camera_config/__init__.py
@@ -2,7 +2,7 @@
 
 from .camera_config import CameraConfig
 from .camera_config_boxes import CameraConfigBoxes
-from .config_tools import Box, SpotsBoxes, SpotsDetector, Zoom
+from .config_tools import Box, Overlay, SpotsBoxes, SpotsDetector, Zoom
 from .dic_ve_config import DICVEConfig
 from .dis_correl_config import DISCorrelConfig
 from .video_extenso_config import VideoExtensoConfig

--- a/src/crappy/tool/camera_config/config_tools/__init__.py
+++ b/src/crappy/tool/camera_config/config_tools/__init__.py
@@ -2,6 +2,7 @@
 
 from .box import Box
 from .histogram_process import HistogramProcess
+from .overlay_object import Overlay
 from .spots_boxes import SpotsBoxes
 from .spots_detector import SpotsDetector
 from .zoom import Zoom

--- a/src/crappy/tool/camera_config/config_tools/box.py
+++ b/src/crappy/tool/camera_config/config_tools/box.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Tuple
+import logging
+
+from .overlay_object import Overlay
 
 
 @dataclass
-class Box:
   """This class represents a box to be drawn on top of the image of a
   :class:`~crappy.tool.camera_config.CameraConfig` window.
+class Box(Overlay):
 
   It can be either the box drawn when selecting a region, or the bounding box
   of a previously detected area."""
@@ -24,8 +27,16 @@ class Box:
   x_centroid: Optional[float] = None
   y_centroid: Optional[float] = None
 
+  def __str__(self) -> str:
+    """The string representation of this class, only for debugging."""
+
+    return (f"Box with coordinates ({self.x_start}, {self.y_start}), "
+            f"({self.x_end}, {self.y_end})")
+
   def update(self, box: Box) -> None:
     """Changes the coordinates of the box to those of another box."""
+
+    self.log(logging.DEBUG, f"Updating {self} to {box}")
 
     self.x_start = box.x_start
     self.y_start = box.y_start
@@ -47,6 +58,8 @@ class Box:
   def reset(self) -> None:
     """Resets the sides to :obj:`None`."""
 
+    self.log(logging.DEBUG, f"Resetting {self}")
+
     self.x_start = None
     self.x_end = None
     self.y_start = None
@@ -60,11 +73,16 @@ class Box:
     min y, max y."""
 
     if self.no_points():
+      self.log(logging.WARNING, f"Trying to sort the Box, but some of its "
+                                f"coordinates are undefined !")
       raise ValueError("Cannot sort, some values are None !")
 
     x_top = min(self.x_start, self.x_end)
     x_bottom = max(self.x_start, self.x_end)
     y_left = min(self.y_start, self.y_end)
     y_right = max(self.y_start, self.y_end)
+
+    self.log(logging.DEBUG, f"Sorted {self}, returning ({x_top}, {x_bottom}, "
+                            f"{y_left}, {y_right})")
 
     return x_top, x_bottom, y_left, y_right

--- a/src/crappy/tool/camera_config/config_tools/box.py
+++ b/src/crappy/tool/camera_config/config_tools/box.py
@@ -72,8 +72,8 @@ class Box(Overlay):
                     (slice(y_left, y_right), x_bottom - i))):
         img[line] = 255 * int(np.mean(img[line]) < 128)
 
-        self.log(logging.DEBUG, f"Drew {self} on top of the image to display")
-        return img
+      self.log(logging.DEBUG, f"Drew {self} on top of the image to display")
+      return img
 
     # If anything goes wrong, aborting
     except (Exception,) as exc:

--- a/src/crappy/tool/camera_config/config_tools/box.py
+++ b/src/crappy/tool/camera_config/config_tools/box.py
@@ -45,7 +45,7 @@ class Box(Overlay):
     return (f"Box with coordinates ({self.x_start}, {self.y_start}), "
             f"({self.x_end}, {self.y_end})")
 
-  def draw(self, img: np.ndarray) -> np.ndarray:
+  def draw(self, img: np.ndarray) -> None:
     """Draws the Box on top of the given image, and returns the modified image.
 
     The thickness of the drawn lines adapts to the size of the image, so that
@@ -57,13 +57,12 @@ class Box(Overlay):
     if self.no_points():
       self.log(logging.DEBUG, f"Cannot draw {self}, not all points are "
                               f"defined !")
-      return img
 
     # Getting the thickness of the lines to draw
     x_top, x_bottom, y_left, y_right = self.sorted()
     max_fact = max(img.shape[0] // 480, img.shape[1] // 640, 1)
 
-    # Drawing the lines on top of the image and returning the modified image
+    # Drawing the lines on top of the image
     try:
       for line in (line for i in range(max_fact + 1) for line in
                    ((self.y_start + i, slice(x_top, x_bottom)),
@@ -71,15 +70,12 @@ class Box(Overlay):
                     (slice(y_left, y_right), x_top + i),
                     (slice(y_left, y_right), x_bottom - i))):
         img[line] = 255 * int(np.mean(img[line]) < 128)
-
       self.log(logging.DEBUG, f"Drew {self} on top of the image to display")
-      return img
 
     # If anything goes wrong, aborting
     except (Exception,) as exc:
       self._logger.exception("Encountered exception while drawing boxes, "
                              "ignoring", exc_info=exc)
-      return img
 
   def update(self, box: Box) -> None:
     """Changes the coordinates of the box to those of another box."""

--- a/src/crappy/tool/camera_config/config_tools/box.py
+++ b/src/crappy/tool/camera_config/config_tools/box.py
@@ -32,6 +32,12 @@ class Box(Overlay):
   x_centroid: Optional[float] = None
   y_centroid: Optional[float] = None
 
+  def __post_init__(self) -> None:
+    """Needed to have the :obj:`~logging.Logger` of the parent class properly
+    initialized."""
+
+    super().__init__()
+
   def __str__(self) -> str:
     """The string representation of this class, only for debugging."""
 

--- a/src/crappy/tool/camera_config/config_tools/box.py
+++ b/src/crappy/tool/camera_config/config_tools/box.py
@@ -9,12 +9,17 @@ from .overlay_object import Overlay
 
 
 @dataclass
-  """This class represents a box to be drawn on top of the image of a
-  :class:`~crappy.tool.camera_config.CameraConfig` window.
 class Box(Overlay):
+  """This class represents a box to be drawn on top of the images of a
+  :class:`~crappy.tool.camera_config.CameraConfig` window or
+  :class:`~crappy.blocks.camera_processes.Displayer` Process of a
+  :class:`~crappy.blocks.Camera` Block.
 
-  It can be either the box drawn when selecting a region, or the bounding box
-  of a previously detected area."""
+  It is a child of :class:`~crappy.tool.camera_config.config_tools.Overlay`.
+
+  It can represent either the box drawn when selecting a region, or the
+  bounding box of a tracked area.
+  """
 
   x_start: Optional[int] = None
   x_end: Optional[int] = None

--- a/src/crappy/tool/camera_config/config_tools/overlay_object.py
+++ b/src/crappy/tool/camera_config/config_tools/overlay_object.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+
+from numpy import ndarray
+import logging
+from multiprocessing import current_process
+from typing import Optional
+
+
+class Overlay:
+  """This class is the base class for all the classes adding overlays on top of
+  the images displayed by a :class:`~crappy.blocks.camera_processes.Displayer`
+  Process of a :class:`~crappy.blocks.Camera` Block.
+
+  Also used for drawing overlays on top of the images in the
+  :class:`~crappy.tool.camera_config.CameraConfig` window, for the children of
+  the Camera Block supporting it.
+
+  It is mainly useful for providing the :meth:`log` method, and creating a
+  clear architecture. It is also relevant to use for type-hinting.
+  """
+
+  def __init__(self) -> None:
+    """Simply initializes the logger to :obj:`None`."""
+
+    self._logger: Optional[logging.Logger] = None
+
+  def draw(self, img: ndarray) -> ndarray:
+    """This method takes the image to display as an input, draws an overlay on
+    top of it, and returns the modified image.
+
+    It is meant to be overriden by subclasses of this class.
+    """
+
+    ...
+
+  def log(self, log_level: int, msg: str) -> None:
+    """Method for recording log messages from the Overlay class.
+
+    Args:
+      log_level: An :obj:`int` indicating the logging level of the message.
+      msg: The message to log, as a :obj:`str`.
+    """
+
+    if self._logger is None:
+      self._logger = logging.getLogger(f"{current_process().name}."
+                                       f"{type(self).__name__}")
+
+    self._logger.log(log_level, msg)

--- a/src/crappy/tool/camera_config/config_tools/overlay_object.py
+++ b/src/crappy/tool/camera_config/config_tools/overlay_object.py
@@ -24,7 +24,7 @@ class Overlay:
 
     self._logger: Optional[logging.Logger] = None
 
-  def draw(self, img: ndarray) -> ndarray:
+  def draw(self, img: ndarray) -> None:
     """This method takes the image to display as an input, draws an overlay on
     top of it, and returns the modified image.
 


### PR DESCRIPTION
Until now, there was no possibility for users to add a custom overlay on top of the images displayed by a [Camera Displayer](https://github.com/LaboratoireMecaniqueLille/crappy/blob/8c49d4e12ccbcfab47eb8809744afaf55ab8e122/src/crappy/blocks/camera_processes/display.py) window.
Users could only add one or several bounding boxes as an overlay, using the [Box](https://github.com/LaboratoireMecaniqueLille/crappy/blob/8c49d4e12ccbcfab47eb8809744afaf55ab8e122/src/crappy/tool/camera_config/config_tools/box.py) object.

It was brought to our attention in #47 that this possibility could be of interest for users.
Consequently, an `Overlay` object was created (571711fe) as a base class for overlays. It possesses a `draw` method, that draws a shape on top of the displayed image.
The `Displayer` object was modified to be compatible with this new architecture (f3495afb).
The existing `Box` object was also modified to be a child of `Overlay` and define a `draw` method (135ca1c4).
The documentation was updated accordingly (add83cd0 and 3c54a4ec).

In addition, an unrelated minor bug was spotted and fixed in the `CameraProcess` object (08effe13).

Closes #47 