### PR TITLE
Update the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,83 +4,87 @@ Command and Real-time Acquisition in Parallelized PYthon (CRAPPY)
 [![Downloads](https://pepy.tech/badge/crappy)](https://pepy.tech/project/crappy)
 [![Documentation Status](https://readthedocs.org/projects/crappy/badge/?version=latest)](https://crappy.readthedocs.io/en/latest/?badge=latest)
 [![PyPi version](https://badgen.net/pypi/v/crappy/)](https://pypi.org/project/crappy)
+[![Python version](https://img.shields.io/pypi/pyversions/crappy.svg)](https://pypi.python.org/pypi/crappy/)
 
-This package aims to provide an open-source software canvas for developing 
-experimental tests in a versatile and accessible way.
+CRAPPY aims to provide a free and open-source software canvas for driving 
+experimental setups in a versatile and accessible way.
 
 Presentation
 ------------
 
+Setups in experimental research tend to get increasingly complex, and require 
+to drive a variety of actuators, sensors, and cameras from various suppliers. 
+However, as researchers are one step ahead of industrials, the commercially 
+available testing solutions are not always well-suited to their objectives. 
+Developing a custom software interface is also not always an option, as the 
+synchronization of the devices and the optimization of the computer resources
+can prove challenging even to experienced developers.
+
+The purpose of CRAPPY is to provide a framework for driving experimental 
+setups, in which even the most complex designs can be controlled in usually 
+less than a hundred lines of code. CRAPPY is:
+
+- A free and open source Python module
+- Written in pure Python, to make it easily understandable and editable by a 
+large audience
+- Highly modular and versatile, and can adapt to almost any setup
+- Distributed with a wide collection of ready-to-run [examples](https://github.com/LaboratoireMecaniqueLille/crappy/examples)
+- Heavily optimized, to make the most of your computer's resources
+- Distributed with a collection of powerful tools for performing real-time data
+and image processing
+
 Crappy is developed at the [LaMCube](https://lamcube.univ-lille.fr/), a
-mechanical research laboratory based in Lille, France to provide a powerful and
-easy-to-use framework for materials testing.
+mechanical research laboratory based in Lille, France, where it is used mainly 
+for materials testing.
 
-In order to understand the mechanical behaviour of materials, we tend to perform
-tests with more and more sensors and actuators from various suppliers. There's
-thus an increasing need to drive these devices in a synchronized way while
-managing the high complexity of the setups.
+Requirements
+------------
 
-As we are one step ahead of industrials, the commercially available testing
-solutions may also not be well-suited to our objectives. Custom software
-solutions thus need to be developed in order to further improve our tests.
+CRAPPY can run with Python 3.7 to 3.10, and has been tested on Windows, Linux, 
+Raspberry Pi and macOS. It can probably run on other operating systems 
+supporting the required Python versions. 
 
-These are the original purposes of Crappy : providing a framework for
-controlling tests and driving hardware in a synchronized and
-supplier-independent software environment.
+CRAPPY has only one requirement: [Numpy](https://numpy.org/) (1.21 or higher).
+In addition, other modules can be necessary depending on which features you 
+want to use. The main ones are [Matplotlib](https://matplotlib.org/),
+[openCV](https://opencv.org/), [pyserial](https://pypi.org/project/pyserial/)
+and [Pillow](https://python-pillow.org/).
+
+Installation
+------------
+
+CRAPPY is distributed on PyPI, and can be installed on the supported operating 
+systems simply by running the following command in a terminal:
+
+    python -m pip install crappy
+
+You'll find more details in the dedicated [installation section](https://crappy.readthedocs.io/en/latest/installation.html) 
+of the documentation, as well as alternative installation methods.
 
 Citing Crappy
 -------------
 
 If Crappy has been of help in your research, please reference it in your 
-academic publications by citing the following article :
+academic publications by citing one or both of the following articles:
 
 - Couty V., Witz J-F., Martel C. et al., *Command and Real-Time Acquisition in 
 Parallelized Python, a Python module for experimental setups*, SoftwareX 16, 
 2021, DOI: 10.1016/j.softx.2021.100848. 
-([publisher link](https://www.sciencedirect.com/science/article/pii/S2352711021001278))
-
-Requirements
-------------
-
-To install Crappy you will need Python 3 (3.6 or higher) with the following 
-modules :
-- [Numpy](https://numpy.org/) (1.19.0 or higher)
-
-In addition, other modules are necessary for a wide range of applications in Crappy 
-without being mandatory for installing the module. The main ones are [Matplotlib](https://matplotlib.org/),
-[openCV](https://opencv.org/), [pyserial](https://pypi.org/project/pyserial/)
-and [Tk](https://docs.python.org/3/library/tkinter.html).
-
-Installation
-------------
-
-Tested on Windows 10, Ubuntu 18.04 and 20.04, and MacOS Sierra.
-Simply run in a terminal (with Python installed) :
-
-    pip install crappy
-
-or
-
-    pip3 install crappy
-
-Refer to the dedicated [installation section](https://crappy.readthedocs.io/en/latest/installation.html) 
-of the documentation for more details.
+([link to Couty et al.](https://www.sciencedirect.com/science/article/pii/S2352711021001278))
+- Weisrock A., Couty V., Witz J-F. et al., *CRAPPY goes embedded: Including 
+low-cost hardware in experimental setups*, SoftwareX 22, 2023, DOI: 
+10.1016/j.softx.2023.101348. 
+([link to Weisrock et al.](https://www.sciencedirect.com/science/article/pii/S2352711023000444))
 
 Documentation
 -------------
 
 The latest versions of the documentation can be accessed on our
-[ReadTheDocs](https://crappy.readthedocs.io/) page. It contains descriptions of
-Crappy's features, tutorials, and other useful information.
+[ReadTheDocs](https://crappy.readthedocs.io/) page. It contains a description 
+of Crappy's features, tutorials, and other useful information.
 
-Bug reports
------------
+License
+-------
 
-Please report bugs, issues, ask for help or give feedback in the [dedicated github section](https://github.com/LaboratoireMecaniqueLille/crappy/issues).
-
-License information
--------------------
-
-Refer to the file [``LICENSE.txt``](https://github.com/LaboratoireMecaniqueLille/crappy/blob/master/LICENSE) 
-for information on the history of this software, terms & conditions for usage, 
-and a disclaimer of all warranties.
+[GNU GPLv2](https://github.com/LaboratoireMecaniqueLille/crappy/blob/master/LICENSE) 
+&copy; 2015, Laboratoire Mécanique de Lille & contributors

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+Documentation
+=============
+
+This folder contains the files necessary for generating the online 
+documentation on ReadTheDocs. It also contains example scripts that are
+included in the documentation.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+Examples
+========
+
+This folder contains examples of use of CRAPPY. Most of them can be run without
+any specific hardware, but some of them require additional Python modules to be
+installed.
+
+- **blocks** contains for each Block in CRAPPY one or several usage examples. 
+It is where you should look if you want to learn how to use a specific Block.
+- **custom_objects** contains examples of instantiation and use of custom
+defined objects in CRAPPY. It is where you should look to learn how to 
+implement your own functionalities and hardware.
+- **fake_tests** contains various examples that use the ``FakeMachine`` Block.
+- **modifiers** contains for each ``Modifier`` object a usage example. It is
+where you should look if you want to learn how to use ``Modifier`` objects.
+- **other_examples** contains examples requiring third-party hardware and 
+therefore not directly runnable by most users.
+- **real_setups_scripts** contains scripts used in real life by researchers at 
+the LaMcube laboratory.

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ from os import popen, walk
 import platform
 from pathlib import Path
 
-# Change long description
-
 # Reading version from __version__.py file
 with open('src/crappy/__version__.py') as file:
   for line in file:
@@ -21,7 +19,7 @@ with open('src/crappy/__version__.py') as file:
       __version__ = line.split("'")[1]
 
 # Get the long description from the relevant file
-long_description = Path('docs/source/what_is_crappy.rst').read_text()
+long_description = Path('README.md').read_text()
 
 # Getting the current version of Python
 py_ver = '.'.join(platform.python_version().split('.')[:2])
@@ -101,7 +99,7 @@ setup(
   version=__version__,
   description='Command and Real-time Acquisition in Parallelized Python',
   long_description=long_description,
-  long_description_content_type='text/x-rst',
+  long_description_content_type='text/markdown',
   keywords='control,command,acquisition,multiprocessing',
   license='GPL V2',
   classifiers=['Development Status :: 4 - Beta ',

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-SOURCES
+Sources
 =======
 
 This folder contains the source files of CRAPPY. **crappy** contains the files

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,7 @@
+SOURCES
+=======
+
+This folder contains the source files of CRAPPY. **crappy** contains the files
+for the Python module, and **ext** contains files for C++ extensions that can 
+be required for some features. The extensions are kept for backwards 
+compatibility only and could be removed in future releases.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+Tests
+=====
+
+This folder contains the test suite that allows checking if CRAPPY runs as 
+expected. The unit tests check the methods and functions individually, and the
+integration tests check if the module performs well at runtime. All tests are
+performed using the ``unittest`` module.
+
+**WARNING** :
+The test suite is currently work in progress, and should be fully functional 
+and used in the coming releases.

--- a/util/README.md
+++ b/util/README.md
@@ -1,0 +1,9 @@
+Utilities
+=========
+
+This folder contains two files that can come in use to CRAPPY's users.
+
+**set_ft232h_serial_nr.py** can set the serial number of an FT232H device
+connected to your computer.
+**udev_rule_setter** is for setting the udev rules on a Linux computer. They 
+can be necessary for using USB devices with CRAPPY.


### PR DESCRIPTION
The README file of the repo hasn't been updated for a while.
It was missing a badge indicating the supported Python versions.

The main README was updated in 1e3e3604.
README files for all the folders at the root of the repo were also created in 91469607, to make it clearer what each directory is intended for.
The README file is also now used as the long description in `setup.py`, instead of `what_is_crappy.rst` (42148afd).