### PR TITLE
Simplify the creation of custom Path objects

### DIFF
--- a/docs/source/downloads/complex_custom_objects/custom_path.py
+++ b/docs/source/downloads/complex_custom_objects/custom_path.py
@@ -9,15 +9,13 @@ from math import pi
 class CustomPath(crappy.blocks.generator_path.meta_path.Path):
 
   def __init__(self,
-               _last_time,
-               _last_cmd,
                low_value,
                high_value,
                duty_cycle,
                freq,
                condition):
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
     # Getting the min and max values, and the frequency
     self._low = min(low_value, high_value)

--- a/docs/source/tutorials/complex_custom_objects.rst
+++ b/docs/source/tutorials/complex_custom_objects.rst
@@ -33,22 +33,19 @@ custom Paths and the Paths have to be children of
 
    class MyPath(crappy.blocks.generator_path.meta_path.Path):
 
-       def __init__(self, _last_time, _last_cmd, *_, **__):
-           super().__init__(_last_time, _last_cmd)
+       def __init__():
+           super().__init__()
 
        def get_cmd(self, data):
            ...
 
-As you can see, there are only two methods to define ! Unlike for the other
+As you can see, there are only two methods to define ! Just like for the other
 custom objects, :meth:`~crappy.blocks.generator_path.meta_path.Path.__init__`
-has two mandatory positional arguments that must always be handled and passed
-to the parent class for initialization. They represent the last time when a
-command was sent by the :ref:`Generator` Block, and the last sent value. In
-addition to these two mandatory arguments, users can define as many other
-arguments as needed. Note that these two arguments are used for defining the
-:py:`t0` and :py:`last_cmd` attributes. that have the same values as
-:py:`_last_time` and :py:`_last_cmd` but can be accessed from anywhere in the
-Path.
+should initialize the parent class. It can also accept arguments, that will
+correspond to the keys and values given in the :obj:`dict` passed to the
+:ref:`Generator` Block. Note that in addition to these arguments, the value of
+the last command sent by the Generator and the moment when it was sent are
+accessible through the :py:`self.t0` and :py:`self.last_cmd` attributes.
 
 The :meth:`~crappy.blocks.generator_path.meta_path.Path.get_cmd` method is for
 generating the next command for the Generator to send. It must return the next
@@ -97,15 +94,14 @@ either fixed or controlled by the value of an input label :
 
 .. literalinclude:: /downloads/complex_custom_objects/custom_path.py
    :language: python
-   :emphasize-lines: 20, 37, 42-43, 51, 54-55
+   :emphasize-lines: 35, 40-41, 49, 52-53
 
 .. Note::
    To run this example, you'll need to have the *matplotlib* and *scipy* Python
    modules installed.
 
 This example contains all the ingredients described above. The parent class is
-initialized with the two mandatory arguments, then the :py:`condition` argument
-is parsed with
+initialized, then the :py:`condition` argument is parsed with
 :meth:`~crappy.blocks.generator_path.meta_path.Path.parse_condition`. In
 :meth:`~crappy.blocks.generator_path.meta_path.Path.get_cmd`, the given
 condition is checked based on the latest received data from upstream Blocks,

--- a/examples/blocks/generator/generator_feedback_loop.py
+++ b/examples/blocks/generator/generator_feedback_loop.py
@@ -15,7 +15,7 @@ here the stop condition of the Generator path depends on the value of a label,
 whereas in the basic example a delay is given instead.
 
 After starting this script, you can visualize the shape of the generated signal
-in the Grapher window. This script ends after 32s. You can also hit CTRL+C to
+in the Grapher window. This script ends after 62s. You can also hit CTRL+C to
 stop it earlier, but it is not a clean way to stop Crappy. You can then restart
 it with different parameters for the Generator path.
 """

--- a/examples/custom_objects/custom_generator_path.py
+++ b/examples/custom_objects/custom_generator_path.py
@@ -41,8 +41,6 @@ class CustomPath(Path):
   """
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                amplitude: float,
                freq: float,
                power: int,
@@ -55,10 +53,6 @@ class CustomPath(Path):
     where the arguments are passed to the Path by the Generator Block.
 
     Args:
-      _last_time: This argument is for internal use only, it must always be
-        present but should not be modified.
-      _last_cmd: This argument is for internal use only, it must always be
-        present but should not be modified.
       amplitude: The peak to peak amplitude of the sine wave.
       freq: The frequency of the sine wave in Hz.
       power: The power to elevate the sine wave to, as an integer.
@@ -67,9 +61,7 @@ class CustomPath(Path):
     """
 
     # Mandatory line usually at the very beginning of the __init__ method
-    # The parent class takes the _last_time and _last_cmd parameters as
-    # arguments, they are mandatory to give
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
     # The parse_condition method allows to parse a condition given as a string
     # or as a callable or None, and returns a callable that can be used later

--- a/src/crappy/blocks/generator.py
+++ b/src/crappy/blocks/generator.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import logging
 
 from .meta_block import Block
-from .generator_path.meta_path import paths_dict
+from .generator_path.meta_path import paths_dict, Path
 from .._global import GeneratorStop
 
 
@@ -206,10 +206,9 @@ class Generator(Block):
     path_name = next_path_dict.pop('type')
     self._check_path_exists(path_name)
     path_type = paths_dict[path_name]
-    self._current_path = path_type(
-      _last_time=self._last_t if self._last_t is not None else self.t0,
-      _last_cmd=self._last_cmd,
-      **next_path_dict)
+    Path.t0 = self._last_t if self._last_t is not None else self.t0
+    Path.last_cmd = self._last_cmd
+    self._current_path = path_type(**next_path_dict)
 
   def _check_path_validity(self, path: Iterator[Dict[str, Any]]) -> None:
     """Simply instantiates all the Paths in a row to check no error is
@@ -219,8 +218,10 @@ class Generator(Block):
       next_dict = deepcopy(next_dict)
       path_name = next_dict.pop('type')
       self._check_path_exists(path_name)
+      Path.t0 = 0
+      Path.last_cmd = None if i == 0 else 0
       path_type = paths_dict[path_name]
-      path_type(_last_time=0, _last_cmd=None if i == 0 else 0, **next_dict)
+      path_type(**next_dict)
 
   @staticmethod
   def _check_path_exists(name: str) -> None:

--- a/src/crappy/blocks/generator_path/conditional.py
+++ b/src/crappy/blocks/generator_path/conditional.py
@@ -16,8 +16,6 @@ class Conditional(Path):
   """
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                condition1: Union[str, ConditionType],
                condition2: Union[str, ConditionType],
                value1: float,
@@ -26,10 +24,6 @@ class Conditional(Path):
     """Sets the args and initializes the parent class.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       condition1: The first condition checked by the Path. Refer to
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
@@ -46,7 +40,7 @@ class Conditional(Path):
       This Generator Path never ends, it doesn't have a stop condition.
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
     # Setting the attributes
     self._value0 = value0

--- a/src/crappy/blocks/generator_path/constant.py
+++ b/src/crappy/blocks/generator_path/constant.py
@@ -11,31 +11,25 @@ class Constant(Path):
   condition is met."""
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                condition: Union[str, ConditionType],
                value: float = None) -> None:
     """Sets the args and initializes the parent class.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       condition: The condition for switching to the next Path. Refer to
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
       value: The value to output.
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
     self._condition = self.parse_condition(condition)
 
-    if value is None and _last_cmd is None:
+    if value is None and self.last_cmd is None:
       raise ValueError('For the first path, a value must be given !')
 
-    self._value = _last_cmd if value is None else value
+    self._value = self.last_cmd if value is None else value
 
   def get_cmd(self, data: Dict[str, list]) -> float:
     """Returns the value to send or raises :exc:`StopIteration` if the stop

--- a/src/crappy/blocks/generator_path/custom.py
+++ b/src/crappy/blocks/generator_path/custom.py
@@ -17,8 +17,6 @@ class Custom(Path):
   """
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                file_name: Union[str, pathlib.Path],
                delimiter: str = ',') -> None:
     """Loads the file and sets the arguments.
@@ -27,10 +25,6 @@ class Custom(Path):
     file.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       file_name: Path to the file containing the information on the Generator
         Path. Can be either a :obj:`str` or a :obj:`pathlib.Path`. The file
         must contain two columns: the first one containing timestamps (starting
@@ -38,7 +32,7 @@ class Custom(Path):
       delimiter: The delimiter between columns in the file, usually a coma.
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
     self.log(logging.DEBUG, f"Extracting data from file {file_name}")
     array = loadtxt(pathlib.Path(file_name), delimiter=delimiter)
@@ -61,4 +55,4 @@ class Custom(Path):
     if t - self.t0 > self._timestamps[-1]:
       self.log(logging.DEBUG, "Stop condition met")
       raise StopIteration
-    return interp(t - self.t0, self._timestamps, self._values)
+    return float(interp(t - self.t0, self._timestamps, self._values))

--- a/src/crappy/blocks/generator_path/cyclic.py
+++ b/src/crappy/blocks/generator_path/cyclic.py
@@ -18,8 +18,6 @@ class Cyclic(Path):
   """
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                condition1: Union[str, ConditionType],
                condition2: Union[str, ConditionType],
                value1: float,
@@ -30,10 +28,6 @@ class Cyclic(Path):
     The Path always starts with ``value1``, and then switches to ``value2``.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       condition1: The condition for switching to ``value2``. Refer to
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
@@ -58,7 +52,7 @@ class Cyclic(Path):
         {'type': 'Constant', 'value': 0, 'condition': 'AIN1<1'}] * 5
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
     # Creates an interator object with a given length
     if cycles > 0:

--- a/src/crappy/blocks/generator_path/cyclic_ramp.py
+++ b/src/crappy/blocks/generator_path/cyclic_ramp.py
@@ -17,8 +17,6 @@ class CyclicRamp(Path):
   """
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                condition1: Union[str, ConditionType],
                condition2: Union[str, ConditionType],
                speed1: float,
@@ -30,10 +28,6 @@ class CyclicRamp(Path):
     The path always starts with ``speed1``, and then switches to ``speed2``.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       condition1: The condition for switching to ``speed2``. Refer to
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
@@ -61,9 +55,9 @@ class CyclicRamp(Path):
         {'type': 'Ramp', 'value': -2, 'condition': 'AIN1<1'}] * 5
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
-    if init_value is None and _last_cmd is None:
+    if init_value is None and self.last_cmd is None:
       raise ValueError('For the first path, an init_value must be given !')
 
     # Creates an interator object with a given length
@@ -85,7 +79,7 @@ class CyclicRamp(Path):
     self._speed = None
 
     # The last extreme command sent
-    self._last_peak_cmd = _last_cmd if init_value is None else init_value
+    self._last_peak_cmd = self.last_cmd if init_value is None else init_value
 
   def get_cmd(self, data: Dict[str, list]) -> float:
     """Returns the current value of the signal and raises :exc:`StopIteration`

--- a/src/crappy/blocks/generator_path/integrator.py
+++ b/src/crappy/blocks/generator_path/integrator.py
@@ -19,8 +19,6 @@ class Integrator(Path):
   """
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                condition: Union[str, ConditionType],
                inertia: float,
                func_label: str,
@@ -29,10 +27,6 @@ class Integrator(Path):
     """Sets the arguments and initializes the parent class.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       condition: The condition for switching to the next Path. Refer to
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
@@ -47,9 +41,9 @@ class Integrator(Path):
         given !
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
-    if init_value is None and _last_cmd is None:
+    if init_value is None and self.last_cmd is None:
       raise ValueError('For the first path, an init_value must be given !')
 
     # Setting the attributes
@@ -57,7 +51,7 @@ class Integrator(Path):
     self._time_label = time_label
     self._func_label = func_label
     self._inertia = inertia
-    self._value = _last_cmd if init_value is None else init_value
+    self._value = self.last_cmd if init_value is None else init_value
     self._last_t = None
     self._last_val = None
 

--- a/src/crappy/blocks/generator_path/meta_path/path.py
+++ b/src/crappy/blocks/generator_path/meta_path/path.py
@@ -18,11 +18,10 @@ class Path(metaclass=MetaPath):
   generate signals.
   """
 
-  def __init__(self,
-               _last_time: float,
-               _last_cmd: Optional[float] = None,
-               *_,
-               **__) -> None:
+  t0: Optional[float] = None
+  last_cmd: Optional[float] = None
+
+  def __init__(self, *_, **__) -> None:
     """Here, the arguments given to the Path should be handled.
 
     If the Path accepts one or more conditions, (e.g. stop conditions for
@@ -37,8 +36,6 @@ class Path(metaclass=MetaPath):
     previous :class:`~crappy.blocks.generator_path.meta_path.Path`.
     """
 
-    self.t0 = _last_time
-    self.last_cmd = _last_cmd if _last_cmd is not None else 0
     self._logger: Optional[logging.Logger] = None
 
   def get_cmd(self, data: Dict[str, list]) -> Optional[float]:

--- a/src/crappy/blocks/generator_path/ramp.py
+++ b/src/crappy/blocks/generator_path/ramp.py
@@ -12,18 +12,12 @@ class Ramp(Path):
   is met."""
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                condition: Union[str, ConditionType],
                speed: float,
                init_value: Optional[float] = None):
     """Sets the arguments and initializes the parent class.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       condition: The condition for switching to the next Path. Refer to
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
@@ -33,15 +27,15 @@ class Ramp(Path):
         first one in the Generator Paths, this argument must be given !
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
-    if init_value is None and _last_cmd is None:
+    if init_value is None and self.last_cmd is None:
       raise ValueError('For the first path, an init_value must be given !')
 
     # Setting the attributes
     self._condition = self.parse_condition(condition)
     self._speed = speed
-    self._init_value = init_value if init_value is not None else _last_cmd
+    self._init_value = init_value if init_value is not None else self.last_cmd
 
   def get_cmd(self, data: Dict[str, list]) -> float:
     """Returns the value to send or raises :exc:`StopIteration` if the stop

--- a/src/crappy/blocks/generator_path/sine.py
+++ b/src/crappy/blocks/generator_path/sine.py
@@ -13,8 +13,6 @@ class Sine(Path):
   is met."""
 
   def __init__(self,
-               _last_time: float,
-               _last_cmd: float,
                condition: Union[str, ConditionType],
                freq: float,
                amplitude: float,
@@ -23,10 +21,6 @@ class Sine(Path):
     """Sets the arguments and initializes the parent class.
 
     Args:
-      _last_time: The last timestamp when a command was generated. For internal
-        use only, do not overwrite.
-      _last_cmd: The last sent command. For internal use only, do not
-        overwrite.
       condition: The condition for switching to the next Path. Refer to
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
@@ -36,7 +30,7 @@ class Sine(Path):
       phase: The phase of the sine (in radians).
     """
 
-    super().__init__(_last_time, _last_cmd)
+    super().__init__()
 
     # Setting the attributes
     self._condition = self.parse_condition(condition)


### PR DESCRIPTION
Until now in Crappy, the base `Path` object was requiring the last sent command and its timestamp as arguments.
Any other `Path` subclassing it also needed to take these two values as arguments, and to pass them to the parent class (for example with `super().__init__(last_time, last_cmd)`).

Starting with version `2.0.0`, users can now define their own custom `Path` objects.
With the old architecture, however, they had to define a `_last_cmd` and a `_last_time` argument to their new class, only to provide it as argument to the parent class. 
This is at the same time not elegant, a potential source of bugs, and definitely not intuitive.

Instead, this PR slightly modifies the base `Path` object and the `Generator` Block so that the last command and its timestamp are not needed as arguments anymore.
To do so, they are now set as class attributes of `Path`, and set by the `Generator` Block before instantiating a new `Path` (88bd0ba3).
The distributed Generator Paths, the examples, and the documentation were updated accordingly (respectively e9e6891a, ae501101, ed14e7a0).