### PR TITLE
Add deprecation errors for objects renamed between v1.5 and v2.0

### DIFF
--- a/src/crappy/actuator/__init__.py
+++ b/src/crappy/actuator/__init__.py
@@ -16,4 +16,5 @@ from .ft232h import DCMotorHatFT232H
 
 from .meta_actuator import MetaActuator, Actuator
 
+from ._deprecated import deprecated_actuators
 actuator_dict: Dict[str, Type[Actuator]] = MetaActuator.classes

--- a/src/crappy/actuator/_deprecated.py
+++ b/src/crappy/actuator/_deprecated.py
@@ -1,0 +1,9 @@
+# coding: utf-8
+
+deprecated_actuators = {'CM_drive': 'SchneiderMDrive23',
+                        'Fake_motor': 'FakeDCMotor',
+                        'Motorkit_pump': 'DCMotorHat',
+                        'Oriental': 'OrientalARDK',
+                        'Pololu_tic': 'PololuTic',
+                        'Servostar': 'ServoStar300',
+                        'Tra6ppd': 'NewportTRA6PPD'}

--- a/src/crappy/blocks/__init__.py
+++ b/src/crappy/blocks/__init__.py
@@ -30,3 +30,7 @@ from .video_extenso import VideoExtenso
 
 from . import generator_path
 from . import camera_processes
+
+from ._deprecated import (AutoDrive, Client_server, Displayer, DISVE, Drawing,
+                          Fake_machine, GUI, Hdf_recorder, Mean_block,
+                          Multiplex, Reader, Video_extenso)

--- a/src/crappy/blocks/_deprecated.py
+++ b/src/crappy/blocks/_deprecated.py
@@ -1,0 +1,205 @@
+# coding: utf-8
+
+from .meta_block import Block
+
+
+class AutoDrive(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to AutoDriveVideoExtenso in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class Client_server(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to ClientServer in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+  
+  
+class Displayer(Block):
+  """Empty class for signaling an object of version 1.5 that wa removed in 
+  version 2.0.O."""
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was removed "
+                              f"in version 2.0.0 ! It is now contained "
+                              f"directly in the Camera Block. "
+                              f"Check the documentation for more information.")
+
+
+class DISVE(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to DICVE in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class Drawing(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to Canvas in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class Fake_machine(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to FakeMachine in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class GUI(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to Button in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+  
+  
+class Hdf_recorder(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to HDFRecorder in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class Mean_block(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to MeanBlock in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class Multiplex(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to Multiplexer in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class Reader(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to LinkReader in version 2.0.0 ! "
+                              f"Check the documentation for more information.")
+
+
+class Video_extenso(Block):
+  """Empty class for signaling an object of version 1.5 whose name changed in
+  version 2.0 and is now deprecated.
+
+  The new name of the correct object to use is given.
+  """
+
+  def __init__(self, *_, **__) -> None:
+    """Simply raises the exception when instantiating the object."""
+
+    super().__init__()
+
+    raise NotImplementedError(f"The {type(self).__name__} Block was renamed "
+                              f"to VideoExtenso in version 2.0.0 ! "
+                              f"Check the documentation for more information.")

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -13,7 +13,7 @@ import logging
 
 from .meta_block import Block
 from .camera_processes import Displayer, ImageSaver, CameraProcess
-from ..camera import camera_dict, Camera as BaseCam
+from ..camera import camera_dict, Camera as BaseCam, deprecated_cameras
 from ..tool.camera_config import CameraConfig
 from .._global import CameraPrepareError, CameraRuntimeError, CameraConfigError
 
@@ -205,6 +205,13 @@ class Camera(Block):
     self.freq = freq
     self.niceness = -10
     self.debug = debug
+
+    # Checking for deprecated names
+    if camera in deprecated_cameras:
+      raise NotImplementedError(
+          f"The {camera} Camera was deprecated in version 2.0.0, and renamed "
+          f"to {deprecated_cameras[camera]} ! Please update your code "
+          f"accordingly and check the documentation for more information")
 
     # Checking if the requested camera exists in Crappy
     if image_generator is None:

--- a/src/crappy/blocks/ioblock.py
+++ b/src/crappy/blocks/ioblock.py
@@ -4,7 +4,7 @@ from typing import Union, Optional, Iterable, Any
 import logging
 
 from .meta_block import Block
-from ..inout import inout_dict, InOut
+from ..inout import inout_dict, InOut, deprecated_inouts
 from ..tool.ft232h import USBServer
 
 
@@ -155,6 +155,13 @@ class IOBlock(Block):
                          "there are in cmd_labels !")
 
     self._trig_label = trigger_label
+
+    # Checking for deprecated names
+    if name in deprecated_inouts:
+      raise NotImplementedError(
+          f"The {name} InOut was deprecated in version 2.0.0, and renamed "
+          f"to {deprecated_inouts[name]} ! Please update your code "
+          f"accordingly and check the documentation for more information")
 
     # Checking that all the given actuators are valid
     if name not in inout_dict:

--- a/src/crappy/blocks/machine.py
+++ b/src/crappy/blocks/machine.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, fields
 import logging
 
 from .meta_block import Block
-from ..actuator import actuator_dict, Actuator
+from ..actuator import actuator_dict, Actuator, deprecated_actuators
 from ..tool.ft232h import USBServer
 
 
@@ -143,6 +143,15 @@ class Machine(Block):
 
     # The list of all the Actuator types to instantiate
     self._types = [actuator['type'] for actuator in actuators]
+
+    # Checking for deprecated names
+    deprecated = [type_ for type_ in self._types
+                  if type_ in deprecated_actuators]
+    for type_ in deprecated:
+      raise NotImplementedError(
+          f"The {type_} Actuator was deprecated in version 2.0.0, and renamed "
+          f"to {deprecated_actuators[type_]} ! Please update your code "
+          f"accordingly and check the documentation for more information")
 
     # Checking that all the given actuators are valid
     if not all(type_ in actuator_dict for type_ in self._types):

--- a/src/crappy/camera/__init__.py
+++ b/src/crappy/camera/__init__.py
@@ -27,4 +27,5 @@ if system() == 'Linux':
 else:
   from .gstreamer_camera_basic import CameraGstreamer
 
+from ._deprecated import deprecated_cameras
 camera_dict: Dict[str, Type[Camera]] = MetaCamera.classes

--- a/src/crappy/camera/_deprecated.py
+++ b/src/crappy/camera/_deprecated.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+
+deprecated_cameras = {'Bispectral': 'BiSpectral',
+                      'Cl_camera': 'BaslerIronmanCameraLink',
+                      'Fake_camera': 'FakeCamera',
+                      'File_reader': 'FileReader',
+                      'Camera_gstreamer': 'CameraGstreamer',
+                      'Jai8': 'JaiGO5000CPMCL8Bits',
+                      'Jai': 'JaiGO5000CPMCL',
+                      'Camera_opencv': 'CameraOpencv',
+                      'Picamera': 'RaspberryPiCamera',
+                      'Seek_thermal_pro': 'SeekThermalPro',
+                      'Xiapi': 'XiAPI'}

--- a/src/crappy/inout/__init__.py
+++ b/src/crappy/inout/__init__.py
@@ -34,4 +34,5 @@ from .ft232h import WaveshareADDAFT232H
 from .meta_inout import InOut, MetaIO
 
 # All the inout objects
+from ._deprecated import deprecated_inouts
 inout_dict: Dict[str, Type[InOut]] = MetaIO.classes

--- a/src/crappy/inout/_deprecated.py
+++ b/src/crappy/inout/_deprecated.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+
+deprecated_inouts = {'Ads1115': 'ADS1115',
+                     'Daqmx': 'DAQmx',
+                     'Fake_inout': 'FakeInOut',
+                     'Gpio_pwm': 'GPIOPWM',
+                     'Gpio_switch': 'GPIOSwitch',
+                     'Gsm': 'Sim868',
+                     'Koll': 'KollmorgenAKDPDMM',
+                     'Labjack_t7': 'LabjackT7',
+                     'Labjack_ue9': 'LabjackUE9',
+                     'Mcp9600': 'MCP9600',
+                     'Mprls': 'MPRLS',
+                     'Nau7802': 'NAU7802',
+                     'Nidaqmx': 'NIDAQmx',
+                     'Opsens': 'HandySens',
+                     'Pijuice': 'PiJuice',
+                     'Spectrum': 'SpectrumM2I4711',
+                     'T7_streamer': 'T7Streamer',
+                     'Waveshare_ad_da': 'WaveshareADDA',
+                     'Waveshare_high_precision': 'WaveshareHighPrecision'}


### PR DESCRIPTION
With the upcoming change of major version to 2.0.0, a number of public classes in the project will be renamed.
In order to provide support for users migrating from version 1.5 to 2.0, the deprecated names of the renamed objects are now nicely handled instead of raising bare Exceptions.
This PR closes #60.

Two different strategies were used.
For Blocks that are directly instantiated by users, empty Blocks with the deprecated names and simply raising an Exception were created (5bf52172). The Exception is raised at `__init__`, before Crappy even starts.
For Camera, InOut and Actuator objects for which the user only provides a name, the Camera, IOBlock and Machine Blocks check if the given name is deprecated (respectively 8a57fb4d, 1d346ea1 and 4e3d4954). If so, an Exception is raised, again at `__init__`.

The new objects instantiated in this PR will be removed after some time, when it can be considered that most users will have migrated to version 2.0.0.