### PR TITLE
Add a step option for the camera scale setting in the configuration window

### DIFF
--- a/src/crappy/camera/fake_camera.py
+++ b/src/crappy/camera/fake_camera.py
@@ -23,10 +23,10 @@ class FakeCamera(Camera):
     super().__init__()
     self._frame_nr = -1
 
-    self.add_scale_setting('width', 1, 4096, None, self._gen_image, 1280)
-    self.add_scale_setting('height', 1, 4096, None, self._gen_image, 720)
-    self.add_scale_setting('speed', 0., 800., None, None, 100.)
-    self.add_scale_setting('fps', 0.1, 100., None, None, 50.)
+    self.add_scale_setting('width', 1, 4096, None, self._gen_image, 1280, 1)
+    self.add_scale_setting('height', 1, 4096, None, self._gen_image, 720, 1)
+    self.add_scale_setting('speed', 0., 800., None, None, 400., 0.8)
+    self.add_scale_setting('fps', 0.1, 100., None, None, 50., 0.1)
 
     self._t0 = time()
     self._t = self._t0

--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -186,7 +186,8 @@ class Camera(metaclass=MetaCamera):
                         highest: NbrType,
                         getter: Optional[Callable[[], NbrType]] = None,
                         setter: Optional[Callable[[NbrType], None]] = None,
-                        default: Optional[NbrType] = None) -> None:
+                        default: Optional[NbrType] = None,
+                        step: Optional[NbrType] = None) -> None:
     """Adds a scale setting, whose value is an :obj:`int` or a :obj:`float`
     lying between two boundaries.
 
@@ -216,6 +217,7 @@ class Camera(metaclass=MetaCamera):
         given, the value to be set is simply stored.
       default: The default value to assign to the setting. If not given, will
         be the average of ``lowest`` and ``highest``.
+      step: The step value for the variation of the setting values.
     """
 
     # Checking if the given name is valid
@@ -226,7 +228,7 @@ class Camera(metaclass=MetaCamera):
       raise ValueError('This setting already exists !')
     self.log(logging.INFO, f"Adding the {name} scale setting")
     self.settings[name] = CameraScaleSetting(name, lowest, highest, getter,
-                                             setter, default)
+                                             setter, default, step)
 
   def add_choice_setting(self,
                          name: str,

--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -369,16 +369,16 @@ class Camera(metaclass=MetaCamera):
     self.log(logging.INFO, "Adding the software ROI settings")
     self.settings[self.roi_x_name] = CameraScaleSetting(
         name=self.roi_x_name, lowest=0, highest=width - 2, getter=None,
-        setter=None, default=0)
+        setter=None, default=0, step=1)
     self.settings[self.roi_y_name] = CameraScaleSetting(
         name=self.roi_y_name, lowest=0, highest=height - 2, getter=None,
-        setter=None, default=0)
+        setter=None, default=0, step=1)
     self.settings[self.roi_width_name] = CameraScaleSetting(
         name=self.roi_width_name, lowest=2, highest=width, getter=None,
-        setter=None, default=width)
+        setter=None, default=width, step=1)
     self.settings[self.roi_height_name] = CameraScaleSetting(
         name=self.roi_height_name, lowest=2, highest=height, getter=None,
-        setter=None, default=height)
+        setter=None, default=height, step=1)
 
     self._soft_roi_set = True
 

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -64,8 +64,7 @@ class CameraScaleSetting(CameraSetting):
                                                 self.lowest) / 1000
         self.log(logging.WARNING, f"Could not set {self.name} steps to "
                                   f"{step}, the step is now {self.step} !")
-      if self.type == int:
-        if (self.highest - self.lowest) % self.step:
+      if self.type == int and (self.highest - self.lowest) % self.step:
           self.highest -= (self.highest - self.lowest) % self.step
           self.log(logging.WARNING, f"Could not set {self.name} highest to "
                                     f"{highest} with this step {self.step},"

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -53,7 +53,7 @@ class CameraScaleSetting(CameraSetting):
 
     super().__init__(name, getter, setter, default)
 
-    if self.step:
+    if self.step is not None:
       if self.type == int and isinstance(self.step, float):
         self.step = int(self.step)
         self.log(logging.WARNING, f"Could not set {self.name} steps to "
@@ -64,16 +64,12 @@ class CameraScaleSetting(CameraSetting):
                                                 self.lowest) / 1000
         self.log(logging.WARNING, f"Could not set {self.name} steps to "
                                   f"{step}, the step is now {self.step} !")
-      if (self.highest - self.lowest) % self.step:
-        i = 1
-        new_high = lowest
-        while abs(new_high - highest) > step:
-          new_high = lowest + i * step
-          i += 1
-        self.highest = new_high
-        self.log(logging.WARNING, f"Could not set {self.name} highest to "
-                                  f"{highest} with this step {self.step},"
-                                  f" the highest is now {self.highest} !")
+      if self.type == int:
+        if (self.highest - self.lowest) % self.step:
+          self.highest -= (self.highest - self.lowest) % self.step
+          self.log(logging.WARNING, f"Could not set {self.name} highest to "
+                                    f"{highest} with this step {self.step},"
+                                    f" the highest is now {self.highest} !")
     else:
       self.step = 1 if self.type == int else (self.highest -
                                               self.lowest) / 1000

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -121,7 +121,7 @@ class CameraScaleSetting(CameraSetting):
 
   def _check_value(self) -> None:
     """Checks if the step value is compatible with the limit values and
-    types of the scale settings"""
+    types of the scale settings."""
 
     if self.step is not None:
       if self.type == int and isinstance(self.step, float):

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -644,13 +644,11 @@ class CameraConfig(tk.Tk):
       cam_set.tk_var = tk.IntVar(value=cam_set.value)
     else:
       cam_set.tk_var = tk.DoubleVar(value=cam_set.value)
-    res = 1 if cam_set.type == int else (cam_set.highest -
-                                         cam_set.lowest) / 1000
 
     cam_set.tk_obj = tk.Scale(self._canvas_frame,
                               label=f'{cam_set.name} :',
                               variable=cam_set.tk_var,
-                              resolution=res,
+                              resolution=cam_set.step,
                               orient='horizontal',
                               from_=cam_set.lowest,
                               to=cam_set.highest)


### PR DESCRIPTION
Currently, there is no step value for the variation of the camera scale setting values when the user uses the slide bar in the configuration window. The value of the step is fixed, depending on the type of the boundaries.
This is not very convenient because a step value can be given for some camera parameters.

In this PR, a step attribute is added when the camera scale setting is created (5b21ffb9).
