### PR TITLE
Make it more user-friendly to instantiate custom Camera Blocks

### DIFF
--- a/docs/source/crappy_docs/blocks.rst
+++ b/docs/source/crappy_docs/blocks.rst
@@ -233,42 +233,49 @@ Camera Processes
 Camera Process
 ++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.CameraProcess
-   :members: set_shared, run
+   :members: set_shared, run, init, loop, finish, send, send_to_draw
+   :special-members: __init__
+
+DIC VE Process
+++++++++++++++
+.. autoclass:: crappy.blocks.camera_processes.DICVEProcess
+   :members: init, loop
    :special-members: __init__
 
 DIS Correl Process
 ++++++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.DISCorrelProcess
-   :special-members: __init__
-
-DIS VE Process
-++++++++++++++
-.. autoclass:: crappy.blocks.camera_processes.DICVEProcess
+   :members: init, loop
    :special-members: __init__
 
 Displayer Process
 +++++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.Displayer
+   :members: init, loop, finish
    :special-members: __init__, __del__
 
 GPU Correl Process
 ++++++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.GPUCorrelProcess
+   :members: init, loop, finish
    :special-members: __init__
 
 GPU VE Process
 ++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.GPUVEProcess
+   :members: init, loop, finish
    :special-members: __init__
 
 Recorder Process
 ++++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.ImageSaver
+   :members: init, loop
    :special-members: __init__
 
 Video Extenso Process
 +++++++++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.VideoExtensoProcess
+   :members: init, loop, finish
    :special-members: __init__
 
 Parent Block

--- a/docs/source/crappy_docs/blocks.rst
+++ b/docs/source/crappy_docs/blocks.rst
@@ -233,7 +233,7 @@ Camera Processes
 Camera Process
 ++++++++++++++
 .. autoclass:: crappy.blocks.camera_processes.CameraProcess
-   :members: set_shared, run, init, loop, finish, send, send_to_draw
+   :members: set_shared, run, init, loop, finish, send, send_to_draw, log
    :special-members: __init__
 
 DIC VE Process

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -307,18 +307,12 @@ class Camera(Block):
     # instantiating the ImageSaver CameraProcess
     if self._save_proc_kw is not None:
       self.log(logging.INFO, "Instantiating the saver process")
-      self._save_proc = ImageSaver(log_queue=self._log_queue,
-                                   log_level=self._log_level,
-                                   display_freq=self.display_freq,
-                                   **self._save_proc_kw)
+      self._save_proc = ImageSaver(**self._save_proc_kw)
 
     # instantiating the Displayer CameraProcess
     if self._display_proc_kw is not None:
       self.log(logging.INFO, "Instantiating the displayer process")
-      self._display_proc = Displayer(log_queue=self._log_queue,
-                                     log_level=self._log_level,
-                                     display_freq=self.display_freq,
-                                     **self._display_proc_kw)
+      self._display_proc = Displayer(**self._display_proc_kw)
 
     # Creating the Barrier for the synchronization of the CameraProcesses
     n_proc = sum(int(proc is not None) for proc in (self.process_proc,
@@ -399,7 +393,10 @@ class Camera(Block):
                                    dtype=self._img_dtype,
                                    to_draw_conn=overlay_conn,
                                    outputs=self.outputs,
-                                   labels=labels)
+                                   labels=labels,
+                                   log_queue=self._log_queue,
+                                   log_level=self._log_level,
+                                   display_freq=self.display_freq)
       self.log(logging.INFO, "Starting the image processing process")
       self.process_proc.start()
 
@@ -412,9 +409,14 @@ class Camera(Block):
                                  lock=self._save_lock,
                                  barrier=self._cam_barrier,
                                  event=self._stop_event_cam,
-                                 shape=self._img_shape, dtype=self._img_dtype,
-                                 to_draw_conn=None, outputs=list(),
-                                 labels=list())
+                                 shape=self._img_shape,
+                                 dtype=self._img_dtype,
+                                 to_draw_conn=None,
+                                 outputs=list(),
+                                 labels=list(),
+                                 log_queue=self._log_queue,
+                                 log_level=self._log_level,
+                                 display_freq=self.display_freq)
       self.log(logging.INFO, "Starting the image saver process")
       self._save_proc.start()
 
@@ -430,7 +432,11 @@ class Camera(Block):
                                     shape=self._img_shape,
                                     dtype=self._img_dtype,
                                     to_draw_conn=self._overlay_conn_out,
-                                    outputs=list(), labels=list())
+                                    outputs=list(),
+                                    labels=list(),
+                                    log_queue=self._log_queue,
+                                    log_level=self._log_level,
+                                    display_freq=self.display_freq)
       self.log(logging.INFO, "Starting the image displayer process")
       self._display_proc.start()
 

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -194,7 +194,7 @@ class Camera(Block):
 
     self._save_proc: Optional[ImageSaver] = None
     self._display_proc: Optional[Displayer] = None
-    self._process_proc: Optional[CameraProcess] = None
+    self.process_proc: Optional[CameraProcess] = None
     self._manager: Optional[managers.SyncManager] = None
 
     self._camera: Optional[BaseCam] = None
@@ -273,8 +273,8 @@ class Camera(Block):
     If they did not stop in time, just terminates them.
     """
 
-    if self._process_proc is not None and self._process_proc.is_alive():
-      self._process_proc.terminate()
+    if self.process_proc is not None and self.process_proc.is_alive():
+      self.process_proc.terminate()
 
     if self._save_proc is not None and self._save_proc.is_alive():
       self._save_proc.terminate()
@@ -321,7 +321,7 @@ class Camera(Block):
                                      **self._display_proc_kw)
 
     # Creating the Barrier for the synchronization of the CameraProcesses
-    n_proc = sum(int(proc is not None) for proc in (self._process_proc,
+    n_proc = sum(int(proc is not None) for proc in (self.process_proc,
                                                     self._save_proc,
                                                     self._display_proc))
     if not n_proc:
@@ -384,24 +384,24 @@ class Camera(Block):
                               dtype=self._img_dtype).reshape(self._img_shape)
 
     # Starting the CameraProcess for image processing if it was instantiated
-    if self._process_proc is not None:
+    if self.process_proc is not None:
       self.log(logging.DEBUG, "Sharing the synchronization objects with the "
                               "image processing process")
       overlay_conn = (self._overlay_conn_in if self._display_proc is not None
                       else None)
       labels = self.labels if self.labels is not None else None
-      self._process_proc.set_shared(array=self._img_array,
-                                    data_dict=self._metadata,
-                                    lock=self._proc_lock,
-                                    barrier=self._cam_barrier,
-                                    event=self._stop_event_cam,
-                                    shape=self._img_shape,
-                                    dtype=self._img_dtype,
-                                    to_draw_conn=overlay_conn,
-                                    outputs=self.outputs,
-                                    labels=labels)
+      self.process_proc.set_shared(array=self._img_array,
+                                   data_dict=self._metadata,
+                                   lock=self._proc_lock,
+                                   barrier=self._cam_barrier,
+                                   event=self._stop_event_cam,
+                                   shape=self._img_shape,
+                                   dtype=self._img_dtype,
+                                   to_draw_conn=overlay_conn,
+                                   outputs=self.outputs,
+                                   labels=labels)
       self.log(logging.INFO, "Starting the image processing process")
-      self._process_proc.start()
+      self.process_proc.start()
 
     # Starting the ImageSaver CameraProcess if it was instantiated
     if self._save_proc is not None:
@@ -558,10 +558,10 @@ class Camera(Block):
       sleep(0.2)
 
     # If the processing CameraProcess is not done, terminating it
-    if self._process_proc is not None and self._process_proc.is_alive():
+    if self.process_proc is not None and self.process_proc.is_alive():
       self.log(logging.WARNING, "Image processing process not stopped, "
                                 "killing it !")
-      self._process_proc.terminate()
+      self.process_proc.terminate()
     # If the ImageSaver CameraProcess is not done, terminating it
     if self._save_proc is not None and self._save_proc.is_alive():
       self.log(logging.WARNING, "Image saver process not stopped, "

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -248,22 +248,17 @@ class Camera(Block):
     self._last_cam_fps = time()
 
     # Instantiating the ImageSaver if requested
-    if not save_images:
-      self._save_proc_kw = None
-    else:
-      self._save_proc_kw = dict(img_extension=img_extension,
-                                save_folder=save_folder,
-                                save_period=save_period,
-                                save_backend=save_backend)
+    self._save_images = save_images
+    self._img_extension = img_extension
+    self._save_folder = save_folder
+    self._save_period = save_period
+    self._save_backend = save_backend
 
     # Instantiating the Displayer window if requested
-    if not display_images:
-      self._display_proc_kw = None
-    else:
-      self._display_proc_kw = dict(
-        title=f"Displayer {camera} "
-              f"{Camera.cam_count[self._camera_name]}",
-        framerate=displayer_framerate, backend=displayer_backend)
+    self._display_images = display_images
+    self._title = f"Displayer {camera} {Camera.cam_count[self._camera_name]}"
+    self._framerate = displayer_framerate
+    self._displayer_backend = displayer_backend
 
   def __del__(self) -> None:
     """Safety method called when deleting the Block and ensuring that all the
@@ -305,14 +300,19 @@ class Camera(Block):
     self._proc_lock = RLock()
 
     # instantiating the ImageSaver CameraProcess
-    if self._save_proc_kw is not None:
+    if self._save_images:
       self.log(logging.INFO, "Instantiating the saver process")
-      self._save_proc = ImageSaver(**self._save_proc_kw)
+      self._save_proc = ImageSaver(img_extension=self._img_extension,
+                                   save_folder=self._save_folder,
+                                   save_period=self._save_period,
+                                   save_backend=self._save_backend)
 
     # instantiating the Displayer CameraProcess
-    if self._display_proc_kw is not None:
+    if self._display_images:
       self.log(logging.INFO, "Instantiating the displayer process")
-      self._display_proc = Displayer(**self._display_proc_kw)
+      self._display_proc = Displayer(title=self._title,
+                                     framerate=self._framerate,
+                                     backend=self._displayer_backend)
 
     # Creating the Barrier for the synchronization of the CameraProcesses
     n_proc = sum(int(proc is not None) for proc in (self.process_proc,

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -166,7 +166,7 @@ class CameraProcess(Process):
       # Initializing the CameraProcess, and breaking the Barrier to warn the
       # other CameraProcesses in case something goes wrong
       try:
-        self._init()
+        self.init()
       except (Exception,):
         self._cam_barrier.abort()
         self._log(logging.ERROR, "Breaking the barrier due to caught exception"
@@ -183,7 +183,7 @@ class CameraProcess(Process):
 
       # Looping forever until told to stop or an exception is raised
       while not self._stop_event.is_set():
-        self._loop()
+        self.loop()
 
         # Displaying the looping frequency is required
         if self.display_freq:
@@ -217,9 +217,9 @@ class CameraProcess(Process):
 
     # Always calling finish in the end
     finally:
-      self._finish()
+      self.finish()
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """This method should perform any action required for initializing the
     CameraProcess.
 
@@ -269,7 +269,7 @@ class CameraProcess(Process):
 
     return True
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method is the main loop of the CameraProcess.
     
     It is called repeatedly until the :obj:`~multiprocessing.Process` is told
@@ -282,7 +282,7 @@ class CameraProcess(Process):
 
     ...
 
-  def _finish(self) -> None:
+  def finish(self) -> None:
     """This method should perform any action required for properly exiting the
     CameraProcess.
 
@@ -295,8 +295,8 @@ class CameraProcess(Process):
 
     ...
 
-  def _send(self, data: Optional[Union[Dict[str, Any],
-                                       Iterable[Any]]]) -> None:
+  def send(self, data: Optional[Union[Dict[str, Any],
+                                      Iterable[Any]]]) -> None:
     """This method allows sending data to downstream Blocks.
 
     It is similar to the :meth:`~crappy.blocks.Block.send` method of the
@@ -332,7 +332,7 @@ class CameraProcess(Process):
       self._logger.log(logging.DEBUG, f"Sending {data} to Link {link.name}")
       link.send(data)
 
-  def _send_to_draw(self, to_draw: Iterable[Overlay]) -> None:
+  def send_to_draw(self, to_draw: Iterable[Overlay]) -> None:
     """This method sends a collection of
     :class:`~crappy.tool.camera_config.config_tools.Overlay` objects to the
     :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess.

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -183,7 +183,10 @@ class CameraProcess(Process):
 
       # Looping forever until told to stop or an exception is raised
       while not self._stop_event.is_set():
-        self.loop()
+        # Only looping if a new image is available
+        if self._get_data():
+          self._log(logging.DEBUG, "Running the loop method")
+          self.loop()
 
         # Displaying the looping frequency is required
         if self.display_freq:

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -274,7 +274,9 @@ class CameraProcess(Process):
     
     It is called repeatedly until the :obj:`~multiprocessing.Process` is told
     to stop. It should perform the desired action for handling the latest
-    available frame, that can be grabbed by calling :meth:`_get_data`.
+    available frame, stored in the *self.img* attribute. The latest available
+    metadata containing at least the timestamp and frame index of the latest
+    image is stored in *self.metadata*.
     
     This method is meant to be overwritten by children classes, at is otherwise 
     does not perform any action.

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -187,6 +187,7 @@ class CameraProcess(Process):
         if self._get_data():
           self.log(logging.DEBUG, "Running the loop method")
           self.loop()
+          self.fps_count += 1
 
         # Displaying the looping frequency is required
         if self.display_freq:

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -161,7 +161,7 @@ class CameraProcess(Process):
     try:
       # First thing, setting the Logger
       self._set_logger()
-      self._log(logging.INFO, "Logger configured")
+      self.log(logging.INFO, "Logger configured")
 
       # Initializing the CameraProcess, and breaking the Barrier to warn the
       # other CameraProcesses in case something goes wrong
@@ -169,15 +169,15 @@ class CameraProcess(Process):
         self.init()
       except (Exception,):
         self._cam_barrier.abort()
-        self._log(logging.ERROR, "Breaking the barrier due to caught exception"
-                                 " while preparing")
+        self.log(logging.ERROR, "Breaking the barrier due to caught exception"
+                                " while preparing")
         raise
 
       # Waiting for all other CameraProcess to be ready
-      self._log(logging.INFO, "Waiting for the other Camera processes to be "
-                              "ready")
+      self.log(logging.INFO, "Waiting for the other Camera processes to be "
+                             "ready")
       self._cam_barrier.wait()
-      self._log(logging.INFO, "All Camera processes ready now")
+      self.log(logging.INFO, "All Camera processes ready now")
 
       self._last_fps = time()
 
@@ -185,36 +185,36 @@ class CameraProcess(Process):
       while not self._stop_event.is_set():
         # Only looping if a new image is available
         if self._get_data():
-          self._log(logging.DEBUG, "Running the loop method")
+          self.log(logging.DEBUG, "Running the loop method")
           self.loop()
 
         # Displaying the looping frequency is required
         if self.display_freq:
           t = time()
           if t - self._last_fps > 2:
-            self._log(logging.INFO, f"Images processed /s: "
-                                    f"{self.fps_count / (t - self._last_fps)}")
+            self.log(logging.INFO, f"Images processed /s: "
+                                   f"{self.fps_count / (t - self._last_fps)}")
             self._last_fps = t
             self.fps_count = 0
 
-      self._log(logging.INFO, "Stop event set, stopping the processing")
+      self.log(logging.INFO, "Stop event set, stopping the processing")
 
     # Case when CTRL+C was pressed
     except KeyboardInterrupt:
-      self._log(logging.INFO, "KeyboardInterrupt caught, stopping the "
-                              "processing")
+      self.log(logging.INFO, "KeyboardInterrupt caught, stopping the "
+                             "processing")
 
     # Case when another CameraProcess raised an exception while initializing
     except BrokenBarrierError:
-      self._log(logging.WARNING,
-                "Exception raised in another Camera process while waiting "
-                "for all Camera processes to be ready, stopping")
+      self.log(logging.WARNING,
+               "Exception raised in another Camera process while waiting "
+               "for all Camera processes to be ready, stopping")
 
     # Handling any other unexpected exception
     except (Exception,) as exc:
       self._logger.exception("Exception caught wile running !", exc_info=exc)
-      self._log(logging.ERROR, "Setting the stop event to stop the other "
-                               "Camera processes")
+      self.log(logging.ERROR, "Setting the stop event to stop the other "
+                              "Camera processes")
       self._stop_event.set()
       raise
 
@@ -313,7 +313,7 @@ class CameraProcess(Process):
     if self._to_draw_conn is None:
       return
 
-    self._log(logging.DEBUG, "Sending the overlays to the displayer process")
+    self.log(logging.DEBUG, "Sending the overlays to the displayer process")
 
     # Sending the overlay
     if self._system == 'Linux':
@@ -322,9 +322,9 @@ class CameraProcess(Process):
         self._to_draw_conn.send(to_draw)
       elif time() - self._last_warn > 1:
         # Warning in case the pipe is full
-          self._last_warn = time()
-          self._log(logging.WARNING, f"Cannot send the overlay to draw to the "
-                                     f"Displayer process, the Pipe is full !")
+        self._last_warn = time()
+        self.log(logging.WARNING, f"Cannot send the overlay to draw to the "
+                                  f"Displayer process, the Pipe is full !")
     else:
       self._to_draw_conn.send(to_draw)
 
@@ -355,8 +355,8 @@ class CameraProcess(Process):
       # Copying the metadata
       self._metadata = self._data_dict.copy()
 
-      self._log(logging.DEBUG, f"Got new image to process with id "
-                               f"{self._metadata['ImageUniqueID']}")
+      self.log(logging.DEBUG, f"Got new image to process with id "
+                              f"{self._metadata['ImageUniqueID']}")
 
       # Copying the frame
       np.copyto(self._img,
@@ -389,7 +389,7 @@ class CameraProcess(Process):
 
     self._logger = logger
 
-  def _log(self, level: int, msg: str) -> None:
+  def log(self, level: int, msg: str) -> None:
     """Sends a log message to the :obj:`~logging.Logger`.
 
     Args:

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -80,15 +80,15 @@ class CameraProcess(Process):
     self._to_draw_conn: Optional[Connection] = None
     self._outputs: List[Link] = list()
     self._labels: List[str] = list()
-    self._img: Optional[np.ndarray] = None
+    self.img: Optional[np.ndarray] = None
     self._dtype = None
-    self._metadata = {'ImageUniqueID': None}
+    self.metadata = {'ImageUniqueID': None}
     self._img0_set = False
 
     # Other attribute for internal use
     self._last_warn = time()
     self.fps_count = 0
-    self.display_freq = display_freq
+    self._display_freq = display_freq
     self._last_fps = time()
 
   def set_shared(self,
@@ -143,7 +143,7 @@ class CameraProcess(Process):
     self._outputs = outputs
     self._labels = labels
 
-    self._img = np.empty(shape=shape, dtype=dtype)
+    self.img = np.empty(shape=shape, dtype=dtype)
 
   def run(self) -> None:
     """This method is the core of the :obj:`~multiprocessing.Process`.
@@ -190,7 +190,7 @@ class CameraProcess(Process):
           self.fps_count += 1
 
         # Displaying the looping frequency is required
-        if self.display_freq:
+        if self._display_freq:
           t = time()
           if t - self._last_fps > 2:
             self.log(logging.INFO, f"Images processed /s: "
@@ -362,17 +362,17 @@ class CameraProcess(Process):
         return False
 
       # In case the frame in buffer was already handled during a previous loop
-      if self._data_dict['ImageUniqueID'] == self._metadata['ImageUniqueID']:
+      if self._data_dict['ImageUniqueID'] == self.metadata['ImageUniqueID']:
         return False
 
       # Copying the metadata
-      self._metadata = self._data_dict.copy()
+      self.metadata = self._data_dict.copy()
 
       self.log(logging.DEBUG, f"Got new image to process with id "
-                              f"{self._metadata['ImageUniqueID']}")
+                              f"{self.metadata['ImageUniqueID']}")
 
       # Copying the frame
-      np.copyto(self._img,
+      np.copyto(self.img,
                 np.frombuffer(self._img_array.get_obj(),
                               dtype=self._dtype).reshape(self._shape))
 

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -328,6 +328,18 @@ class CameraProcess(Process):
     else:
       self._to_draw_conn.send(to_draw)
 
+  def log(self, level: int, msg: str) -> None:
+    """Sends a log message to the :obj:`~logging.Logger`.
+
+    Args:
+      level: The logging level, as an :obj:`int`.
+      msg: The message to log, as a :obj:`str`.
+    """
+
+    if self._logger is None:
+      return
+    self._logger.log(level, msg)
+
   def _get_data(self) -> bool:
     """This method allows to grab the latest available frame.
 
@@ -388,15 +400,3 @@ class CameraProcess(Process):
       logger.addHandler(queue_handler)
 
     self._logger = logger
-
-  def log(self, level: int, msg: str) -> None:
-    """Sends a log message to the :obj:`~logging.Logger`.
-
-    Args:
-      level: The logging level, as an :obj:`int`.
-      msg: The message to log, as a :obj:`str`.
-    """
-
-    if self._logger is None:
-      return
-    self._logger.log(level, msg)

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -164,7 +164,6 @@ class DICVEProcess(CameraProcess):
 
     # Do nothing if the patches were already lost
     if not self._lost_patch:
-      self.fps_count += 1
       try:
 
         # On the first frame, initialize the correlation
@@ -193,4 +192,5 @@ class DICVEProcess(CameraProcess):
     
     # If the patches are lost, sleep to avoid spamming the CPU in vain
     else:
+      self.fps_count -= 1
       sleep(0.1)

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from multiprocessing.queues import Queue
 from typing import Optional
 import numpy as np
 import logging
@@ -28,8 +27,6 @@ class DICVEProcess(CameraProcess):
 
   def __init__(self,
                patches: SpotsBoxes,
-               log_queue: Queue,
-               log_level: int = 20,
                method: str = 'Disflow',
                alpha: float = 3,
                delta: float = 1,
@@ -42,8 +39,7 @@ class DICVEProcess(CameraProcess):
                border: float = 0.2,
                safe: bool = True,
                follow: bool = True,
-               raise_on_exit: bool = True,
-               display_freq: bool = False) -> None:
+               raise_on_exit: bool = True) -> None:
     """Sets the arguments and initializes the parent class.
 
     Args:
@@ -52,10 +48,6 @@ class DICVEProcess(CameraProcess):
         containing the coordinates of the patches to track. This argument is
         passed to the :obj:`~crappy.tool.image_processing.DICVETool` and not
         used in this class.
-      log_queue: A :obj:`~multiprocessing.Queue` for sending the log messages
-        to the main :obj:`~logging.Logger`, only used in Windows.
-      log_level: The minimum logging level of the entire Crappy script, as an
-        :obj:`int`.
       method: The method to use to calculate the displacement. `Disflow` uses
         opencv's DISOpticalFlow and `Lucas Kanade` uses opencv's
         calcOpticalFlowPyrLK, while all other methods are based on a basic
@@ -117,13 +109,9 @@ class DICVEProcess(CameraProcess):
       raise_on_exit: If :obj:`True`, raises an exception and stops the test
         when losing the patches. Otherwise, simply stops processing but lets 
         the test go on.
-      display_freq: If :obj:`True`, the looping frequency of this class will be
-        displayed while running.
     """
 
-    super().__init__(log_queue=log_queue,
-                     log_level=log_level,
-                     display_freq=display_freq)
+    super().__init__()
 
     self._dic_ve_kw = dict(patches=patches,
                            method=method,

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -169,14 +169,14 @@ class DICVEProcess(CameraProcess):
         # On the first frame, initialize the correlation
         if not self._img0_set:
           self.log(logging.INFO, "Setting the reference image")
-          self._disve.set_img0(np.copy(self._img))
+          self._disve.set_img0(np.copy(self.img))
           self._img0_set = True
           return
 
         # Calculating the displacement and sending it to downstream Blocks
         self.log(logging.DEBUG, "Processing the received image")
-        data = self._disve.calculate_displacement(self._img)
-        self.send([self._metadata['t(s)'], self._metadata, *data])
+        data = self._disve.calculate_displacement(self.img)
+        self.send([self.metadata['t(s)'], self.metadata, *data])
 
         # Sending the patches to the Displayer for display
         self.send_to_draw(self._disve.patches)

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -143,14 +143,14 @@ class DICVEProcess(CameraProcess):
     self._img0_set = False
     self._lost_patch = False
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """Instantiates the :obj:`~crappy.tool.image_processing.DICVETool` that
     will perform the image correlation."""
 
     self._log(logging.INFO, "Instantiating the Disve tool")
     self._disve = DICVETool(**self._dic_ve_kw)
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method grabs the latest frame and gives it for processing to the
     :obj:`~crappy.tool.image_processing.DICVETool`. Then sends the result of
     the correlation to the downstream Blocks.
@@ -181,10 +181,10 @@ class DICVEProcess(CameraProcess):
         # Calculating the displacement and sending it to downstream Blocks
         self._log(logging.DEBUG, "Processing the received image")
         data = self._disve.calculate_displacement(self._img)
-        self._send([self._metadata['t(s)'], self._metadata, *data])
+        self.send([self._metadata['t(s)'], self._metadata, *data])
 
         # Sending the patches to the Displayer for display
-        self._send_to_draw(self._disve.patches)
+        self.send_to_draw(self._disve.patches)
 
       # If the patches are lost, deciding whether to raise exception or not
       except RuntimeError as exc:

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -162,10 +162,6 @@ class DICVEProcess(CameraProcess):
     CameraProcess.
     """
 
-    # Nothing to do if no new frame was grabbed
-    if not self._get_data():
-      return
-
     # Do nothing if the patches were already lost
     if not self._lost_patch:
       self.fps_count += 1

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -113,19 +113,22 @@ class DICVEProcess(CameraProcess):
 
     super().__init__()
 
-    self._dic_ve_kw = dict(patches=patches,
-                           method=method,
-                           alpha=alpha,
-                           delta=delta,
-                           gamma=gamma,
-                           finest_scale=finest_scale,
-                           iterations=iterations,
-                           gradient_iterations=gradient_iterations,
-                           patch_size=patch_size,
-                           patch_stride=patch_stride,
-                           border=border,
-                           safe=safe,
-                           follow=follow)
+    # Arguments to pass to the DICVETool
+    self._patches = patches
+    self._method = method
+    self._alpha = alpha
+    self._delta = delta
+    self._gamma = gamma
+    self._finest_scale = finest_scale
+    self._iterations = iterations
+    self._gradient_iterations = gradient_iterations
+    self._patch_size = patch_size
+    self._patch_stride = patch_stride
+    self._border = border
+    self._safe = safe
+    self._follow = follow
+    
+    # Other attributes
     self._raise_on_exit = raise_on_exit
     self._disve: Optional[DICVETool] = None
     self._img0_set = False
@@ -136,7 +139,19 @@ class DICVEProcess(CameraProcess):
     will perform the image correlation."""
 
     self.log(logging.INFO, "Instantiating the Disve tool")
-    self._disve = DICVETool(**self._dic_ve_kw)
+    self._disve = DICVETool(patches=self._patches,
+                            method=self._method,
+                            alpha=self._alpha,
+                            delta=self._delta,
+                            gamma=self._gamma,
+                            finest_scale=self._finest_scale,
+                            iterations=self._iterations,
+                            gradient_iterations=self._gradient_iterations,
+                            patch_size=self._patch_size,
+                            patch_stride=self._patch_stride,
+                            border=self._border,
+                            safe=self._safe,
+                            follow=self._follow)
 
   def loop(self) -> None:
     """This method grabs the latest frame and gives it for processing to the

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -147,7 +147,7 @@ class DICVEProcess(CameraProcess):
     """Instantiates the :obj:`~crappy.tool.image_processing.DICVETool` that
     will perform the image correlation."""
 
-    self._log(logging.INFO, "Instantiating the Disve tool")
+    self.log(logging.INFO, "Instantiating the Disve tool")
     self._disve = DICVETool(**self._dic_ve_kw)
 
   def loop(self) -> None:
@@ -169,13 +169,13 @@ class DICVEProcess(CameraProcess):
 
         # On the first frame, initialize the correlation
         if not self._img0_set:
-          self._log(logging.INFO, "Setting the reference image")
+          self.log(logging.INFO, "Setting the reference image")
           self._disve.set_img0(np.copy(self._img))
           self._img0_set = True
           return
 
         # Calculating the displacement and sending it to downstream Blocks
-        self._log(logging.DEBUG, "Processing the received image")
+        self.log(logging.DEBUG, "Processing the received image")
         data = self._disve.calculate_displacement(self._img)
         self.send([self._metadata['t(s)'], self._metadata, *data])
 
@@ -188,8 +188,8 @@ class DICVEProcess(CameraProcess):
           self._logger.exception("Patch exiting the ROI !", exc_info=exc)
           raise
         self._lost_patch = True
-        self._log(logging.WARNING, "Patch exiting the ROI, not processing "
-                                   "data anymore !")
+        self.log(logging.WARNING, "Patch exiting the ROI, not processing "
+                                  "data anymore !")
     
     # If the patches are lost, sleep to avoid spamming the CPU in vain
     else:

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from multiprocessing.queues import Queue
 import numpy as np
 from typing import Optional, List
 import logging
@@ -26,9 +25,7 @@ class DISCorrelProcess(CameraProcess):
   """
 
   def __init__(self,
-               log_queue: Queue,
                patch: Box,
-               log_level: int = 20,
                fields: Optional[List[str]] = None,
                alpha: float = 3,
                delta: float = 1,
@@ -39,20 +36,15 @@ class DISCorrelProcess(CameraProcess):
                init: bool = True,
                patch_size: int = 8,
                patch_stride: int = 3,
-               residual: bool = False,
-               display_freq: bool = False) -> None:
+               residual: bool = False) -> None:
     """Sets the arguments and initializes the parent class.
     
     Args:
-      log_queue: A :obj:`~multiprocessing.Queue` for sending the log messages
-        to the main :obj:`~logging.Logger`, only used in Windows.
       patch: An instance of the
         :class:`~crappy.tool.camera_config.config_tools.Box` class, containing
         the coordinates of the ROI to perform DIS on. This argument is passed
         to the :obj:`~crappy.tool.image_processing.DISCorrelTool` and not used
         in this class.
-      log_level: The minimum logging level of the entire Crappy script, as an
-        :obj:`int`.
       fields: The base of fields to use for the projection, given as a
         :obj:`list` of :obj:`str`. The available fields are :
         ::
@@ -103,13 +95,9 @@ class DISCorrelProcess(CameraProcess):
       residual: If :obj:`True`, the residuals will be computed at each new
         frame and sent to downstream Blocks, by default under the ``'res'``
         label.
-      display_freq: If :obj:`True`, the looping frequency of this class will be
-        displayed while running.
     """
 
-    super().__init__(log_queue=log_queue,
-                     log_level=log_level,
-                     display_freq=display_freq)
+    super().__init__()
 
     self._dis_correl_kw = dict(box=patch,
                                fields=fields,

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -145,10 +145,6 @@ class DISCorrelProcess(CameraProcess):
     :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess.
     """
 
-    # Nothing to do if no new frame was grabbed
-    if not self._get_data():
-      return
-
     self.fps_count += 1
 
     # On the first frame, initializes the dense inverse search

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -126,7 +126,7 @@ class DISCorrelProcess(CameraProcess):
     self._dis_correl: Optional[DISCorrelTool] = None
     self._img0_set = False
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """Instantiates the :obj:`~crappy.tool.image_processing.DISCorrelTool` that
     will perform the Dense Inverse Search."""
 
@@ -134,7 +134,7 @@ class DISCorrelProcess(CameraProcess):
     self._dis_correl = DISCorrelTool(**self._dis_correl_kw)
     self._dis_correl.set_box()
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method grabs the latest frame and gives it for processing to the
     :obj:`~crappy.tool.image_processing.DISCorrelTool`. Then sends the result
     of the dense inverse search to the downstream Blocks.
@@ -161,7 +161,7 @@ class DISCorrelProcess(CameraProcess):
     # Calculating the fields and sending them to downstream Blocks
     self._log(logging.DEBUG, "Processing the received image")
     data = self._dis_correl.get_data(self._img, self._residual)
-    self._send([self._metadata['t(s)'], self._metadata, *data])
+    self.send([self._metadata['t(s)'], self._metadata, *data])
 
     # Sending the ROI to the Displayer for display
-    self._send_to_draw(SpotsBoxes(self._dis_correl.box))
+    self.send_to_draw(SpotsBoxes(self._dis_correl.box))

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -145,8 +145,6 @@ class DISCorrelProcess(CameraProcess):
     :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess.
     """
 
-    self.fps_count += 1
-
     # On the first frame, initializes the dense inverse search
     if not self._img0_set:
       self.log(logging.INFO, "Setting the reference image")

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -99,17 +99,20 @@ class DISCorrelProcess(CameraProcess):
 
     super().__init__()
 
-    self._dis_correl_kw = dict(box=patch,
-                               fields=fields,
-                               alpha=alpha,
-                               delta=delta,
-                               gamma=gamma,
-                               finest_scale=finest_scale,
-                               init=init,
-                               iterations=iterations,
-                               gradient_iterations=gradient_iterations,
-                               patch_size=patch_size,
-                               patch_stride=patch_stride)
+    # Arguments to pass to the DISCorrelTool
+    self._box = patch
+    self._fields = fields
+    self._alpha = alpha
+    self._delta = delta
+    self._gamma = gamma
+    self._finest_scale = finest_scale
+    self._init = init
+    self._iterations = iterations
+    self._gradient_iterations = gradient_iterations
+    self._patch_size = patch_size
+    self._patch_stride = patch_stride
+    
+    # Other attributes
     self._residual = residual
     self._dis_correl: Optional[DISCorrelTool] = None
     self._img0_set = False
@@ -119,7 +122,18 @@ class DISCorrelProcess(CameraProcess):
     will perform the Dense Inverse Search."""
 
     self.log(logging.INFO, "Instantiating the Discorrel tool")
-    self._dis_correl = DISCorrelTool(**self._dis_correl_kw)
+    self._dis_correl = DISCorrelTool(
+        box=self._box,
+        fields=self._fields,
+        alpha=self._alpha,
+        delta=self._delta,
+        gamma=self._gamma,
+        finest_scale=self._finest_scale,
+        init=self._init,
+        iterations=self._iterations,
+        gradient_iterations=self._gradient_iterations,
+        patch_size=self._patch_size,
+        patch_stride=self._patch_stride)
     self._dis_correl.set_box()
 
   def loop(self) -> None:

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -130,7 +130,7 @@ class DISCorrelProcess(CameraProcess):
     """Instantiates the :obj:`~crappy.tool.image_processing.DISCorrelTool` that
     will perform the Dense Inverse Search."""
 
-    self._log(logging.INFO, "Instantiating the Discorrel tool")
+    self.log(logging.INFO, "Instantiating the Discorrel tool")
     self._dis_correl = DISCorrelTool(**self._dis_correl_kw)
     self._dis_correl.set_box()
 
@@ -149,13 +149,13 @@ class DISCorrelProcess(CameraProcess):
 
     # On the first frame, initializes the dense inverse search
     if not self._img0_set:
-      self._log(logging.INFO, "Setting the reference image")
+      self.log(logging.INFO, "Setting the reference image")
       self._dis_correl.set_img0(np.copy(self._img))
       self._img0_set = True
       return
 
     # Calculating the fields and sending them to downstream Blocks
-    self._log(logging.DEBUG, "Processing the received image")
+    self.log(logging.DEBUG, "Processing the received image")
     data = self._dis_correl.get_data(self._img, self._residual)
     self.send([self._metadata['t(s)'], self._metadata, *data])
 

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -148,14 +148,14 @@ class DISCorrelProcess(CameraProcess):
     # On the first frame, initializes the dense inverse search
     if not self._img0_set:
       self.log(logging.INFO, "Setting the reference image")
-      self._dis_correl.set_img0(np.copy(self._img))
+      self._dis_correl.set_img0(np.copy(self.img))
       self._img0_set = True
       return
 
     # Calculating the fields and sending them to downstream Blocks
     self.log(logging.DEBUG, "Processing the received image")
-    data = self._dis_correl.get_data(self._img, self._residual)
-    self.send([self._metadata['t(s)'], self._metadata, *data])
+    data = self._dis_correl.get_data(self.img, self._residual)
+    self.send([self.metadata['t(s)'], self.metadata, *data])
 
     # Sending the ROI to the Displayer for display
     self.send_to_draw(SpotsBoxes(self._dis_correl.box))

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -112,7 +112,7 @@ class Displayer(CameraProcess):
       except RuntimeError:
         pass
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """Starts the :obj:`~threading.Thread` for grabbing the
     :class:`~crappy.tool.camera_config.config_tools.Overlay` to display, and
     initializes the Displayer window."""
@@ -169,7 +169,7 @@ class Displayer(CameraProcess):
 
     return True
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method grabs the latest frame, casts it to 8 bits if necessary,
     and updates the Displayer window to draw it.
     
@@ -209,7 +209,7 @@ class Displayer(CameraProcess):
     elif self._backend == 'mpl':
       self._update_mpl(img)
 
-  def _finish(self) -> None:
+  def finish(self) -> None:
     """Closes the Displayer window and stops the :obj:`~threading.Thread`
     grabbing the :class:`~crappy.tool.camera_config.config_tools.Overlay`"""
 

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -177,10 +177,6 @@ class Displayer(CameraProcess):
     :class:`~crappy.tool.camera_config.config_tools.Overlay` on top of the
     displayed frame.
     """
-
-    # Nothing to do if no new frame was grabbed
-    if not self._get_data():
-      return
     
     self.fps_count += 1
 

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -177,8 +177,6 @@ class Displayer(CameraProcess):
     :class:`~crappy.tool.camera_config.config_tools.Overlay` on top of the
     displayed frame.
     """
-    
-    self.fps_count += 1
 
     # Casting the image to uint8 if it's not already in this format
     if self._img.dtype != np.uint8:

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -118,16 +118,16 @@ class Displayer(CameraProcess):
     initializes the Displayer window."""
 
     # Instantiating and starting the Thread for grabbing the Overlays
-    self._log(logging.INFO, "Instantiating the thread for getting the Overlays"
-                            " to display")
+    self.log(logging.INFO, "Instantiating the thread for getting the Overlays"
+                           " to display")
     self._overlay_thread = Thread(target=self._thread_target)
-    self._log(logging.INFO, "Starting the thread for getting the Overlays to "
-                            "display")
+    self.log(logging.INFO, "Starting the thread for getting the Overlays to "
+                           "display")
     self._overlay_thread.start()
 
     # Preparing the Displayer window
-    self._log(logging.INFO, f"Opening the displayer window with the backend "
-                            f"{self._backend}")
+    self.log(logging.INFO, f"Opening the displayer window with the backend "
+                           f"{self._backend}")
     if self._backend == 'cv2':
       self._prepare_cv2()
     elif self._backend == 'mpl':
@@ -159,8 +159,8 @@ class Displayer(CameraProcess):
       self._metadata = self._data_dict.copy()
       self._last_upd = time()
 
-      self._log(logging.DEBUG, f"Got new image to process with id "
-                               f"{self._metadata['ImageUniqueID']}")
+      self.log(logging.DEBUG, f"Got new image to process with id "
+                              f"{self._metadata['ImageUniqueID']}")
 
       # Copying the frame
       np.copyto(self._img,
@@ -182,8 +182,8 @@ class Displayer(CameraProcess):
 
     # Casting the image to uint8 if it's not already in this format
     if self._img.dtype != np.uint8:
-      self._log(logging.DEBUG, f"Casting displayed image from "
-                               f"{self._img.dtype} to uint8")
+      self.log(logging.DEBUG, f"Casting displayed image from "
+                              f"{self._img.dtype} to uint8")
       if np.max(self._img) > 255:
         factor = max(ceil(log2(np.max(self._img) + 1) - 8), 0)
         img = (self._img / 2 ** factor).astype(np.uint8)
@@ -195,8 +195,8 @@ class Displayer(CameraProcess):
     # Drawing the latest known overlay
     for overlay in self._overlay:
       if overlay is not None:
-        self._log(logging.DEBUG, f"Drawing {overlay} on top of the image to "
-                                 "display")
+        self.log(logging.DEBUG, f"Drawing {overlay} on top of the image to "
+                                "display")
         overlay.draw(img)
 
     # Calling the right update method
@@ -210,7 +210,7 @@ class Displayer(CameraProcess):
     grabbing the :class:`~crappy.tool.camera_config.config_tools.Overlay`"""
 
     # Closing the Displayer window
-    self._log(logging.INFO, "Closing the displayer window")
+    self.log(logging.INFO, "Closing the displayer window")
     if self._backend == 'cv2':
       self._finish_cv2()
     elif self._backend == 'mpl':
@@ -222,8 +222,8 @@ class Displayer(CameraProcess):
       try:
         self._overlay_thread.join(0.05)
       except RuntimeError:
-        self._log(logging.WARNING, "Thread for receiving the Overlay did not "
-                                   "stop as expected")
+        self.log(logging.WARNING, "Thread for receiving the Overlay did not "
+                                  "stop as expected")
 
   def _thread_target(self) -> None:
     """This method is the target to the :obj:`~threading.Thread` in charge of
@@ -245,14 +245,14 @@ class Displayer(CameraProcess):
 
       # Saving the received Overlay
       if overlay is not None:
-        self._log(logging.DEBUG, f"Received overlay to display: {overlay}")
+        self.log(logging.DEBUG, f"Received overlay to display: {overlay}")
         self._overlay = overlay
 
       # To avoid spamming the CPU in vain
       else:
         sleep(0.001)
 
-    self._log(logging.INFO, "Thread for receiving the Overlays ended")
+    self.log(logging.INFO, "Thread for receiving the Overlays ended")
 
   def _prepare_cv2(self) -> None:
     """Instantiates the display window of :mod:`cv2`."""
@@ -275,14 +275,13 @@ class Displayer(CameraProcess):
 
     if img.shape[0] > 480 or img.shape[1] > 640:
       factor = min(480 / img.shape[0], 640 / img.shape[1])
-      self._log(
-        logging.DEBUG,
-        f"Reshaping displayed image from {img.shape} to "
-        f"{int(img.shape[1] * factor), int(img.shape[0] * factor)}")
+      self.log(logging.DEBUG,
+               f"Reshaping displayed image from {img.shape} to "
+               f"{int(img.shape[1] * factor), int(img.shape[0] * factor)}")
       img = cv2.resize(img, (int(img.shape[1] * factor),
                              int(img.shape[0] * factor)))
 
-    self._log(logging.DEBUG, "Displaying the image")
+    self.log(logging.DEBUG, "Displaying the image")
     cv2.imshow(self._title, img)
     cv2.waitKey(1)
 
@@ -292,14 +291,13 @@ class Displayer(CameraProcess):
 
     if img.shape[0] > 480 or img.shape[1] > 640:
       factor = max(ceil(img.shape[0] / 480), ceil(img.shape[1] / 640))
-      self._log(
-        logging.DEBUG,
-        f"Reshaping the displayed image from {img.shape} to "
-        f"{(img.shape[0] / factor, img.shape[1] / factor)}")
+      self.log(logging.DEBUG,
+               f"Reshaping the displayed image from {img.shape} to "
+               f"{(img.shape[0] / factor, img.shape[1] / factor)}")
       img = img[::factor, ::factor]
 
     self._ax.clear()
-    self._log(logging.DEBUG, "Displaying the image")
+    self.log(logging.DEBUG, "Displaying the image")
     self._ax.imshow(img, cmap='gray')
     plt.pause(0.001)
     plt.show()

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from multiprocessing.queues import Queue
 from threading import Thread
 from math import log2, ceil
 import numpy as np
@@ -42,10 +41,7 @@ class Displayer(CameraProcess):
   def __init__(self,
                title: str,
                framerate: float,
-               log_queue: Queue,
-               log_level: int = 20,
-               backend: Optional[str] = None,
-               display_freq: bool = False) -> None:
+               backend: Optional[str] = None) -> None:
     """Sets the arguments and initializes the parent class.
 
     Args:
@@ -53,15 +49,9 @@ class Displayer(CameraProcess):
         window border.
       framerate: The target framerate for the display. The actual achieved
         framerate might be lower, but never greater than this value.
-      log_queue: A :obj:`~multiprocessing.Queue` for sending the log messages
-        to the main :obj:`~logging.Logger`, only used in Windows.
-      log_level: The minimum logging level of the entire Crappy script, as an
-        :obj:`int`.
       backend: The module to use for displaying the images. Can be either
         ``'cv2'`` or ``'mpl'``, to use respectively :mod:`cv2` or
         :mod:`matplotlib`.
-      display_freq: If :obj:`True`, the looping frequency of this class will be
-        displayed while running.
     """
 
     # The thread must be initialized later for compatibility with Windows
@@ -69,9 +59,7 @@ class Displayer(CameraProcess):
     self._overlay: Iterable[Overlay] = list()
     self._stop_thread = False
 
-    super().__init__(log_queue=log_queue,
-                     log_level=log_level,
-                     display_freq=display_freq)
+    super().__init__()
 
     self._title = title
     self._framerate = framerate

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -151,19 +151,19 @@ class Displayer(CameraProcess):
 
       # In case the frame in buffer was already handled during a previous loop,
       # or it's too early to grab a new frame because of the target framerate
-      if self._data_dict['ImageUniqueID'] == self._metadata['ImageUniqueID'] \
+      if self._data_dict['ImageUniqueID'] == self.metadata['ImageUniqueID'] \
           or time() - self._last_upd < 1 / self._framerate:
         return False
 
       # Copying the metadata
-      self._metadata = self._data_dict.copy()
+      self.metadata = self._data_dict.copy()
       self._last_upd = time()
 
       self.log(logging.DEBUG, f"Got new image to process with id "
-                              f"{self._metadata['ImageUniqueID']}")
+                              f"{self.metadata['ImageUniqueID']}")
 
       # Copying the frame
-      np.copyto(self._img,
+      np.copyto(self.img,
                 np.frombuffer(self._img_array.get_obj(),
                               dtype=self._dtype).reshape(self._shape))
 
@@ -179,16 +179,16 @@ class Displayer(CameraProcess):
     """
 
     # Casting the image to uint8 if it's not already in this format
-    if self._img.dtype != np.uint8:
+    if self.img.dtype != np.uint8:
       self.log(logging.DEBUG, f"Casting displayed image from "
-                              f"{self._img.dtype} to uint8")
-      if np.max(self._img) > 255:
-        factor = max(ceil(log2(np.max(self._img) + 1) - 8), 0)
-        img = (self._img / 2 ** factor).astype(np.uint8)
+                              f"{self.img.dtype} to uint8")
+      if np.max(self.img) > 255:
+        factor = max(ceil(log2(np.max(self.img) + 1) - 8), 0)
+        img = (self.img / 2 ** factor).astype(np.uint8)
       else:
-        img = self._img.astype(np.uint8)
+        img = self.img.astype(np.uint8)
     else:
-      img = self._img.copy()
+      img = self.img.copy()
 
     # Drawing the latest known overlay
     for overlay in self._overlay:

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -67,7 +67,7 @@ class GPUCorrelProcess(CameraProcess):
         this class.
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
-        is displayed that is slows the code down. This argument is passed to
+        is displayed that it slows the code down. This argument is passed to
         the :class:`~crappy.tool.image_processing.GPUCorrelTool` and not used
         in this class.
       levels: Number of levels of the pyramid. More levels may help converging

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -172,8 +172,6 @@ class GPUCorrelProcess(CameraProcess):
     provided limit. Otherwise, just drops the calculated data.
     """
 
-    self.fps_count += 1
-
     # Setting the reference image with the first received frame if it was not
     # given as an argument
     if not self._img0_set:

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -172,10 +172,6 @@ class GPUCorrelProcess(CameraProcess):
     provided limit. Otherwise, just drops the calculated data.
     """
 
-    # Nothing to do if no new frame was grabbed
-    if not self._get_data():
-      return
-
     self.fps_count += 1
 
     # Setting the reference image with the first received frame if it was not

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from multiprocessing.queues import Queue
 import numpy as np
 from typing import Optional, List, Union
 from pathlib import Path
@@ -27,8 +26,6 @@ class GPUCorrelProcess(CameraProcess):
   """
 
   def __init__(self,
-               log_queue: Queue,
-               log_level: int = 20,
                discard_limit: float = 3,
                discard_ref: int = 5,
                calc_res: bool = False,
@@ -44,10 +41,6 @@ class GPUCorrelProcess(CameraProcess):
     """Sets the arguments and initializes the parent class.
     
     Args:
-      log_queue: A :obj:`~multiprocessing.Queue` for sending the log messages
-        to the main :obj:`~logging.Logger`, only used in Windows.
-      log_level: The minimum logging level of the entire Crappy script, as an
-        :obj:`int`.
       discard_limit: If ``calc_res`` is :obj:`True`, the result of the
         correlation is not sent to the downstream Blocks if the residuals for
         the current image are greater than ``discard_limit`` times the average
@@ -119,8 +112,7 @@ class GPUCorrelProcess(CameraProcess):
         used in this class.
     """
 
-    super().__init__(log_queue=log_queue, log_level=log_level,
-                     display_freq=bool(verbose))
+    super().__init__()
 
     self._gpu_correl_kw = dict(context=None,
                                verbose=verbose,

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -147,17 +147,17 @@ class GPUCorrelProcess(CameraProcess):
     ``img_ref`` argument was provided."""
 
     # Instantiating the GPUCorrelTool
-    self._log(logging.INFO, "Instantiating the GPUCorrel tool")
+    self.log(logging.INFO, "Instantiating the GPUCorrel tool")
     self._gpu_correl_kw.update(logger_name=self.name)
     self._correl = GPUCorrelTool(**self._gpu_correl_kw)
 
     # Setting the reference image if it was given as an argument
     if self._img_ref is not None:
-      self._log(logging.INFO, "Initializing the GPUCorrel tool with the "
-                              "given reference image")
+      self.log(logging.INFO, "Initializing the GPUCorrel tool with the "
+                             "given reference image")
       self._correl.set_img_size(self._img_ref.shape)
       self._correl.set_orig(self._img_ref.astype(np.float32))
-      self._log(logging.INFO, "Preparing the GPUCorrel tool")
+      self.log(logging.INFO, "Preparing the GPUCorrel tool")
       self._correl.prepare()
 
   def loop(self) -> None:
@@ -177,7 +177,7 @@ class GPUCorrelProcess(CameraProcess):
     # Setting the reference image with the first received frame if it was not
     # given as an argument
     if not self._img0_set:
-      self._log(logging.INFO, "Setting the reference image")
+      self.log(logging.INFO, "Setting the reference image")
       self._correl.set_img_size(self._img.shape)
       self._correl.set_orig(self._img.astype(np.float32))
       self._correl.prepare()
@@ -185,27 +185,27 @@ class GPUCorrelProcess(CameraProcess):
       return
 
     # Performing the image correlation
-    self._log(logging.DEBUG, "Processing the received image")
+    self.log(logging.DEBUG, "Processing the received image")
     data = [self._metadata['t(s)'], self._metadata]
     data += self._correl.get_disp(self._img.astype(np.float32)).tolist()
 
     # Calculating the residuals if requested
     if self._calc_res:
-      self._log(logging.DEBUG, "Calculating the residuals")
+      self.log(logging.DEBUG, "Calculating the residuals")
       res = self._correl.get_res()
       data.append(res)
 
       # Checking that the residuals are within the given limit, otherwise
       # dropping the calculated data
       if self._discard_limit:
-        self._log(logging.DEBUG, "Adding residuals to the residuals "
-                                 "history")
+        self.log(logging.DEBUG, "Adding residuals to the residuals "
+                                "history")
         self._res_history.append(res)
         self._res_history = self._res_history[-self._discard_ref - 1:]
 
         if res > self._discard_limit * np.average(self._res_history[:-1]):
-          self._log(logging.WARNING, "Residual too high, not sending "
-                                     "values")
+          self.log(logging.WARNING, "Residual too high, not sending "
+                                    "values")
           return
 
     # Sending the data to downstream Blocks
@@ -216,5 +216,5 @@ class GPUCorrelProcess(CameraProcess):
     :class:`~crappy.tool.image_processing.GPUCorrelTool`."""
 
     if self._correl is not None:
-      self._log(logging.INFO, "Cleaning up the GPUCorrel tool")
+      self.log(logging.INFO, "Cleaning up the GPUCorrel tool")
       self._correl.clean()

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -176,16 +176,16 @@ class GPUCorrelProcess(CameraProcess):
     # given as an argument
     if not self._img0_set:
       self.log(logging.INFO, "Setting the reference image")
-      self._correl.set_img_size(self._img.shape)
-      self._correl.set_orig(self._img.astype(np.float32))
+      self._correl.set_img_size(self.img.shape)
+      self._correl.set_orig(self.img.astype(np.float32))
       self._correl.prepare()
       self._img0_set = True
       return
 
     # Performing the image correlation
     self.log(logging.DEBUG, "Processing the received image")
-    data = [self._metadata['t(s)'], self._metadata]
-    data += self._correl.get_disp(self._img.astype(np.float32)).tolist()
+    data = [self.metadata['t(s)'], self.metadata]
+    data += self._correl.get_disp(self.img.astype(np.float32)).tolist()
 
     # Calculating the residuals if requested
     if self._calc_res:

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -142,7 +142,7 @@ class GPUCorrelProcess(CameraProcess):
     self._discard_ref = discard_ref
     self._calc_res = calc_res
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """Initializes the GPUCorrelTool, and set its reference image if a
     ``img_ref`` argument was provided."""
 
@@ -160,7 +160,7 @@ class GPUCorrelProcess(CameraProcess):
       self._log(logging.INFO, "Preparing the GPUCorrel tool")
       self._correl.prepare()
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method grabs the latest frame and gives it for processing to the
     :class:`~crappy.tool.image_processing.GPUCorrelTool`. Then sends the result
     of the correlation to the downstream Blocks.
@@ -213,9 +213,9 @@ class GPUCorrelProcess(CameraProcess):
           return
 
     # Sending the data to downstream Blocks
-    self._send(data)
+    self.send(data)
 
-  def _finish(self) -> None:
+  def finish(self) -> None:
     """Performs cleanup on the
     :class:`~crappy.tool.image_processing.GPUCorrelTool`."""
 

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -114,17 +114,17 @@ class GPUCorrelProcess(CameraProcess):
 
     super().__init__()
 
-    self._gpu_correl_kw = dict(context=None,
-                               verbose=verbose,
-                               levels=levels,
-                               resampling_factor=resampling_factor,
-                               kernel_file=kernel_file,
-                               iterations=iterations,
-                               fields=fields,
-                               ref_img=img_ref,
-                               mask=mask,
-                               mul=mul)
+    # Arguments to pass to the GPUCorrelTool
+    self._verbose = verbose
+    self._levels = levels
+    self._resampling_factor = resampling_factor
+    self._kernel_file = kernel_file
+    self._iterations = iterations
+    self._fields = fields
+    self._mask = mask
+    self._mul = mul
 
+    # Other attributes
     self._correl: Optional[GPUCorrelTool] = None
     self._img_ref = img_ref
     self._img0_set = img_ref is not None
@@ -140,8 +140,17 @@ class GPUCorrelProcess(CameraProcess):
 
     # Instantiating the GPUCorrelTool
     self.log(logging.INFO, "Instantiating the GPUCorrel tool")
-    self._gpu_correl_kw.update(logger_name=self.name)
-    self._correl = GPUCorrelTool(**self._gpu_correl_kw)
+    self._correl = GPUCorrelTool(logger_name=self.name,
+                                 context=None,
+                                 verbose=self._verbose,
+                                 levels=self._levels,
+                                 resampling_factor=self._resampling_factor,
+                                 kernel_file=self._kernel_file,
+                                 iterations=self._iterations,
+                                 fields=self._fields,
+                                 ref_img=self._img_ref,
+                                 mask=self._mask,
+                                 mul=self._mul)
 
     # Setting the reference image if it was given as an argument
     if self._img_ref is not None:

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -117,20 +117,20 @@ class GPUVEProcess(CameraProcess):
     if a ``img_ref`` argument was provided."""
 
     # Instantiating the GPUCorrelTool instances
-    self._log(logging.INFO, "Instantiating the GPUCorrel tool instances")
+    self.log(logging.INFO, "Instantiating the GPUCorrel tool instances")
     self._gpu_ve_kw.update(logger_name=self.name)
     self._correls = [GPUCorrelTool(**self._gpu_ve_kw) for _ in self._patches]
 
     # We can already set the sizes of the images as they are already known
-    self._log(logging.INFO, "Setting the sizes of the patches")
+    self.log(logging.INFO, "Setting the sizes of the patches")
     for correl, (_, __, h, w) in zip(self._correls, self._patches):
       correl.set_img_size((h, w))
 
     # Setting the reference image if it was given as an argument
     if self._img_ref is not None:
-      self._log(logging.INFO, "Initializing the GPUCorrel tool instances "
-                              "with the given reference image and preparing "
-                              "them")
+      self.log(logging.INFO, "Initializing the GPUCorrel tool instances "
+                             "with the given reference image and preparing "
+                             "them")
       for correl, (oy, ox, h, w) in zip(self._correls, self._patches):
         correl.set_orig(
           self._img_ref[oy:oy + h, ox:ox + w].astype(np.float32))
@@ -153,7 +153,7 @@ class GPUVEProcess(CameraProcess):
     # Setting the reference image with the first received frame if it was not
     # given as an argument
     if not self._img0_set:
-      self._log(logging.INFO, "Setting the reference image")
+      self.log(logging.INFO, "Setting the reference image")
       for correl, (oy, ox, h, w) in zip(self._correls, self._patches):
         correl.set_orig(self._img[oy:oy + h,
                         ox:ox + w].astype(np.float32))
@@ -162,7 +162,7 @@ class GPUVEProcess(CameraProcess):
       return
 
     # Performing the image correlation
-    self._log(logging.DEBUG, "Processing the received image")
+    self.log(logging.DEBUG, "Processing the received image")
     data = [self._metadata['t(s)'], self._metadata]
     for correl, (oy, ox, h, w) in zip(self._correls, self._patches):
       data.extend(correl.get_disp(
@@ -179,6 +179,6 @@ class GPUVEProcess(CameraProcess):
     :class:`~crappy.tool.image_processing.GPUCorrelTool` used."""
 
     if self._correls is not None:
-      self._log(logging.INFO, "Cleaning up the GPUCorrel instances")
+      self.log(logging.INFO, "Cleaning up the GPUCorrel instances")
       for correl in self._correls:
         correl.clean()

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -112,7 +112,7 @@ class GPUVEProcess(CameraProcess):
 
     self._img0_set = img_ref is not None
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """Initializes the GPUCorrelTool instances, and set their reference image
     if a ``img_ref`` argument was provided."""
 
@@ -136,7 +136,7 @@ class GPUVEProcess(CameraProcess):
           self._img_ref[oy:oy + h, ox:ox + w].astype(np.float32))
         correl.prepare()
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method grabs the latest frame and gives it for processing to the
     several instances of :class:`~crappy.tool.image_processing.GPUCorrelTool`.
     Then sends the displacement data to the downstream Blocks.
@@ -173,12 +173,12 @@ class GPUVEProcess(CameraProcess):
         self._img[oy:oy + h, ox:ox + w].astype(np.float32)).tolist())
 
     # Sending the data to downstream Blocks
-    self._send(data)
+    self.send(data)
 
     # Sending the patches to the Displayer for display
-    self._send_to_draw(self._spots)
+    self.send_to_draw(self._spots)
 
-  def _finish(self) -> None:
+  def finish(self) -> None:
     """Performs cleanup on the several
     :class:`~crappy.tool.image_processing.GPUCorrelTool` used."""
 

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -148,8 +148,6 @@ class GPUVEProcess(CameraProcess):
     :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess.
     """
 
-    self.fps_count += 1
-
     # Setting the reference image with the first received frame if it was not
     # given as an argument
     if not self._img0_set:

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -153,18 +153,17 @@ class GPUVEProcess(CameraProcess):
     if not self._img0_set:
       self.log(logging.INFO, "Setting the reference image")
       for correl, (oy, ox, h, w) in zip(self._correls, self._patches):
-        correl.set_orig(self._img[oy:oy + h,
-                        ox:ox + w].astype(np.float32))
+        correl.set_orig(self.img[oy:oy + h, ox:ox + w].astype(np.float32))
         correl.prepare()
       self._img0_set = True
       return
 
     # Performing the image correlation
     self.log(logging.DEBUG, "Processing the received image")
-    data = [self._metadata['t(s)'], self._metadata]
+    data = [self.metadata['t(s)'], self.metadata]
     for correl, (oy, ox, h, w) in zip(self._correls, self._patches):
       data.extend(correl.get_disp(
-        self._img[oy:oy + h, ox:ox + w].astype(np.float32)).tolist())
+          self.img[oy:oy + h, ox:ox + w].astype(np.float32)).tolist())
 
     # Sending the data to downstream Blocks
     self.send(data)

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -55,7 +55,7 @@ class GPUVEProcess(CameraProcess):
         :obj:`int`.
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
-        is displayed that is slows the code down. This argument is passed to
+        is displayed that it slows the code down. This argument is passed to
         the :class:`~crappy.tool.image_processing.GPUCorrelTool` and not used
         in this class.
       kernel_file: The path to the file containing the kernels to use for the

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -148,10 +148,6 @@ class GPUVEProcess(CameraProcess):
     :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess.
     """
 
-    # Nothing to do if no new frame was grabbed
-    if not self._get_data():
-      return
-
     self.fps_count += 1
 
     # Setting the reference image with the first received frame if it was not

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from multiprocessing.queues import Queue
 import numpy as np
 from typing import Optional, Tuple, List, Union
 from pathlib import Path
@@ -35,8 +34,6 @@ class GPUVEProcess(CameraProcess):
 
   def __init__(self,
                patches: List[Tuple[int, int, int, int]],
-               log_queue: Queue,
-               log_level: int = 20,
                verbose: int = 0,
                kernel_file: Optional[Union[str, Path]] = None,
                iterations: int = 4,
@@ -49,10 +46,6 @@ class GPUVEProcess(CameraProcess):
         track, as a :obj:`tuple` for each patch. Each tuple should contain
         exactly `4` elements, giving in pixels the `y` origin, `x` origin,
         height and width of the patch.
-      log_queue: A :obj:`~multiprocessing.Queue` for sending the log messages
-        to the main :obj:`~logging.Logger`, only used in Windows.
-      log_level: The minimum logging level of the entire Crappy script, as an
-        :obj:`int`.
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
         is displayed that it slows the code down. This argument is passed to
@@ -85,8 +78,7 @@ class GPUVEProcess(CameraProcess):
         used in this class.
     """
 
-    super().__init__(log_queue=log_queue, log_level=log_level,
-                     display_freq=bool(verbose))
+    super().__init__()
 
     # Making a CUDA context common to all the patches
     pycuda.driver.init()

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -114,7 +114,7 @@ class ImageSaver(CameraProcess):
     self._csv_path = None
     self._metadata_name = 'metadata.csv'
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """Creates the folder for saving the images.
 
     If a folder is already present at the indicated path and contains images,
@@ -188,7 +188,7 @@ class ImageSaver(CameraProcess):
 
     return True
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method grabs the latest frame, writes its metadata to a `.csv` file
     and saves the image at the chosen location using the chosen backend.
 

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from multiprocessing.queues import Queue
 from csv import DictWriter
 import numpy as np
 from typing import Optional, Union
@@ -41,20 +40,13 @@ class ImageSaver(CameraProcess):
   """
 
   def __init__(self,
-               log_queue: Queue,
-               log_level: int = 20,
                img_extension: str = "tiff",
                save_folder: Optional[Union[str, Path]] = None,
                save_period: int = 1,
-               save_backend: Optional[str] = None,
-               display_freq: bool = False) -> None:
+               save_backend: Optional[str] = None) -> None:
     """Sets the arguments and initializes the parent class.
 
     Args:
-      log_queue: A :obj:`~multiprocessing.Queue` for sending the log messages
-        to the main :obj:`~logging.Logger`, only used in Windows.
-      log_level: The minimum logging level of the entire Crappy script, as an
-        :obj:`int`.
       img_extension: The file extension for the recorded images, as a
         :obj:`str` and without the dot. Common file extensions include `tiff`,
         `png`, `jpg`, etc.
@@ -74,13 +66,9 @@ class ImageSaver(CameraProcess):
         :mod:`PIL` (Pillow Fork), and :mod:`numpy`. Depending on the machine,
         some may be faster or slower. The ``img_extension`` is ignored for the
         backend ``'npy'``, that saves the images as raw numpy arrays.
-      display_freq: If :obj:`True`, the looping frequency of this class will be
-        displayed while running.
     """
 
-    super().__init__(log_queue=log_queue,
-                     log_level=log_level,
-                     display_freq=display_freq)
+    super().__init__()
 
     # Trying the different possible backends and checking if the given one
     # is correct

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -127,26 +127,26 @@ class ImageSaver(CameraProcess):
       content = (path.name for path in self._save_folder.iterdir())
       # If it contains images, saving to a different folder
       if self._metadata_name in content:
-        self._log(logging.WARNING, f"The folder {self._save_folder} already "
-                                   f"seems to contain images from Crappy !")
+        self.log(logging.WARNING, f"The folder {self._save_folder} already "
+                                  f"seems to contain images from Crappy !")
         parent, name = self._save_folder.parent, self._save_folder.name
         i = 1
         # Adding an integer at the end of the folder name to differentiate it
         while (parent / f'{name}_{i:05d}').exists():
           i += 1
         self._save_folder = parent / f'{name}_{i:05d}'
-        self._log(logging.WARNING, f"Saving the images at {self._save_folder} "
-                                   f"instead !")
+        self.log(logging.WARNING, f"Saving the images at {self._save_folder} "
+                                  f"instead !")
 
       else:
-        self._log(logging.DEBUG,
-                  f"The folder {self._save_folder} for recording images exists"
-                  f" but does not contain images yet.")
+        self.log(logging.DEBUG,
+                 f"The folder {self._save_folder} for recording images exists"
+                 f" but does not contain images yet.")
 
     # Creating the folder for recording images
     if not self._save_folder.exists():
-      self._log(logging.INFO, f"Creating the folder for saving images at: "
-                              f"{self._save_folder}")
+      self.log(logging.INFO, f"Creating the folder for saving images at: "
+                             f"{self._save_folder}")
       Path.mkdir(self._save_folder, exist_ok=True, parents=True)
 
   def _get_data(self) -> bool:
@@ -178,8 +178,8 @@ class ImageSaver(CameraProcess):
       # Copying the metadata
       self._metadata = self._data_dict.copy()
 
-      self._log(logging.DEBUG, f"Got new image to process with id "
-                               f"{self._metadata['ImageUniqueID']}")
+      self.log(logging.DEBUG, f"Got new image to process with id "
+                              f"{self._metadata['ImageUniqueID']}")
 
       # Copying the frame
       np.copyto(self._img,
@@ -202,8 +202,8 @@ class ImageSaver(CameraProcess):
     if not self._csv_created:
       self._csv_path = (self._save_folder / self._metadata_name)
 
-      self._log(logging.INFO, f"Creating file for saving the metadata: "
-                              f"{self._csv_path}")
+      self.log(logging.INFO, f"Creating file for saving the metadata: "
+                             f"{self._csv_path}")
 
       # Also writing the header of the .csv file when creating it
       with open(self._csv_path, 'w') as csvfile:
@@ -213,7 +213,7 @@ class ImageSaver(CameraProcess):
       self._csv_created = True
 
     # Saving the received metadata to the .csv file
-    self._log(logging.DEBUG, f"Saving metadata: {self._metadata}")
+    self.log(logging.DEBUG, f"Saving metadata: {self._metadata}")
     with open(self._csv_path, 'a') as csvfile:
       writer = DictWriter(csvfile, fieldnames=self._metadata.keys())
       writer.writerow({**self._metadata, 't(s)': self._metadata['t(s)']})
@@ -228,7 +228,7 @@ class ImageSaver(CameraProcess):
                                      f"{self._metadata['t(s)']:.3f}")
 
     # Saving the image at the destination path using the chosen backend
-    self._log(logging.DEBUG, "Saving image")
+    self.log(logging.DEBUG, "Saving image")
     if self._save_backend == 'sitk':
       Sitk.WriteImage(Sitk.GetImageFromArray(self._img), path)
 

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -196,8 +196,6 @@ class ImageSaver(CameraProcess):
     populated using the metadata of the frame.
     """
 
-    self.fps_count += 1
-
     # Creating the .csv containing the metadata on the first received frame
     if not self._csv_created:
       self._csv_path = (self._save_folder / self._metadata_name)

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -196,10 +196,6 @@ class ImageSaver(CameraProcess):
     populated using the metadata of the frame.
     """
 
-    # Nothing to do if no new frame was grabbed
-    if not self._get_data():
-      return
-
     self.fps_count += 1
 
     # Creating the .csv containing the metadata on the first received frame

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-from multiprocessing.queues import Queue
 from typing import Optional
 import logging
 import logging.handlers
@@ -28,10 +27,7 @@ class VideoExtensoProcess(CameraProcess):
 
   def __init__(self,
                detector: SpotsDetector,
-               log_queue: Queue,
-               log_level: int = 20,
-               raise_on_lost_spot: bool = True,
-               display_freq: bool = False) -> None:
+               raise_on_lost_spot: bool = True) -> None:
     """Sets the arguments and initializes the parent class.
     
     Args:
@@ -41,20 +37,12 @@ class VideoExtensoProcess(CameraProcess):
         argument is passed to the
         :class:`~crappy.tool.image_processing.video_extenso.VideoExtensoTool`
         and not used in this class.
-      log_queue: A :obj:`~multiprocessing.Queue` for sending the log messages
-        to the main :obj:`~logging.Logger`, only used in Windows.
-      log_level: The minimum logging level of the entire Crappy script, as an
-        :obj:`int`.
       raise_on_lost_spot: If :obj:`True`, raises an exception when losing the
         spots to track, which stops the test. Otherwise, stops the tracking but
         lets the test go on and silently sleeps.
-      display_freq: If :obj:`True`, the looping frequency of this class will be
-        displayed while running.
     """
 
-    super().__init__(log_queue=log_queue,
-                     log_level=log_level,
-                     display_freq=display_freq)
+    super().__init__()
 
     self._ve: Optional[VideoExtensoTool] = None
     self._detector = detector

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -66,7 +66,7 @@ class VideoExtensoProcess(CameraProcess):
     :class:`~crappy.tool.image_processing.video_extenso.VideoExtensoTool` and
     starts tracking the spots."""
 
-    self._log(logging.INFO, "Instantiating the VideoExtenso tool")
+    self.log(logging.INFO, "Instantiating the VideoExtenso tool")
     self._ve = VideoExtensoTool(spots=self._detector.spots,
                                 thresh=self._detector.thresh,
                                 log_level=self._log_level,
@@ -77,8 +77,8 @@ class VideoExtensoProcess(CameraProcess):
                                 border=self._detector.border,
                                 blur=self._detector.blur)
 
-    self._log(logging.INFO, "Starting the VideoExtenso spot tracker "
-                            "processes")
+    self.log(logging.INFO, "Starting the VideoExtenso spot tracker "
+                           "processes")
     self._ve.start_tracking()
 
   def loop(self) -> None:
@@ -98,7 +98,7 @@ class VideoExtensoProcess(CameraProcess):
       
       # Processing the received frame
       try:
-        self._log(logging.DEBUG, "Processing the received image")
+        self.log(logging.DEBUG, "Processing the received image")
         data = self._ve.get_data(self._img)
         
         # Sending the results to the downstream Blocks
@@ -110,19 +110,19 @@ class VideoExtensoProcess(CameraProcess):
 
       # In case the spots were just lost
       except LostSpotError:
-        self._log(logging.INFO, "Spots lost, stopping the spot trackers")
+        self.log(logging.INFO, "Spots lost, stopping the spot trackers")
         self._ve.stop_tracking()
         # Raising if specified by the user
         if self._raise_on_lost_spot:
-          self._log(logging.ERROR, "Spots lost, stopping the VideoExtenso "
-                                   "process")
+          self.log(logging.ERROR, "Spots lost, stopping the VideoExtenso "
+                                  "process")
           raise
         # Otherwise, simply setting a flag so that no additional
         # processing is performed
         else:
           self._lost_spots = True
-          self._log(logging.WARNING, "Spots lost, VideoExtenso staying "
-                                     "idle until the test ends")
+          self.log(logging.WARNING, "Spots lost, VideoExtenso staying "
+                                    "idle until the test ends")
     
     # If the spots were lost, avoid spamming the CPU in vain
     else:
@@ -134,5 +134,5 @@ class VideoExtensoProcess(CameraProcess):
     stop tracking the spots."""
 
     if self._ve is not None:
-      self._log(logging.INFO, "Stopping the spot trackers before returning")
+      self.log(logging.INFO, "Stopping the spot trackers before returning")
       self._ve.stop_tracking()

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -94,7 +94,6 @@ class VideoExtensoProcess(CameraProcess):
 
     # Processing only if the spots haven't been lost
     if not self._lost_spots:
-      self.fps_count += 1
       
       # Processing the received frame
       try:
@@ -126,6 +125,7 @@ class VideoExtensoProcess(CameraProcess):
     
     # If the spots were lost, avoid spamming the CPU in vain
     else:
+      self.fps_count -= 1
       sleep(0.1)
 
   def finish(self) -> None:

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -92,10 +92,6 @@ class VideoExtensoProcess(CameraProcess):
     the :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess.
     """
 
-    # Nothing to do if no new frame was grabbed
-    if not self._get_data():
-      return
-
     # Processing only if the spots haven't been lost
     if not self._lost_spots:
       self.fps_count += 1

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -98,11 +98,11 @@ class VideoExtensoProcess(CameraProcess):
       # Processing the received frame
       try:
         self.log(logging.DEBUG, "Processing the received image")
-        data = self._ve.get_data(self._img)
+        data = self._ve.get_data(self.img)
         
         # Sending the results to the downstream Blocks
         if data is not None:
-          self.send([self._metadata['t(s)'], self._metadata, *data])
+          self.send([self.metadata['t(s)'], self.metadata, *data])
 
         # Sending the detected spots to the Displayer for display
         self.send_to_draw(self._ve.spots)

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -61,7 +61,7 @@ class VideoExtensoProcess(CameraProcess):
     self._raise_on_lost_spot = raise_on_lost_spot
     self._lost_spots = False
 
-  def _init(self) -> None:
+  def init(self) -> None:
     """Instantiates the 
     :class:`~crappy.tool.image_processing.video_extenso.VideoExtensoTool` and
     starts tracking the spots."""
@@ -81,7 +81,7 @@ class VideoExtensoProcess(CameraProcess):
                             "processes")
     self._ve.start_tracking()
 
-  def _loop(self) -> None:
+  def loop(self) -> None:
     """This method grabs the latest frame and gives it for processing to the
     :class:`~crappy.tool.image_processing.video_extenso.VideoExtensoTool`. Then
     sends the strain and displacement data to the downstream Blocks.
@@ -107,10 +107,10 @@ class VideoExtensoProcess(CameraProcess):
         
         # Sending the results to the downstream Blocks
         if data is not None:
-          self._send([self._metadata['t(s)'], self._metadata, *data])
+          self.send([self._metadata['t(s)'], self._metadata, *data])
 
         # Sending the detected spots to the Displayer for display
-        self._send_to_draw(self._ve.spots)
+        self.send_to_draw(self._ve.spots)
 
       # In case the spots were just lost
       except LostSpotError:
@@ -132,7 +132,7 @@ class VideoExtensoProcess(CameraProcess):
     else:
       sleep(0.1)
 
-  def _finish(self) -> None:
+  def finish(self) -> None:
     """Indicates the 
     :class:`~crappy.tool.image_processing.video_extenso.VideoExtensoTool` to
     stop tracking the spots."""

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -363,10 +363,7 @@ class DICVE(Camera):
       self._patches.save_length()
 
     # Instantiating the DICVEProcess
-    self.process_proc = DICVEProcess(log_queue=self._log_queue,
-                                     log_level=self._log_level,
-                                     display_freq=self.display_freq,
-                                     patches=self._patches,
+    self.process_proc = DICVEProcess(patches=self._patches,
                                      **self._dic_ve_kw)
 
     super().prepare()

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -332,20 +332,19 @@ class DICVE(Camera):
     self._raise_on_exit = raise_on_patch_exit
     self._patches_int = list(patches) if patches is not None else None
 
-    # These arguments or for the DICVEProcess
-    self._dic_ve_kw = dict(method=method,
-                           alpha=alpha,
-                           delta=delta,
-                           gamma=gamma,
-                           finest_scale=finest_scale,
-                           iterations=iterations,
-                           gradient_iterations=gradient_iterations,
-                           patch_size=patch_size,
-                           patch_stride=patch_stride,
-                           border=border,
-                           safe=safe,
-                           follow=follow,
-                           raise_on_exit=raise_on_patch_exit)
+    # These arguments are for the DICVEProcess
+    self._method = method
+    self._alpha = alpha
+    self._delta = delta
+    self._gamma = gamma
+    self._finest_scale = finest_scale
+    self._iterations = iterations
+    self._gradient_iterations = gradient_iterations
+    self._patch_size = patch_size
+    self._patch_stride = patch_stride
+    self._border = border
+    self._safe = safe
+    self._follow = follow
 
   def prepare(self) -> None:
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare` 
@@ -363,8 +362,21 @@ class DICVE(Camera):
       self._patches.save_length()
 
     # Instantiating the DICVEProcess
-    self.process_proc = DICVEProcess(patches=self._patches,
-                                     **self._dic_ve_kw)
+    self.process_proc = DICVEProcess(
+        patches=self._patches,
+        method=self._method,
+        alpha=self._alpha,
+        delta=self._delta,
+        gamma=self._gamma,
+        finest_scale=self._finest_scale,
+        iterations=self._iterations,
+        gradient_iterations=self._gradient_iterations,
+        patch_size=self._patch_size,
+        patch_stride=self._patch_stride,
+        border=self._border,
+        safe=self._safe,
+        follow=self._follow,
+        raise_on_exit=self._raise_on_exit)
 
     super().prepare()
 

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -363,11 +363,11 @@ class DICVE(Camera):
       self._patches.save_length()
 
     # Instantiating the DICVEProcess
-    self._process_proc = DICVEProcess(log_queue=self._log_queue,
-                                      log_level=self._log_level,
-                                      display_freq=self.display_freq,
-                                      patches=self._patches,
-                                      **self._dic_ve_kw)
+    self.process_proc = DICVEProcess(log_queue=self._log_queue,
+                                     log_level=self._log_level,
+                                     display_freq=self.display_freq,
+                                     patches=self._patches,
+                                     **self._dic_ve_kw)
 
     super().prepare()
 

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -351,7 +351,7 @@ class DICVE(Camera):
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare` 
     method of the parent class.
     
-    In addition to that is instantiates the
+    In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.DICVEProcess` object that performs
     the image correlation and the tracking.
     """

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -309,17 +309,18 @@ class DISCorrel(Camera):
         "The number of fields is inconsistent with the number "
         "of labels !\nMake sure that the time label was given")
 
-    self._dis_correl_kw = dict(fields=fields,
-                               alpha=alpha,
-                               delta=delta,
-                               gamma=gamma,
-                               finest_scale=finest_scale,
-                               init=init,
-                               iterations=iterations,
-                               gradient_iterations=gradient_iterations,
-                               patch_size=patch_size,
-                               patch_stride=patch_stride,
-                               residual=residual)
+    # These arguments are for the DISCorrelProcess
+    self._fields = fields
+    self._alpha = alpha
+    self._delta = delta
+    self._gamma = gamma
+    self._finest_scale = finest_scale
+    self._init = init
+    self._iterations = iterations
+    self._gradient_iterations = gradient_iterations
+    self._patch_size = patch_size
+    self._patch_stride = patch_stride
+    self._residual = residual
 
   def prepare(self) -> None:
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
@@ -340,8 +341,19 @@ class DISCorrel(Camera):
       self._patch = Box()
 
     # Instantiating the DISCorrelProcess
-    self.process_proc = DISCorrelProcess(patch=self._patch,
-                                         **self._dis_correl_kw)
+    self.process_proc = DISCorrelProcess(
+        patch=self._patch,
+        fields=self._fields,
+        alpha=self._alpha,
+        delta=self._delta,
+        gamma=self._gamma,
+        finest_scale=self._finest_scale,
+        init=self._init,
+        iterations=self._iterations,
+        gradient_iterations=self._gradient_iterations,
+        patch_size=self._patch_size,
+        patch_stride=self._patch_stride,
+        residual=self._residual)
 
     super().prepare()
 

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -325,7 +325,7 @@ class DISCorrel(Camera):
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
     method of the parent class.
 
-    In addition to that is instantiates the
+    In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.DISCorrelProcess` object that
     performs the image correlation and the tracking.
     """

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -340,10 +340,7 @@ class DISCorrel(Camera):
       self._patch = Box()
 
     # Instantiating the DISCorrelProcess
-    self.process_proc = DISCorrelProcess(log_queue=self._log_queue,
-                                         log_level=self._log_level,
-                                         display_freq=self.display_freq,
-                                         patch=self._patch,
+    self.process_proc = DISCorrelProcess(patch=self._patch,
                                          **self._dis_correl_kw)
 
     super().prepare()

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -340,11 +340,11 @@ class DISCorrel(Camera):
       self._patch = Box()
 
     # Instantiating the DISCorrelProcess
-    self._process_proc = DISCorrelProcess(log_queue=self._log_queue,
-                                          log_level=self._log_level,
-                                          display_freq=self.display_freq,
-                                          patch=self._patch,
-                                          **self._dis_correl_kw)
+    self.process_proc = DISCorrelProcess(log_queue=self._log_queue,
+                                         log_level=self._log_level,
+                                         display_freq=self.display_freq,
+                                         patch=self._patch,
+                                         **self._dis_correl_kw)
 
     super().prepare()
 

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -310,9 +310,9 @@ class GPUCorrel(Camera):
     """
 
     # Instantiating the GPUCorrelProcess
-    self._process_proc = GPUCorrelProcess(log_queue=self._log_queue,
-                                          log_level=self._log_level,
-                                          **self._gpu_correl_kw)
+    self.process_proc = GPUCorrelProcess(log_queue=self._log_queue,
+                                         log_level=self._log_level,
+                                         **self._gpu_correl_kw)
 
     super().prepare()
 

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -310,9 +310,7 @@ class GPUCorrel(Camera):
     """
 
     # Instantiating the GPUCorrelProcess
-    self.process_proc = GPUCorrelProcess(log_queue=self._log_queue,
-                                         log_level=self._log_level,
-                                         **self._gpu_correl_kw)
+    self.process_proc = GPUCorrelProcess(**self._gpu_correl_kw)
 
     super().prepare()
 

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -287,18 +287,18 @@ class GPUCorrel(Camera):
       raise ValueError("The number of fields is inconsistent with the number "
                        "of labels !\nMake sure that the time label was given")
 
-    self._gpu_correl_kw = dict(discard_limit=discard_limit,
-                               discard_ref=discard_ref,
-                               calc_res=res,
-                               img_ref=img_ref,
-                               verbose=verbose,
-                               levels=levels,
-                               resampling_factor=resampling_factor,
-                               kernel_file=kernel_file,
-                               iterations=iterations,
-                               fields=fields,
-                               mask=mask,
-                               mul=mul)
+    # These arguments are for the GPUCorrelProcess
+    self._discard_limit = discard_limit
+    self._discard_ref = discard_ref
+    self._img_ref = img_ref
+    self._verbose = verbose
+    self._levels = levels
+    self._resampling_factor = resampling_factor
+    self._kernel_file = kernel_file
+    self._iterations = iterations
+    self._fields = fields
+    self._mask = mask
+    self._mul = mul
 
   def prepare(self) -> None:
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
@@ -310,7 +310,19 @@ class GPUCorrel(Camera):
     """
 
     # Instantiating the GPUCorrelProcess
-    self.process_proc = GPUCorrelProcess(**self._gpu_correl_kw)
+    self.process_proc = GPUCorrelProcess(
+        discard_limit=self._discard_limit,
+        discard_ref=self._discard_ref,
+        calc_res=self._calc_res,
+        img_ref=self._img_ref,
+        verbose=self._verbose,
+        levels=self._levels,
+        resampling_factor=self._resampling_factor,
+        kernel_file=self._kernel_file,
+        iterations=self._iterations,
+        fields=self._fields,
+        mask=self._mask,
+        mul=self._mul)
 
     super().prepare()
 

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -261,9 +261,7 @@ class GPUVE(Camera):
     """
 
     # Instantiating the GPUVEProcess
-    self.process_proc = GPUVEProcess(log_queue=self._log_queue,
-                                     log_level=self._log_level,
-                                     **self._gpu_ve_kw)
+    self.process_proc = GPUVEProcess(**self._gpu_ve_kw)
 
     super().prepare()
 

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -244,12 +244,12 @@ class GPUVE(Camera):
                        "of labels !\nMake sure that the time and metadata "
                        "labels were given")
 
-    self._gpu_ve_kw = dict(patches=patches,
-                           verbose=verbose,
-                           kernel_file=kernel_file,
-                           iterations=iterations,
-                           img_ref=img_ref,
-                           mul=mul)
+    # These arguments are for the GPUVEProcess
+    self._patches = patches
+    self._verbose = verbose
+    self._kernel_file = kernel_file
+    self._iterations = iterations
+    self._mul = mul
 
   def prepare(self) -> None:
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
@@ -261,7 +261,12 @@ class GPUVE(Camera):
     """
 
     # Instantiating the GPUVEProcess
-    self.process_proc = GPUVEProcess(**self._gpu_ve_kw)
+    self.process_proc = GPUVEProcess(patches=self._patches,
+                                     verbose=self._verbose,
+                                     kernel_file=self._kernel_file,
+                                     iterations=self._iterations,
+                                     img_ref=self._img_ref,
+                                     mul=self._mul)
 
     super().prepare()
 

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -261,9 +261,9 @@ class GPUVE(Camera):
     """
 
     # Instantiating the GPUVEProcess
-    self._process_proc = GPUVEProcess(log_queue=self._log_queue,
-                                      log_level=self._log_level,
-                                      **self._gpu_ve_kw)
+    self.process_proc = GPUVEProcess(log_queue=self._log_queue,
+                                     log_level=self._log_level,
+                                     **self._gpu_ve_kw)
 
     super().prepare()
 

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -255,7 +255,7 @@ class GPUVE(Camera):
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
     method of the parent class.
 
-    In addition to that is instantiates the
+    In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.GPUVEProcess` object that
     performs the GPU-accelerated image correlation.
     """

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -276,13 +276,14 @@ class VideoExtenso(Camera):
     self._raise_on_lost_spot = raise_on_lost_spot
     self._spot_detector = SpotsDetector()
 
-    self._detector_kw = dict(white_spots=white_spots,
-                             num_spots=num_spots,
-                             min_area=min_area,
-                             blur=blur,
-                             update_thresh=update_thresh,
-                             safe_mode=safe_mode,
-                             border=border)
+    # These arguments are for the SpotsDetector
+    self._white_spots = white_spots
+    self._num_spots = num_spots
+    self._min_area = min_area
+    self._blur = blur
+    self._update_thresh = update_thresh
+    self._safe_mode = safe_mode
+    self._border = border
 
   def prepare(self) -> None:
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
@@ -294,7 +295,13 @@ class VideoExtenso(Camera):
     """
 
     # Instantiating the SpotsDetector containing the spots to track
-    self._spot_detector = SpotsDetector(**self._detector_kw)
+    self._spot_detector = SpotsDetector(white_spots=self._white_spots,
+                                        num_spots=self._num_spots,
+                                        min_area=self._min_area,
+                                        blur=self._blur,
+                                        update_thresh=self._update_thresh,
+                                        safe_mode=self._safe_mode,
+                                        border=self._border)
 
     # Instantiating the VideoExtensoProcess
     self.process_proc = VideoExtensoProcess(

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -297,7 +297,7 @@ class VideoExtenso(Camera):
     self._spot_detector = SpotsDetector(**self._detector_kw)
 
     # Instantiating the VideoExtensoProcess
-    self._process_proc = VideoExtensoProcess(
+    self.process_proc = VideoExtensoProcess(
       detector=self._spot_detector,
       log_queue=self._log_queue,
       log_level=self._log_level,

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -288,7 +288,7 @@ class VideoExtenso(Camera):
     """This method mostly calls the :meth:`~crappy.blocks.Camera.prepare`
     method of the parent class.
 
-    In addition to that is instantiates the
+    In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.VideoExtensoProcess` object that
     performs the video-extensometry and the tracking.
     """

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -299,10 +299,7 @@ class VideoExtenso(Camera):
     # Instantiating the VideoExtensoProcess
     self.process_proc = VideoExtensoProcess(
       detector=self._spot_detector,
-      log_queue=self._log_queue,
-      log_level=self._log_level,
-      raise_on_lost_spot=self._raise_on_lost_spot,
-      display_freq=self.display_freq)
+      raise_on_lost_spot=self._raise_on_lost_spot)
 
     super().prepare()
 


### PR DESCRIPTION
Until now, few efforts were made to allow users to create their own children of `Camera` Blocks (and of `CameraProcess` as well).
A first step towards more accessibility was made with #49, but it was only improving the display of overlays on top of the displayed images for a custom `Camera` Block.
The instantiation of the Block itself was still chaotic, as it required to access private members of the class and to manage obscure arguments (see the last comment of #47).

With this PR, the creation of custom `Camera` Blocks and `CameraProcess` is made more accessible and straightforward :
- The name of the methods of `CameraProcess` meant to be overridden or called by users were switched from private to public (a2721f4f, 2ba09588).
- Same goes for the attributes of `CameraProcess` (14119ff5) and of the `Camera` Block (6ac74fa3).
- The parent `CameraProcess` now automatically checks for new available images, this doesn't have to be done by the user (fc5dc5d7) anymore.
- Same goes for the processed images counter in `CameraProcess`, that is now updated automatically (88b9f11c).
- The parent `CameraProcess` doesn't need to be provided with the `_log_queue`, `_log_level` and `_display_freq` arguments at initialization anymore. They are now passed automatically by `Camera` to the parent `CameraProcess` (ddef41c9).
- The documentation has been updated accordingly (6be94f7e, 219d5cc2).
- Some typos and minor code style issues were also fixed.

Some attributes and methods that can be accessed and overridden safely by users remain private, to signal that they should remain untouched in the general case.

Weis
