### PR TITLE
Final touch to the documentation after update to 2.0

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,6 +2,8 @@
 API
 ===
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 This section contains the inline documentation of all the objects of the module
 Crappy. In particular, a description is given for each possible argument of the
 classes and methods. The only way to get an even finer understanding of an

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -2,6 +2,8 @@
 Citing Crappy
 ==============
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 If Crappy has been of help in your research, please reference it in your 
 academic publications by citing one or both of the following articles :
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ autodoc_member_order = 'bysource'
 # Including undocumented features
 autodoc_default_options = {'undoc-members': True}
 # The codeauthor and sectionauthor directives do produce output
-show_authors = True
+show_authors = False
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -232,4 +232,8 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+  'python': ('https://docs.python.org/3', None),
+  'numpy': ('https://numpy.org/doc/stable/', None),
+  'matplotlib': ('https://matplotlib.org/stable/', None),
+  'psutil': ('https://psutil.readthedocs.io/en/latest/',  None)}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,8 @@ extensions = [
     'sphinx.ext.duration',
     'sphinx_copybutton',
     'sphinx_tabs.tabs',
-    'sphinx_toolbox.collapse'
+    'sphinx_toolbox.collapse',
+    'sphinx_toolbox.changeset'
 ]
 
 # Tabs settings

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ __version__ = '2.0.0-rc.0'
 # -- Project information -----------------------------------------------------
 
 project = 'Crappy'
-author = 'Antoine Weisrock'
+author = 'LaMcube and contributors'
 copyright = f"{strftime('%Y', gmtime())}, {author}"
 version = match(r'\d+\.\d+', __version__).group()
 release = __version__

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,8 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.duration',
     'sphinx_copybutton',
-    'sphinx_tabs.tabs'
+    'sphinx_tabs.tabs',
+    'sphinx_toolbox.collapse'
 ]
 
 # Tabs settings

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -9,6 +9,8 @@ Developers information
 Contributing to Crappy
 ----------------------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 If you want to help developing Crappy with us, we'll be more than happy to
 welcome you in the community ! Here you'll find some practical information on
 **how Crappy works under the hood, and a few guidelines for contributors**.
@@ -39,6 +41,8 @@ directly committed to.
 
 Technical description of Crappy
 -------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 .. note::
   This is a very simplified overview of how the module actually works. Only the
@@ -247,6 +251,8 @@ the examples.
 
 Detailed runtime sequence of Crappy
 -----------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Crappy's main strength lies in the use of massive parallelization to maximize
 the performance of the module. Unfortunately, this means we had to cope with

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -406,7 +406,8 @@ cases :
 
 - If all the Blocks are not done running at the end of this phase.
 - If an :exc:`Exception` was caught during Crappy's execution.
-- If Crappy was stopped using CTRL+C, resulting in a :exc:`KeyboardInterrupt`.
+- If Crappy was stopped using :kbd:`Control-c`, resulting in a
+  :exc:`KeyboardInterrupt`.
 
 The goal of this exception is to stop the execution of the ``__main__``
 Process, to avoid any more code to be executed in case something went wrong in

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -2,6 +2,8 @@
 Current functionalities
 =======================
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 On this page are listed all the objects currently distributed with Crappy and
 exposed to the users. Information on how to use them can be found in the
 :ref:`Tutorials`, as well as guidelines for creating your own objects. For most
@@ -13,6 +15,8 @@ can click on its name to open the complete documentation given in the
 
 Functionalities (Blocks)
 ------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 The Blocks are the base bricks of Crappy, that fulfill various functions. In
 the tutorials, you can learn more about :ref:`how to use Blocks
@@ -365,6 +369,8 @@ Others
 
 Supported hardware (Cameras, InOuts, Actuators)
 -----------------------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Supported Cameras
 +++++++++++++++++
@@ -809,6 +815,8 @@ LaMcube-specific hardware
 
 On-the-fly data modification (Modifiers)
 ----------------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 - :ref:`Demux`
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,6 +2,8 @@
 Crappy
 ======
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 Crappy is a **Python module** that aims to provide easy-to-use and open-source
 tools for **command and data acquisition on complex experimental setups**. It
 is designed to let users drive most setups in **less than 100 lines of code**.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,6 +9,8 @@ Installation
 Requirements
 ------------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 Crappy was successfully installed and tested on **Linux** (Ubuntu 18.04 and
 higher), **Windows** (8 and higher) and **MacOS** (Sierra and higher). It was
 also successfully installed on **Raspberry Pi** 3B+ and 4B. As a Python module,
@@ -45,6 +47,8 @@ functionalities (this list is not exhaustive) :
 1. Check your Python version
 ----------------------------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 Before installing Crappy, first check that you have **a compatible version of**
 **Python** installed. You can get the current version of Python by running
 :shell:`python --version` in a console. The version should then be displayed,
@@ -67,6 +71,8 @@ are beyond the scope of this documentation.
 2. Deploy a virtual environment (optional)
 ------------------------------------------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 It is **recommended** to install Crappy in a `virtual environment
 <https://docs.python.org/3/library/venv.html>`_, to avoid conflicts with other
 Python packages installed at the user or system level. This step is however not
@@ -84,6 +90,8 @@ console, containing an independent install of Python.
 
 3. Install Crappy
 -----------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Once you have a compatible version of Python installed, and after optionally
 setting up a virtual environment, you're **ready to install Crappy**. A single
@@ -142,6 +150,8 @@ you would need to use along with Crappy. For example :
 
 4. Check your install
 ---------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Once you have installed Crappy, you can **run a few checks** to make sure it
 works fine on your system. First, try to simply import it :

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.24.3
 sphinx_copybutton==0.5.2
 sphinx-tabs==3.4.1
 sphinx-rtd-theme==1.3.0
+sphinx-toolbox==3.5.0

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -2,6 +2,8 @@
 Troubleshooting
 ===============
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 When encountering a problem with Crappy, please **first carefully read the**
 **present documentation**. Most of the difficulties users may face come from an
 incorrect use of Crappy. If you cannot find an answer in the documentation, you

--- a/docs/source/tutorials/complex_custom_objects.rst
+++ b/docs/source/tutorials/complex_custom_objects.rst
@@ -2,6 +2,8 @@
 More about custom objects in Crappy
 ===================================
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 .. role:: py(code)
   :language: python
   :class: highlight
@@ -14,6 +16,8 @@ understanding of the module, or users with a specific need.
 
 1. Custom Generator Paths
 -------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Starting from version 2.0.0, **it is now possible for users to create their**
 **own** :ref:`Generator Paths` ! There are two reasons why this possibility was
@@ -146,6 +150,8 @@ labels).
 2. More about custom InOuts
 ---------------------------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 In addition to what was described in the tutorial section about :ref:`how to
 create custom InOut objects <3. Custom InOuts>`, there is one more minor
 feature that the :ref:`In / Out` possess and that is worth describing in the
@@ -183,6 +189,8 @@ users to override it.
 
 3. More about custom Actuators
 ------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 In the tutorial section about :ref:`how to create custom Actuator objects
 <2. Custom Actuators>`, then entire speed management aspect in :py:`position`
@@ -227,6 +235,8 @@ examples/blocks>`_.
 
 4. More about custom Cameras
 ----------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Because image acquisition is such a complex topic, the
 :class:`~crappy.camera.Camera` object is by far the richest of the classes
@@ -388,6 +398,8 @@ will change in future releases !
 
 5. Custom Camera Blocks
 -----------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 On the previous tutorial page, :ref:`a section <5. Custom Blocks>` was
 dedicated to the instantiation of custom :ref:`Blocks`. Always moving one step
@@ -701,6 +713,8 @@ aspects in future releases.
 
 6. Sharing custom objects and Blocks
 ------------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 You have been through all the tutorials of Crappy and have now become a master
 at creating and using your own objects, and you now **want to share your**

--- a/docs/source/tutorials/complex_custom_objects.rst
+++ b/docs/source/tutorials/complex_custom_objects.rst
@@ -92,9 +92,13 @@ clearer how to create a custom Generator Path and how to handle the
 conditions. This example generates a square wave, whose duty cycle can be
 either fixed or controlled by the value of an input label :
 
-.. literalinclude:: /downloads/complex_custom_objects/custom_path.py
-   :language: python
-   :emphasize-lines: 35, 40-41, 49, 52-53
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/complex_custom_objects/custom_path.py
+      :language: python
+      :emphasize-lines: 35, 40-41, 49, 52-53
+
+|
 
 .. Note::
    To run this example, you'll need to have the :mod:`matplotlib` and *scipy*
@@ -672,8 +676,12 @@ that is the final object called by the user in its script. Based on these
 development, here is a final runnable code performing eye detection and adding
 the detected eyes on the displayed images :
 
-.. literalinclude:: /downloads/complex_custom_objects/custom_camera_block.py
-   :language: python
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/complex_custom_objects/custom_camera_block.py
+      :language: python
+
+|
 
 .. Note::
    To run this example, you'll need to have the *opencv-python* and *Pillow*

--- a/docs/source/tutorials/complex_custom_objects.rst
+++ b/docs/source/tutorials/complex_custom_objects.rst
@@ -97,8 +97,8 @@ either fixed or controlled by the value of an input label :
    :emphasize-lines: 35, 40-41, 49, 52-53
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* and *scipy* Python
-   modules installed.
+   To run this example, you'll need to have the :mod:`matplotlib` and *scipy*
+   Python modules installed.
 
 This example contains all the ingredients described above. The parent class is
 initialized, then the :py:`condition` argument is parsed with

--- a/docs/source/tutorials/custom_objects.rst
+++ b/docs/source/tutorials/custom_objects.rst
@@ -2,6 +2,8 @@
 Creating and using custom objects in Crappy
 ===========================================
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 .. role:: py(code)
   :language: python
   :class: highlight
@@ -18,6 +20,8 @@ custom object instantiation.
 
 1. Custom Modifiers
 -------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 The first type of custom objects that we'll cover here are the
 :ref:`Modifiers`, because they are by far the simplest objects ! **The**
@@ -144,6 +148,8 @@ custom Modifiers ! They stand after all among the simplest objects in Crappy.
 
 2. Custom Actuators
 -------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 After introducing how custom Modifiers work in the first section, this second
 section will focus on the use of custom :ref:`Actuators`. Knowing how to add
@@ -314,6 +320,8 @@ see how the implementation of real-life Actuators looks like.
 
 3. Custom InOuts
 ----------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Creating custom :ref:`In / Out` objects is extremely similar to creating custom
 :ref:`Actuators`, so make sure to first read and understand the previous
@@ -543,6 +551,8 @@ and in the `InOuts distributed with Crappy
 4. Custom Cameras
 -----------------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 Now that you're getting familiar with the instantiation of custom objects in
 Crappy, adding your own :ref:`Cameras` to Crappy should not present any
 particular difficulty. **The camera management is one of the big strengths of**
@@ -713,6 +723,8 @@ how they are implemented.
 
 5. Custom Blocks
 ----------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 For the last section of this tutorial page, we are going to **cover the most**
 **difficult but also most interesting and powerful object that you can**

--- a/docs/source/tutorials/custom_objects.rst
+++ b/docs/source/tutorials/custom_objects.rst
@@ -51,7 +51,7 @@ modified dictionary in the function !
    :lines: 1-3, 5-12, 32-41, 43-45, 47-48
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 In this first example, you can see that instead of replacing the value of the
@@ -107,7 +107,7 @@ Integrate Modifier :
    :lines: 1-6, 13-39, 42-44, 46-48
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 As you can see, compared to the template, several features have been added.
@@ -286,7 +286,7 @@ context to make it run :
    :language: python
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 You can :download:`download this custom Actuator example
@@ -389,7 +389,7 @@ new stored values. Let's now integrate the InOut into a runnable code :
    :language: python
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 In order to obtain two commands from a single :ref:`Generator`, a
@@ -497,7 +497,7 @@ the previous sub-section :
    :emphasize-lines: 5, 25-35, 52, 54-55, 61-62
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 The first difference is that the module :mod:`numpy` must be used, but that is
@@ -649,8 +649,8 @@ management :
    :lines: 1-12, 21-97
 
 .. Note::
-   To run this example, you'll need to have the *opencv-python*, *matplotlib*
-   and *Pillow* Python modules installed.
+   To run this example, you'll need to have the *opencv-python*,
+   :mod:`matplotlib` and *Pillow* Python modules installed.
 
 After the changes, notice that the :meth:`~crappy.camera.Camera.get_image`
 method remains unchanged. The values of the settings, that were previously
@@ -792,7 +792,7 @@ tutorial ! Here is the full code :
    :emphasize-lines: 13-22, 46, 97, 127
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 In this Block, only the :meth:`~crappy.blocks.Block.begin` method is not

--- a/docs/source/tutorials/custom_objects.rst
+++ b/docs/source/tutorials/custom_objects.rst
@@ -120,8 +120,12 @@ consecutive calls is exactly what was desired when using classes as Modifiers !
 The two examples presented in this section can finally be merged into a single
 big one :
 
-.. literalinclude:: /downloads/custom_objects/custom_modifier.py
-   :language: python
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_modifier.py
+      :language: python
+
+|
 
 You can :download:`download this custom Modifier example
 </downloads/custom_objects/custom_modifier.py>` to run it locally on your
@@ -282,8 +286,12 @@ the current one, as well as the :py:`get_position` method since the position
 is also measurable. Now that the Actuator is defined, it is time to add some
 context to make it run :
 
-.. literalinclude:: /downloads/custom_objects/custom_actuator.py
-   :language: python
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_actuator.py
+      :language: python
+
+|
 
 .. Note::
    To run this example, you'll need to have the :mod:`matplotlib` Python module
@@ -385,8 +393,12 @@ called, it simply returns these two values as well as a timestamp. When,
 :py:`set_cmd` is called, it expects two arguments and sets their values as the
 new stored values. Let's now integrate the InOut into a runnable code :
 
-.. literalinclude:: /downloads/custom_objects/custom_inout.py
-   :language: python
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_inout.py
+      :language: python
+
+|
 
 .. Note::
    To run this example, you'll need to have the :mod:`matplotlib` Python module
@@ -492,9 +504,13 @@ you. A short example should help you understand it, it's not as difficult as it
 first seems ! The following example is the continuation of the one presented in
 the previous sub-section :
 
-.. literalinclude:: /downloads/custom_objects/custom_inout_streamer.py
-   :language: python
-   :emphasize-lines: 5, 25-35, 52, 54-55, 61-62
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_inout_streamer.py
+      :language: python
+      :emphasize-lines: 5, 25-35, 52, 54-55, 61-62
+
+|
 
 .. Note::
    To run this example, you'll need to have the :mod:`matplotlib` Python module
@@ -597,10 +613,14 @@ should look like in an actual script, inspired from an `example available on
 GitHub <https://github.com/LaboratoireMecaniqueLille/crappy/examples/
 custom_objects>`_ :
 
-.. literalinclude:: /downloads/custom_objects/custom_camera.py
-   :language: python
-   :emphasize-lines: 8-41
-   :lines: 1-17, 52-76, 86-97
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_camera.py
+      :language: python
+      :emphasize-lines: 8-41
+      :lines: 1-17, 52-76, 86-97
+
+|
 
 In this first example, the Camera object generates a random image with several
 settings that can be adjusted in the :meth:`~crappy.camera.Camera.__init__`
@@ -643,10 +663,14 @@ internally like any other attribute. Every setting can be accessed by calling
 spaces. Let's now modify the first example to include a better setting
 management :
 
-.. literalinclude:: /downloads/custom_objects/custom_camera.py
-   :language: python
-   :emphasize-lines: 13, 15-42, 69-71, 73-75
-   :lines: 1-12, 21-97
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_camera.py
+      :language: python
+      :emphasize-lines: 13, 15-42, 69-71, 73-75
+      :lines: 1-12, 21-97
+
+|
 
 .. Note::
    To run this example, you'll need to have the *opencv-python*,
@@ -787,9 +811,13 @@ provides this functionality using MQTT. The demo Block is really not advanced
 enough to be distributed with Crappy, but it will do just fine for this
 tutorial ! Here is the full code :
 
-.. literalinclude:: /downloads/custom_objects/custom_block.py
-   :language: python
-   :emphasize-lines: 13-22, 46, 97, 127
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_block.py
+      :language: python
+      :emphasize-lines: 13-22, 46, 97, 127
+
+|
 
 .. Note::
    To run this example, you'll need to have the :mod:`matplotlib` Python module
@@ -908,10 +936,14 @@ meaning :
 In the presented example, you may have recognized a few of the presented
 attributes. They are highlighted here for convenience :
 
-.. literalinclude:: /downloads/custom_objects/custom_block.py
-   :language: python
-   :emphasize-lines: 27-29, 49, 74
-   :lines: 1-96
+.. collapse:: (Expand to see the full code)
+
+   .. literalinclude:: /downloads/custom_objects/custom_block.py
+      :language: python
+      :emphasize-lines: 27-29, 49, 74
+      :lines: 1-96
+
+|
 
 There is not much more to say about the available attributes of the Block that
 you can use, you'll see for yourself which ones you need and which ones you

--- a/docs/source/tutorials/custom_objects.rst
+++ b/docs/source/tutorials/custom_objects.rst
@@ -770,8 +770,8 @@ used :
   short timeout (at most a few seconds), and do not use infinite loops that
   could never end. That is because in the smooth termination scenarios, the
   Blocks are only told to terminate once their current method call returns.
-  Otherwise, you'll have to use CTRL+C to stop your script, which is now
-  considered an invalid way to stop Crappy.
+  Otherwise, you'll have to use :kbd:`Control-c` to stop your script, which is
+  now considered an invalid way to stop Crappy.
 
 Now that the possible methods have been described, it is time to put them into
 application in an example. However, as the Block object is quite complex, such

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -2,6 +2,8 @@
 Getting started : writing scripts in Crappy
 ===========================================
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 .. role:: py(code)
   :language: python
   :class: highlight
@@ -12,6 +14,8 @@ level in Python is required, don't worry !
 
 0. General concepts
 -------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 This first section of the tutorials introduces the very basic concepts of
 Crappy. No code is involved for now, it only describes the general way data can
@@ -53,6 +57,8 @@ Block 3 that's using it !
 
 1. Understanding Crappy's syntax
 --------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 In this second part of the tutorials, we're going to **write step-by-step an**
 **actual script for Crappy** that you can run locally on your machine ! All the
@@ -188,6 +194,8 @@ there's still much more to learn in the following sections !
 
 2. The most used Blocks
 -----------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 In this third section, you will **learn how to handle the most used Blocks of**
 **Crappy**. These Blocks are all essential, and you'll come across at least one
@@ -508,6 +516,8 @@ found in the `examples folder on GitHub
 
 3. Properly stopping a script
 -----------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 In the previous sections, several different ways to stop a script in Crappy
 have been presented. In this section, **you will learn about the best**

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -175,10 +175,10 @@ the same level as the script that was just started. It contains the data being
 acquired by the Recorder Block. As mentioned earlier, the execution of the
 script will stop after 40s as specified to the Generator Block. The script can
 also stop earlier if an error occurs (e.g. missing dependency), or if the user
-hits CTRL+C. Note that this last way of ending a script should only be used in
-case something goes wrong, e.g. if the script crashes. You can find more about
-the different ways to stop a script in Crappy in :ref:`a later section <3.
-Properly stopping a script>`.
+hits :kbd:`Control-c`. Note that this last way of ending a script should only
+be used in case something goes wrong, e.g. if the script crashes. You can find
+more about the different ways to stop a script in Crappy in :ref:`a later
+section <3. Properly stopping a script>`.
 
 **You now know learned the very basics of writing scripts for Crappy** ! You
 can :download:`download this first example
@@ -278,10 +278,10 @@ The script should run in the exact same way as the one of the previous section,
 except this time there should be two cycles of stretching and relaxation before
 the final step of stretching until failure. **That reflects the changes we**
 **made to the path of the Generator Block**. Just like previously, the script
-will stop by itself. You can stop it earlier with CTRL+C, but this is not
-considered as a clean way to stop Crappy. :download:`Download this Generator
-example </downloads/getting_started/tuto_generator.py>` to run it locally on
-your machine !
+will stop by itself. You can stop it earlier with :kbd:`Control-c`, but this is
+not considered as a clean way to stop Crappy. :download:`Download this
+Generator example </downloads/getting_started/tuto_generator.py>` to run it
+locally on your machine !
 
 **You should now be able to build an run a variety of patterns for your**
 **Generator Blocks** ! It is after all just a matter of reading the API,
@@ -336,9 +336,9 @@ lines. In particular, unlike the :ref:`Generator` Block, the Camera does not
 automatically stop after a condition is met. To allow the script to stop in a
 proper way, a :ref:`Stop Button` Block should be added. It will display a
 button, that will stop the execution of the script when clicked upon. It is
-always possible to stop Crappy using CTRL+C, but this is not considered a
-proper way of ending the script. After inserting the stop button, here's the
-final runnable script :
+always possible to stop Crappy using :kbd:`Control-c`, but this is not
+considered a proper way of ending the script. After inserting the stop button,
+here's the final runnable script :
 
 .. literalinclude:: /downloads/getting_started/tuto_camera.py
    :language: python
@@ -527,16 +527,17 @@ So, what should you *not* do to stop a script ? Obviously, you should **avoid**
 extreme solutions for the (very unlikely) situations when Crappy would become
 totally unresponsive...
 
-Starting from version 2.0.0, hitting CTRL+C to stop Crappy (i.e. raising
-:exc:`KeyboardInterrupt`) is also considered as an invalid behavior.
-**However**, unlike more aggressive methods, CTRL+C is still handled internally
-and **should lead to a proper termination of the Blocks**. As it might lead to
-unexpected behavior, and to deter users from using it, we chose to have CTRL+C
-raise an Exception once all the Blocks are correctly stopped. This behavior can
-be tuned, see the :ref:`7. Advanced control over the runtime` section of the
-tutorials. The take-home message about CTRL+C is : **using CTRL+C to stop a**
-**script is fine in most cases but it is preferable to do otherwise, so it**
-**will by default raise an error even if everything went fine** !
+Starting from version 2.0.0, hitting :kbd:`Control-c` to stop Crappy (i.e.
+raising :exc:`KeyboardInterrupt`) is also considered as an invalid behavior.
+**However**, unlike more aggressive methods, :kbd:`Control-c` is still handled
+internally and **should lead to a proper termination of the Blocks**. As it
+might lead to unexpected behavior, and to deter users from using it, we chose
+to have :kbd:`Control-c` raise an Exception once all the Blocks are correctly
+stopped. This behavior can be tuned, see the :ref:`7. Advanced control over the
+runtime` section of the tutorials. The take-home message about :kbd:`Control-c`
+is : **using :kbd:`Control-c` to stop a script is fine in most cases but it**
+**is preferable to do otherwise, so it will by default raise an error even if**
+**everything went fine** !
 
 Now that we know what are the forbidden and not recommended ways of stopping
 Crappy, let's review the 100% approved ones ! As you should have noticed in the
@@ -554,9 +555,9 @@ is also an option.
 .. Note::
    A test in Crappy will also end if an unexpected Exception is raised anywhere
    in the module. In that case, all Blocks will instantly stop and, just like
-   with CTRL+C, an error will be raised once all the Blocks are stopped. The
-   unexpected Exception will still be handled and all Blocks should terminate
-   properly if the problem is not too serious.
+   with :kbd:`Control-c`, an error will be raised once all the Blocks are
+   stopped. The unexpected Exception will still be handled and all Blocks
+   should terminate properly if the problem is not too serious.
 
 When writing a script, first determine which termination way seems more
 appropriate. **If you want to be able to stop the test anytime, opt for the**

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -59,7 +59,7 @@ In this second part of the tutorials, we're going to **write step-by-step an**
 following tutorials will also follow the same principle. If a script would not
 work as expected, please signal it to the developers (see the
 :ref:`Troubleshooting` page). Note that this first example script requires the
-`matplotlib <https://matplotlib.org/>`_ Python module to run.
+:mod:`matplotlib` Python module to run.
 
 The first thing to do when writing a script for Crappy is to open a new *.py*
 file. In this new file, you should start by **importing the module Crappy** :
@@ -211,7 +211,7 @@ let's take a closer look at it :
    :lines: 1-11
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 As you can see, the first argument of the Generator is its *path*. It describes
@@ -309,8 +309,8 @@ looks like :
    :lines: 1-13
 
 .. Note::
-   To run this example, you'll need to have the *opencv-python*, *matplotlib*
-   and *Pillow* Python modules installed.
+   To run this example, you'll need to have the *opencv-python*,
+   :mod:`matplotlib` and *Pillow* Python modules installed.
 
 The first given argument is the name of the :class:`~crappy.camera.Camera` to
 use for acquiring the images. In this demo, the :ref:`Fake Camera` is used so
@@ -416,8 +416,8 @@ device. Here's an example of code featuring an IOBlock for data acquisition :
    :lines: 1-6, 15, 17-23, 25-27
 
 .. Note::
-   To run this example, you'll need to have the *psutil* and *matplotlib*
-   Python modules installed.
+   To run this example, you'll need to have the :mod:`psutil` and
+   :mod:`matplotlib` Python modules installed.
 
 As you can see, the base syntax is quite simple for acquiring data with an
 IOBlock. You first have to specify the :class:`~crappy.inout.InOut` that you

--- a/docs/source/tutorials/more_complexity.rst
+++ b/docs/source/tutorials/more_complexity.rst
@@ -2,6 +2,8 @@
 Towards more complexity
 =======================
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 .. role:: py(code)
   :language: python
   :class: highlight
@@ -14,6 +16,8 @@ complexity. So, make sure to read this page until the end !
 
 1. Using feedback loops
 -----------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 In the previous tutorials page, we only used linear data flow patterns. Here,
 we're going to **introduce the concept of feedback loops in a script**. The
@@ -70,6 +74,8 @@ how the PID will react.
 
 2. Using Modifiers
 ------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 One of Crappy's most powerful features is the possibility to **use**
 :ref:`Modifiers` **to alter the data flowing through the** :ref:`Links`. The
@@ -129,6 +135,8 @@ your machine. The Modifiers distributed with Crappy are also showcased in the
 
 3. Advanced Generator condition
 -------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 In :ref:`a previous section <2.a. The Generator Block and its Paths>`, the
 :ref:`Generator` Block and its :ref:`Generator Paths` were introduced. In that
@@ -193,6 +201,8 @@ the Generator, you are now ready to use this block to its full extent !
 
 4. Dealing with streams
 -----------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 In :ref:`the tutorial section dedicated to IOBlocks <2.e. The IOBlock Block>`,
 only the regular usage mode of the :ref:`IOBlock` was presented. In this mode,
@@ -259,6 +269,8 @@ if you would have trouble using it !
 
 5. Writing scripts efficiently
 ------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Because Crappy requires script with a specific syntax to run, users may forget
 that they can still make use of Python's great flexibility and tools even
@@ -376,6 +388,8 @@ Using :mod:`pathlib`, write instead :
 6. Using Crappy objects outside of a Crappy test
 ------------------------------------------------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 In the new section of the tutorial, let's see how you can use the classes
 distributed with Crappy to interact freely with hardware outside the context of
 a Crappy test (i.e. without calling :ref:`crappy.start()` or an equivalent
@@ -436,6 +450,8 @@ used here because it is more visual.
 
 7. Advanced control over the runtime
 ------------------------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 For the last section of this tutorial page, let's see how you can achieve a
 finer-grained control over Crappy's runtime. **There are two ways to control**

--- a/docs/source/tutorials/more_complexity.rst
+++ b/docs/source/tutorials/more_complexity.rst
@@ -515,12 +515,12 @@ Finally, the :py:`'no_raise'` argument is a :obj:`bool` that allows to disable
 the exceptions raised at the end of a script. The default behavior of Crappy is
 to raise an exception when it stops, if either an unexpected error was raised
 during its execution or if a :exc:`KeyboardInterrupt` was caught (script
-stopped using CTRL+C). The purpose of this behavior is to prevent the execution
-of any line of code that would come after :meth:`crappy.start()`, since it
-might not be safe to run it after Crappy has failed or the user interrupted the
-test. By setting :py:`'no_raise'` to :obj:`True`, the exceptions are disabled
-and Python goes on after Crappy finishes, even if it crashed. **Use this**
-**feature with caution, as it can lead to unexpected or even unsafe**
-**behavior** ! This argument can be changed by users who would prefer to use
-CTRL+C to stop tests but don't want exceptions to be raised, although we
-discourage using this strategy.
+stopped using :kbd:`Control-c`). The purpose of this behavior is to prevent the
+execution of any line of code that would come after :meth:`crappy.start()`,
+since it might not be safe to run it after Crappy has failed or the user
+interrupted the test. By setting :py:`'no_raise'` to :obj:`True`, the
+exceptions are disabled and Python goes on after Crappy finishes, even if it
+crashed. **Use this feature with caution, as it can lead to unexpected or**
+**even unsafe behavior** ! This argument can be changed by users who would
+prefer to use :kbd:`Control-c` to stop tests but don't want exceptions to be
+raised, although we discourage using this strategy.

--- a/docs/source/tutorials/more_complexity.rst
+++ b/docs/source/tutorials/more_complexity.rst
@@ -55,7 +55,7 @@ Block together consistently :
    :emphasize-lines: 39-40, 42, 44-45
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 Can you see it ? We have both :py:`crappy.link(mot, pid)` and
@@ -103,7 +103,7 @@ Machine Block and pointing towards a new :ref:`Grapher` for the position :
    :emphasize-lines: 39, 49-51
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 As you can see, the Modifiers are expected to be given to the :py:`'modifier'`
@@ -177,7 +177,7 @@ breaks, no matter the elongation speed. The code is as follows :
    :emphasize-lines: 9, 26
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* Python module
+   To run this example, you'll need to have the :mod:`matplotlib` Python module
    installed.
 
 You can :download:`download this advanced Generator example
@@ -236,8 +236,8 @@ them together :
    :emphasize-lines: 20-24
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* and *psutil*
-   Python modules installed.
+   To run this example, you'll need to have the :mod:`matplotlib` and
+   :mod:`psutil` Python modules installed.
 
 Compared to the regular IOBlock usage, this is when things get a bit more
 complicated ! As the IOBlock and HDFRecorder are both meant to handle stream
@@ -423,7 +423,7 @@ This is not very interesting to watch, let's add some visualization :
    :emphasize-lines: 4, 12-13
 
 .. Note::
-   To run this example, you'll need to have the *matplotlib* and
+   To run this example, you'll need to have the :mod:`matplotlib` and
    *opencv-python* Python modules installed.
 
 You can :download:`download this FakeCamera example

--- a/docs/source/what_is_crappy.rst
+++ b/docs/source/what_is_crappy.rst
@@ -10,6 +10,8 @@ What is Crappy ?
 Overview
 --------
 
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
+
 CRAPPY is an acronym and stands for **C**\ommand and **R**\eal-time
 **A**\cquisition in **P**\arallelized **PY**\thon.
 
@@ -30,6 +32,8 @@ requires to run experimental tests.
 
 Key features of Crappy
 ----------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 - **open-source** :
   It is natural for us to make our work available to anyone, and to keep it
@@ -59,6 +63,8 @@ Key features of Crappy
 
 Is Crappy for me ?
 ------------------
+
+.. sectionauthor:: Antoine Weisrock <antoine.weisrock@gmail.com>
 
 Crappy is **the right solution** for you if :
 

--- a/src/crappy/__init__.py
+++ b/src/crappy/__init__.py
@@ -46,6 +46,9 @@ def docs():
   """Opens the online documentation of Crappy.
 
   It opens the latest version, and of course requires an internet access.
+  
+  .. versionadded:: 1.5.5
+  .. versionchanged:: 2.0.0 renamed from doc to docs
   """
 
   open('https://crappy.readthedocs.io/en/latest/')
@@ -58,6 +61,8 @@ class resources:
 
   These aliases are then used in the examples provided on the GitHub
   repository, but could also be used in custom user scripts.
+
+  .. versionadded:: 1.5.3
   """
 
   try:

--- a/src/crappy/_global.py
+++ b/src/crappy/_global.py
@@ -8,6 +8,8 @@ class OptionalModule:
   """Placeholder for optional dependencies that are not installed.
 
   Will display a message and raise an error when trying to use them.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -23,8 +25,10 @@ class OptionalModule:
         missing (as a :obj:`str`). If not provided, a generic message will be
         displayed.
       lazy_import: If :obj:`True`, the module won't be imported directly even
-        if it is installed. In stead, it will be imported only when necessary.
+        if it is installed. Instead, it will be imported only when necessary.
         Allows reducing the import time, especially on Window.
+    
+    .. versionadded:: 2.0.0 *lazy_import* argument
     """
 
     self._name = module_name

--- a/src/crappy/actuator/adafruit_dc_motor_hat.py
+++ b/src/crappy/actuator/adafruit_dc_motor_hat.py
@@ -62,6 +62,8 @@ class DCMotorHat(Actuator):
   Note:
     The DC Motor Hat can also drive stepper motors, but this feature isn't
     included here.
+  
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/actuator/fake_dc_motor.py
+++ b/src/crappy/actuator/fake_dc_motor.py
@@ -10,6 +10,9 @@ class FakeDCMotor(Actuator):
   voltage.
 
   It is mainly intended for testing scripts without requiring any hardware.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 Renamed from Fake_motor to FakeDCMotor
   """
 
   def __init__(self,
@@ -33,6 +36,9 @@ class FakeDCMotor(Actuator):
         it down.
       initial_speed: The initial speed of the motor, in RPM.
       initial_pos: The initial position of the motor, in turns.
+    
+    .. versionchanged:: 2.0.0
+       renamed *sim_speed* argument to *simulation_speed*
     """
 
     super().__init__()
@@ -66,7 +72,10 @@ class FakeDCMotor(Actuator):
     return self._rpm
 
   def get_position(self) -> float:
-    """Returns the position of the motor, in rounds."""
+    """Returns the position of the motor, in rounds.
+
+    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    """
 
     self._update()
     return self._pos

--- a/src/crappy/actuator/fake_stepper_motor.py
+++ b/src/crappy/actuator/fake_stepper_motor.py
@@ -21,6 +21,8 @@ class FakeStepperMotor(Actuator):
   Internally, the behavior of the motor is emulated in a separate
   :obj:`~threading.Thread` and is based on the fundamental equations of the
   constantly accelerated linear movement.
+  
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/actuator/ft232h/adafruit_dc_motor_hat.py
+++ b/src/crappy/actuator/ft232h/adafruit_dc_motor_hat.py
@@ -45,7 +45,10 @@ class DCMotorHatFT232H(Actuator):
 
   Note:
     The DC Motor Hat can also drive stepper motors, but this feature isn't
-    included here."""
+    included here.
+
+  .. versionadded:: 2.0.0
+  """
 
   ft232h = True
 

--- a/src/crappy/actuator/jvl_mac_140.py
+++ b/src/crappy/actuator/jvl_mac_140.py
@@ -25,14 +25,18 @@ class JVLMac140(Actuator):
   in position.
 
   It interfaces with the servomotor over a serial connection.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed class from Biotens to JVLMac140
   """
 
-  def __init__(self,
-               port: str = '/dev/ttyUSB0') -> None:
+  def __init__(self, port: str = '/dev/ttyUSB0') -> None:
     """Initializes the parent class.
 
     Args:
       port: Path to the serial port to use for communication.
+
+    .. deprecated:: 2.0.0 *baudrate* argument
     """
 
     self._ser = None
@@ -83,6 +87,8 @@ class JVLMac140(Actuator):
       position: The target position, in `mm`.
       speed: The target speed for reaching the desired position, in `mm/min`.
         The speed must be given, otherwise an exception is raised.
+    
+    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     """
 
     if speed is None:
@@ -109,7 +115,10 @@ class JVLMac140(Actuator):
     self._ser.writelines(cmd)
 
   def get_position(self) -> float:
-    """Reads and returns the current position of the servomotor, in `mm`."""
+    """Reads and returns the current position of the servomotor, in `mm`.
+
+    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    """
 
     # We have 20 attempts for reading the position
     for _ in range(20):

--- a/src/crappy/actuator/kollmorgen_servostar_300.py
+++ b/src/crappy/actuator/kollmorgen_servostar_300.py
@@ -19,6 +19,9 @@ class ServoStar300(Actuator):
   It communicates with the servomotor over a serial connection. The
   :class:`~crappy.lamcube.Biaxe` Actuator can drive the same hardware, but only
   in speed.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Servostar to ServoStar300
   """
 
   def __init__(self,
@@ -33,6 +36,9 @@ class ServoStar300(Actuator):
       mode: The driving mode to use when starting the test. Can be `'analog'`
         or `'serial'`. It can be changed afterward while the test is running,
         by sending the right command.
+    
+    .. deprecated:: 2.0.0 *device argument*
+    .. versionchanged:: 2.0.0 use *port* instead of *device*
     """
 
     self._ser = None
@@ -84,6 +90,9 @@ class ServoStar300(Actuator):
         sets the driving mode to analog.
       speed: The speed at which the actuator should reach its target position.
         If no speed is specified, the default is `20000`.
+    
+    .. deprecated:: 2.0.0 remove *acc* and *dec* arguments
+    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     """
 
     if speed is None:
@@ -118,7 +127,10 @@ class ServoStar300(Actuator):
     self._last_pos = pos
 
   def get_position(self) -> Optional[float]:
-    """Reads and returns the current position of the motor."""
+    """Reads and returns the current position of the motor.
+
+    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    """
 
     # Requesting a position reading
     self._ser.flushInput()

--- a/src/crappy/actuator/meta_actuator/actuator.py
+++ b/src/crappy/actuator/meta_actuator/actuator.py
@@ -15,6 +15,8 @@ class Actuator(metaclass=MetaActuator):
   The Actuator objects are helper classes used by the
   :class:`~crappy.blocks.Machine` Block to communicate with motors or other
   actuators.
+
+  .. versionadded:: 1.4.0
   """
 
   ft232h: bool = False
@@ -32,6 +34,8 @@ class Actuator(metaclass=MetaActuator):
     Args:
       level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:
@@ -51,6 +55,8 @@ class Actuator(metaclass=MetaActuator):
     Blocks.
 
     It is fine for this method not to perform anything.
+
+    .. versionadded:: 2.0.0
     """
 
     ...
@@ -68,6 +74,8 @@ class Actuator(metaclass=MetaActuator):
 
     Args:
       speed: The speed to reach, as a :obj:`float`.
+
+    .. versionadded:: 1.5.10
     """
 
     self.log(logging.WARNING, f"The set_speed method was called but is not "
@@ -109,6 +117,10 @@ class Actuator(metaclass=MetaActuator):
       position: The position to reach, as a :obj:`float`.
       speed: The speed at which to move to the desired position, as a
         :obj:`float`, or :obj:`None` if no speed is specified.
+
+    .. versionadded:: 1.5.10
+    .. versionchanged:: 2.0.0
+       *speed* is now a mandatory argument even if it is :obj:`None`
     """
 
     self.log(logging.WARNING, f"The set_position method was called but is not "
@@ -124,7 +136,10 @@ class Actuator(metaclass=MetaActuator):
     :class:`~crappy.blocks.Machine` Block.
 
     It is also fine for this method to return :obj:`None` if the speed could
-    not be acquired."""
+    not be acquired.
+
+    .. versionadded:: 1.5.10
+    """
 
     self.log(logging.WARNING, f"The get_speed method as called but is not "
                               f"defined ! Define such a method, don't set the "
@@ -142,7 +157,10 @@ class Actuator(metaclass=MetaActuator):
     :class:`~crappy.blocks.Machine` Block.
 
     It is also fine for this method to return :obj:`None` if the position could
-    not be acquired."""
+    not be acquired.
+
+    .. versionadded:: 1.5.10
+    """
 
     self.log(logging.WARNING, f"The get_position method as called but is not "
                               f"defined ! Define such a method, don't set the "
@@ -162,6 +180,8 @@ class Actuator(metaclass=MetaActuator):
     default behavior is to call :meth:`set_speed` to set the speed to `0`. This
     method doesn't need to be overriden if the actuator doesn't have any
     feature for stopping other than speed control.
+
+    .. versionadded:: 2.0.0
     """
 
     self.set_speed(0)
@@ -176,6 +196,8 @@ class Actuator(metaclass=MetaActuator):
     path, or because an exception was raised in any of the Blocks).
 
     It is fine for this method not to perform anything.
+
+    .. versionadded:: 2.0.0
     """
 
     ...

--- a/src/crappy/actuator/meta_actuator/meta_actuator.py
+++ b/src/crappy/actuator/meta_actuator/meta_actuator.py
@@ -6,7 +6,12 @@ from ..._global import DefinitionError
 class MetaActuator(type):
   """Metaclass ensuring that two Actuators don't have the same name, and
   keeping track of all the :class:`~crappy.actuator.Actuator` classes. It also
-  allows including the user-defined Actuators."""
+  allows including the user-defined Actuators.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0
+     not checking anymore for mandatory methods in :meth:`__init__`
+  """
 
   classes = {}
 

--- a/src/crappy/actuator/newport_tra6ppd.py
+++ b/src/crappy/actuator/newport_tra6ppd.py
@@ -24,6 +24,9 @@ class NewportTRA6PPD(Actuator):
 
   Note:
     This Actuator ignores new position commands while it is moving.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0 renamed from TRA6PPD to NewportTRA6PPD
   """
 
   def __init__(self,

--- a/src/crappy/actuator/oriental_ard_k.py
+++ b/src/crappy/actuator/oriental_ard_k.py
@@ -19,6 +19,9 @@ class OrientalARDK(Actuator):
   It communicates with the stepper motor over a serial connection. This class
   was designed so that the :class:`~crappy.blocks.Machine` Block drives several
   of its instances at a time, corresponding to different axes to drive.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Oriental to OrientalARDK
   """
 
   def __init__(self,
@@ -128,6 +131,8 @@ class OrientalARDK(Actuator):
       position: The target position to reach, in arbitrary units.
       speed: The speed to use for reaching the target position, in arbitrary
         units. A speed must be given, otherwise an exception is raised.
+    
+    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     """
 
     if speed is None:
@@ -140,7 +145,10 @@ class OrientalARDK(Actuator):
     self._ser.write(f'MA {position}'.encode())
 
   def get_position(self) -> float:
-    """Reads and returns the current position of the motor."""
+    """Reads and returns the current position of the motor.
+
+    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    """
 
     # Sending the read command
     self._ser.flushInput()

--- a/src/crappy/actuator/pololu_tic.py
+++ b/src/crappy/actuator/pololu_tic.py
@@ -269,6 +269,9 @@ class PololuTic(Actuator):
 MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
 
     in a shell opened in ``/etc/udev/rules.d``.
+    
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Pololu_tic to PololuTic
   """
 
   def __init__(self,
@@ -724,6 +727,8 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
 
     Returns:
       The position in `mm`
+    
+    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
     """
 
     if self._backend == 'ticcmd':
@@ -754,6 +759,8 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
         maximum speed. The Tic will try to accelerate to the maximum speed but
         may remain slower if it doesn't have time to do so before reaching the
         given position.
+    
+    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     """
 
     if speed is not None:

--- a/src/crappy/actuator/schneider_mdrive_23.py
+++ b/src/crappy/actuator/schneider_mdrive_23.py
@@ -17,6 +17,9 @@ class SchneiderMDrive23(Actuator):
   and in position.
 
   It communicates with the motor over a serial connection.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from CM_drive to SchneiderMDrive23
   """
 
   def __init__(self,
@@ -69,6 +72,9 @@ class SchneiderMDrive23(Actuator):
     Args:
       position: The target position to reach, in `mm`.
       _: The speed argument is ignored.
+    
+    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
+    .. deprecated:: 2.0.0 *motion_type* argument
     """
 
     # Closing and reopening to get rid of errors
@@ -82,7 +88,10 @@ class SchneiderMDrive23(Actuator):
     self._ser.readline()
 
   def get_position(self) -> float:
-    """Reads, displays and returns the current position in `mm`."""
+    """Reads, displays and returns the current position in `mm`.
+    
+    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    """
 
     # Closing and reopening to get rid of errors
     self._ser.close()

--- a/src/crappy/blocks/auto_drive_video_extenso.py
+++ b/src/crappy/blocks/auto_drive_video_extenso.py
@@ -22,6 +22,9 @@ class AutoDriveVideoExtenso(Block):
   It also outputs the difference between the center of the image and the middle
   of the spots, along with a timestamp, over the ``'t(s)'`` and ``'diff(pix)'``
   labels. It can then be used by downstream Blocks.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from AutoDrive to AutoDriveVideoExtenso
   """
 
   def __init__(self,
@@ -61,6 +64,10 @@ class AutoDriveVideoExtenso(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionchanged:: 1.5.10 renamed *P* argument to *gain*
+    .. versionchanged:: 1.5.10 renamed *range* argument to *pixel_range*
+    .. versionadded:: 2.0.0 *display_freq* and *debug* arguments
     """
 
     self._device: Optional[Actuator] = None

--- a/src/crappy/blocks/button.py
+++ b/src/crappy/blocks/button.py
@@ -25,6 +25,9 @@ class Button(Block):
   triggering actions based on an experimenter's decision. It can be handy for
   taking pictures at precise moments, or when an action should only begin after
   the experimenter has completed a task, for example.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from GUI to Button
   """
 
   def __init__(self,
@@ -55,6 +58,9 @@ class Button(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded:: 1.5.10 *send_0* and *time_label* arguments
+    .. versionadded:: 2.0.0 *display_freq* and *debug* arguments
     """
 
     self._root: Optional[tk.Tk] = None

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -44,6 +44,8 @@ class Camera(Block):
   the recording by the :class:`~crappy.blocks.camera_processes.ImageSaver`.
   This Block manages the instantiation, the synchronisation and the
   termination of all the CameraProcess it controls.
+  
+  .. versionadded:: 1.4.0
   """
 
   cam_count = dict()
@@ -190,6 +192,18 @@ class Camera(Block):
       **kwargs: Any additional argument will be passed to the 
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
+    
+    .. versionadded:: 1.5.2 *no_loop* argument
+    .. versionadded:: 1.5.10 
+       *display_images*, *displayer_backend*, *displayer_framerate*, 
+       *software_trig_label*, *freq*, *save_images* and *image_generator*
+       arguments
+    .. versionremoved::
+       1.5.10 *fps_label*, *ext*, *input_label* and *no_loop* arguments
+    .. versionadded:: 2.0.0
+       *debug*, *img_extension*, *img_shape* and *img_dtype* arguments
+    .. versionremoved:: 2.0.0 *img_name* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._save_proc: Optional[ImageSaver] = None

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -44,6 +44,8 @@ class CameraProcess(Process):
   managed by the parent :class:`~crappy.blocks.Camera` Block, depending on the
   provided arguments. Users should normally not need to call this class
   themselves.
+  
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self) -> None:

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -23,6 +23,8 @@ class DICVEProcess(CameraProcess):
   that the :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` are sent
   to the :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess for
   display.
+  
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -22,6 +22,8 @@ class DISCorrelProcess(CameraProcess):
   that the :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` are sent
   to the :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess for
   display.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -36,6 +36,8 @@ class Displayer(CameraProcess):
   The images can be displayed using two different backends : either using
   :mod:`cv2` (OpenCV), or using :mod:`matplotlib`. OpenCV is by far the fastest
   and most convenient.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -23,6 +23,8 @@ class GPUCorrelProcess(CameraProcess):
   It is also this class that takes the decision to send or not the results to
   downstream Blocks based on the value of the calculated residuals, if this
   option is enabled by the user.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -30,6 +30,8 @@ class GPUVEProcess(CameraProcess):
   and that the :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` are
   sent to the :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess
   for display.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -37,6 +37,8 @@ class ImageSaver(CameraProcess):
   Various backends can be used for recording the images, some may be faster or
   slower depending on the machine. It is possible to only save one out of a
   given number of images, if not all frames are needed.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -23,6 +23,8 @@ class VideoExtensoProcess(CameraProcess):
   that the :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` are sent
   to the :class:`~crappy.blocks.camera_processes.Displayer` CameraProcess for
   display.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/canvas.py
+++ b/src/crappy/blocks/canvas.py
@@ -14,7 +14,10 @@ mpl = OptionalModule('matplotlib', lazy_import=True)
 
 
 class Text:
-  """Displays a simple text line on the drawing."""
+  """Displays a simple text line on the drawing.
+  
+  .. versionadded:: 1.4.0
+  """
 
   def __init__(self,
                _: Canvas,
@@ -30,6 +33,9 @@ class Text:
       text: The text to display.
       label: The label carrying the information for updating the text.
       **__: Other unused arguments.
+
+    .. versionchanged:: 1.5.10
+       now explicitly listing the *_*, *coord*, *text* and *label* arguments
     """
 
     x, y = coord
@@ -47,6 +53,9 @@ class Text:
 
 class DotText:
   """Like :class:`Text`, but with a colored dot to visualize a numerical value.
+
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Dot_text to DotText
   """
 
   def __init__(self,
@@ -69,6 +78,10 @@ class DotText:
       The value received in label must be a numeric value. It will be
       normalized on the ``crange`` of the Block and the dot will change
       color from blue to red depending on this value.
+      
+    .. versionchanged:: 1.5.10
+       now explicitly listing the *drawing*, *coord*, *text* and *label*
+       arguments
     """
 
     x, y = coord
@@ -95,7 +108,10 @@ class DotText:
 
 class Time:
   """Displays a time counter on the drawing, starting at the beginning of the
-  test."""
+  test.
+
+  .. versionadded:: 1.4.0
+  """
 
   def __init__(self, drawing: Canvas, coord: Tuple[int, int], **__) -> None:
     """Sets the arguments.
@@ -104,6 +120,9 @@ class Time:
       drawing: The parent drawing Block.
       coord: The coordinates of the time counter on the drawing.
       **__: Other unused arguments.
+
+    .. versionchanged:: 1.5.10
+       now explicitly listing the *drawing* and *coord* arguments
     """
 
     self._block = drawing
@@ -132,6 +151,9 @@ class Canvas(Block):
   representation of data. For simpler displays, the
   :class:`~crappy.blocks.Dashboard`, :class:`~crappy.blocks.Grapher` and
   :class:`~crappy.blocks.LinkReader` Blocks should be preferred.
+
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Drawing to Canvas
   """
 
   def __init__(self,
@@ -183,6 +205,11 @@ class Canvas(Block):
         - ``label``: Mandatory for `'text'` and `'dot_text'` only, the label of
           the data to display. It will try to retrieve this data in the
           incoming Links. The ``text`` will then be updated with this data.
+    
+    .. versionchanged:: 1.5.10 renamed *crange* argument to *color_range*
+    .. versionadded:: 1.5.10 *verbose* argument
+    .. versionadded:: 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()

--- a/src/crappy/blocks/client_server.py
+++ b/src/crappy/blocks/client_server.py
@@ -36,6 +36,9 @@ class ClientServer(Block):
   microcontrollers) acquiring data in enclosed areas or rotating parts, data
   transfer between machines to delegate processing, communication with other
   programs on a same machine, etc.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Client_server to ClientServer
   """
 
   def __init__(self,
@@ -205,6 +208,9 @@ class ClientServer(Block):
 
           ('sign',)
 
+    .. versionadded:: 1.5.10 *verbose*, *freq* and *spam* arguments
+    .. versionadded:: 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._client: Optional[mqtt.Client] = None

--- a/src/crappy/blocks/dashboard.py
+++ b/src/crappy/blocks/dashboard.py
@@ -8,7 +8,11 @@ from .meta_block import Block
 
 
 class DashboardWindow(tk.Tk):
-  """The GUI for displaying the label values."""
+  """The GUI for displaying the label values.
+  
+  .. versionadded:: 1.5.7
+  .. versionchanged:: 2.0.0 renamed from Dashboard_window to DashboardWindow
+  """
 
   def __init__(self, labels: List[str]) -> None:
     """Initializes the GUI and sets the layout."""
@@ -63,6 +67,8 @@ class Dashboard(Block):
   :class:`~crappy.blocks.LinkReader` Block. For displaying the evolution of a
   label over time, the :class:`~crappy.blocks.Grapher` Block should be used
   instead.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -84,6 +90,10 @@ class Dashboard(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded:: 1.5.7 *verbose* and *freq* arguments
+    .. versionadded:: 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._dashboard: Optional[DashboardWindow] = None
@@ -98,7 +108,10 @@ class Dashboard(Block):
 
   def prepare(self) -> None:
     """Checks that there's at least one incoming :class:`~crappy.links.Link`,
-    and starts the GUI."""
+    and starts the GUI.
+    
+    .. versionadded:: 1.5.7
+    """
 
     if not self.inputs:
       raise IOError("No Link pointing towards the Dashboard Block !")
@@ -109,7 +122,10 @@ class Dashboard(Block):
 
   def loop(self) -> None:
     """Receives the data from the incoming :class:`~crappy.links.Link` and
-    displays it."""
+    displays it.
+    
+    .. versionadded:: 1.5.7
+    """
 
     data = self.recv_last_data(fill_missing=False)
 
@@ -133,7 +149,10 @@ class Dashboard(Block):
       pass
 
   def finish(self) -> None:
-    """Closes the display."""
+    """Closes the display.
+
+    .. versionadded:: 1.5.7
+    """
 
     # In case the GUI has been destroyed, don't raise an error
     try:

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -45,6 +45,9 @@ class DICVE(Camera):
   :class:`~crappy.tool.camera_config.DICVEConfig` window before the test
   starts. Here, the user can also select the patches to track if they were not
   already specified as an argument.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from DISVE to DICVE
   """
 
   def __init__(self,
@@ -287,6 +290,23 @@ class DICVE(Camera):
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
+
+    .. versionadded:: 1.5.7 *safe* and *follow* arguments
+    .. versionremoved:: 1.5.9 *fields* argument
+    .. versionadded:: 1.5.9 *method* argument
+    .. versionadded:: 1.5.10 
+       *transform*, *config*, *displayer_backend*, *displayer_framerate*, 
+       *verbose*, *freq*, *save_images*, *img_name*, *save_folder*, 
+       *save_period*, *save_backend* and *image_generator* arguments
+    .. versionchanged:: 1.5.10 
+       renamed *gditerations* argument to *gradient_iterations*
+    .. versionchanged:: 1.5.10 
+       renamed *show_image* argument to *display_images*
+    .. versionadded:: 2.0.0 
+       *debug*, *software_trig_label*, *img_extension*, *raise_on_patch_exit*,
+       *img_size* and *img_dtype* arguments
+    .. versionremoved:: 2.0.0 *img_name* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     if not config and patches is None:
@@ -353,6 +373,9 @@ class DICVE(Camera):
     In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.DICVEProcess` object that performs
     the image correlation and the tracking.
+    
+    .. versionchanged:: 1.5.5 now accepting args and kwargs
+    .. versionchanged:: 1.5.10 not accepting arguments anymore
     """
 
     # Instantiating the SpotsBoxes containing the patches to track

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -38,6 +38,8 @@ class DISCorrel(Camera):
   :class:`~crappy.tool.camera_config.DISCorrelConfig` window before the test
   starts. Here, the user can also select the patch to track if it was not
   already specified as an argument.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -254,6 +256,21 @@ class DISCorrel(Camera):
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
+
+    .. versionadded:: 1.5.10 
+       *transform*, *config*, *displayer_backend*, *displayer_framerate*, 
+       *verbose*, *freq*, *save_images*, *img_name*, *save_folder*, 
+       *save_period*, *save_backend* and *image_generator* arguments
+    .. versionchanged:: 1.5.10 
+       renamed *gditerations* argument to *gradient_iterations*
+    .. versionchanged:: 1.5.10 
+       renamed *show_image* argument to *display_images*
+    .. versionremoved:: 1.5.10 *residual_full* argument
+    .. versionadded:: 2.0.0
+       *debug*, *patch*, *software_trig_label*, *img_extension*, *img_size* and
+       *img_dtype* arguments
+    .. versionremoved:: 2.0.0 *img_name* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     if not config and patch is None:
@@ -329,6 +346,9 @@ class DISCorrel(Camera):
     In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.DISCorrelProcess` object that
     performs the image correlation and the tracking.
+
+    .. versionchanged:: 1.5.5 now accepting args and kwargs
+    .. versionchanged:: 1.5.10 not accepting arguments anymore
     """
 
     # Instantiating the Box containing the patch to track

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -33,6 +33,9 @@ class FakeMachine(Block):
   This Block was originally designed for proposing examples that do not require
   any hardware to run, but still display the possibilities of Crappy. It can
   also be used to test a script without actually interacting with hardware.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Fake_machine to FakeMachine
   """
 
   def __init__(self,
@@ -74,6 +77,12 @@ class FakeMachine(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionchanged:: 1.5.10 renamed *maxstrain* argument to *max_strain*
+    .. versionadded:: 1.5.10 *freq* and *verbose* arguments
+    .. versionadded:: 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *k* argument to *rigidity*
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator.py
+++ b/src/crappy/blocks/generator.py
@@ -32,6 +32,8 @@ class Generator(Block):
   used by a :class:`~crappy.blocks.generator_path.meta_path.Path`. The most
   common use of this feature is to have the stop condition of a Path depend on
   the received values of a label.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -83,6 +85,11 @@ class Generator(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionremoved:: 1.5.10 *cmd* and *trig_link* argument
+    .. versionadded:: 1.5.10 *safe_start* argument
+    .. versionadded:: 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/conditional.py
+++ b/src/crappy/blocks/generator_path/conditional.py
@@ -13,6 +13,8 @@ class Conditional(Path):
   It is especially useful for controlling processes that need to behave
   differently based on input values, e.g. for preventing a heating element
   from overheating, or a motor from driving too far.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -38,6 +40,12 @@ class Conditional(Path):
 
     Note:
       This Generator Path never ends, it doesn't have a stop condition.
+
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionremoved:: 1.5.10 *verbose* argument
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
+    .. versionchanged:: 2.0.0 renamed from Protection to Conditional
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/constant.py
+++ b/src/crappy/blocks/generator_path/constant.py
@@ -8,7 +8,10 @@ from .meta_path import Path, ConditionType
 
 class Constant(Path):
   """The simplest Path, outputs the same constant value until the stop 
-  condition is met."""
+  condition is met.
+  
+  .. versionadded:: 1.4.0
+  """
 
   def __init__(self,
                condition: Union[str, ConditionType],
@@ -20,6 +23,11 @@ class Constant(Path):
         :class:`~crappy.blocks.generator_path.meta_path.Path` for more
         information.
       value: The value to output.
+      
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionremoved:: 1.5.10 *send_one* argument
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     super().__init__()
@@ -33,7 +41,10 @@ class Constant(Path):
 
   def get_cmd(self, data: Dict[str, list]) -> float:
     """Returns the value to send or raises :exc:`StopIteration` if the stop
-    condition is met."""
+    condition is met.
+    
+    .. versionadded:: 1.5.10
+    """
 
     # Checking if the stop condition is met
     if self._condition(data):

--- a/src/crappy/blocks/generator_path/custom.py
+++ b/src/crappy/blocks/generator_path/custom.py
@@ -14,6 +14,8 @@ class Custom(Path):
 
   The file can be in any text format, including the most common `.csv` and
   `.txt` extensions.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -30,6 +32,11 @@ class Custom(Path):
         must contain two columns: the first one containing timestamps (starting
         from 0), the other one containing the values.
       delimiter: The delimiter between columns in the file, usually a coma.
+    
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionchanged:: 2.0.0 renamed *filename* argument to *file_name*
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/cyclic.py
+++ b/src/crappy/blocks/generator_path/cyclic.py
@@ -15,6 +15,8 @@ class Cyclic(Path):
   It can for example be used as a trigger, or used to drive an actuator
   cyclically. It is equivalent to a succession of 
   :class:`~crappy.blocks.generator_path.Constant` Paths.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -50,6 +52,11 @@ class Cyclic(Path):
 
         [{'type': 'Constant', 'value': 1,'condition': 'AIN0>2'},
         {'type': 'Constant', 'value': 0, 'condition': 'AIN1<1'}] * 5
+    
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionremoved:: 1.5.10 *verbose* argument
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/cyclic_ramp.py
+++ b/src/crappy/blocks/generator_path/cyclic_ramp.py
@@ -14,6 +14,9 @@ class CyclicRamp(Path):
 
   It is equivalent to a succession of 
   :class:`~crappy.blocks.generator_path.Ramp` Paths.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Cyclic_ramp to CyclicRamp
   """
 
   def __init__(self,
@@ -53,6 +56,12 @@ class CyclicRamp(Path):
 
         [{'type': 'Ramp', 'speed': 5,'condition': 'AIN0>2'},
         {'type': 'Ramp', 'value': -2, 'condition': 'AIN1<1'}] * 5
+    
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionremoved:: 1.5.10 *verbose* argument
+    .. versionadded:: 1.5.10 *init_value* argument
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/integrator.py
+++ b/src/crappy/blocks/generator_path/integrator.py
@@ -16,6 +16,9 @@ class Integrator(Path):
 
   Then the output value for this Path will be
   :math:`v(t) = v(t0) - [I(t0 -> t)f(t)dt] / m`.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Inertia to Integrator
   """
 
   def __init__(self,
@@ -39,6 +42,14 @@ class Integrator(Path):
         starting point for the inertia path. In the specific case when this
         path is the first one in the Generator Paths, this argument must be
         given !
+    
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionchanged:: 1.5.10 renamed *flabel* argument to *func_label*
+    .. versionchanged:: 1.5.10 renamed *tlabel* argument to *time_label*
+    .. versionchanged:: 1.5.10 renamed *value* argument to *init_value*
+    .. versionremoved:: 1.5.10 *const* argument
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/meta_path/meta_path.py
+++ b/src/crappy/blocks/generator_path/meta_path/meta_path.py
@@ -6,7 +6,10 @@ from ...._global import DefinitionError
 class MetaPath(type):
   """Metaclass ensuring that two Paths don't have the same name, and that all
   Paths define the required methods. Also keeps track of all the Path
-  classes, including the custom user-defined ones."""
+  classes, including the custom user-defined ones.
+  
+  .. versionadded:: 2.0.0
+  """
 
   classes = dict()
 

--- a/src/crappy/blocks/generator_path/meta_path/path.py
+++ b/src/crappy/blocks/generator_path/meta_path/path.py
@@ -16,6 +16,8 @@ class Path(metaclass=MetaPath):
 
   The Path object are used by the :class:`~crappy.blocks.Generator` Block to
   generate signals.
+  
+  .. versionadded:: 1.4.0
   """
 
   t0: Optional[float] = None
@@ -34,6 +36,10 @@ class Path(metaclass=MetaPath):
     previous :class:`~crappy.blocks.generator_path.meta_path.Path` was sent,
     and the ``self.last_cmd`` stores the value of the last command of the
     previous :class:`~crappy.blocks.generator_path.meta_path.Path`.
+
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     self._logger: Optional[logging.Logger] = None
@@ -84,6 +90,8 @@ class Path(metaclass=MetaPath):
     Args:
       level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:

--- a/src/crappy/blocks/generator_path/ramp.py
+++ b/src/crappy/blocks/generator_path/ramp.py
@@ -9,7 +9,10 @@ from .meta_path import Path, ConditionType
 
 class Ramp(Path):
   """Sends a ramp signal varying linearly over time, until the stop condition
-  is met."""
+  is met.
+  
+  .. versionadded:: 1.4.0
+  """
 
   def __init__(self,
                condition: Union[str, ConditionType],
@@ -25,6 +28,11 @@ class Ramp(Path):
       init_value: If given, overwrites the last value of the signal as the
         starting point for the ramp. In the specific case when this path is the
         first one in the Generator Paths, this argument must be given !
+    
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionadded:: 1.5.10 *init_value* argument
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/sine.py
+++ b/src/crappy/blocks/generator_path/sine.py
@@ -10,7 +10,10 @@ from .meta_path import Path, ConditionType
 
 class Sine(Path):
   """This Path generates a sine wave varying with time until the stop condition
-  is met."""
+  is met.
+  
+  .. versionadded:: 1.4.0
+  """
 
   def __init__(self,
                condition: Union[str, ConditionType],
@@ -28,6 +31,10 @@ class Sine(Path):
       amplitude: The amplitude of the sine wave (peak to peak).
       offset: The offset of the sine (average value).
       phase: The phase of the sine (in radians).
+    
+    .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
+    .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
+    .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 
     super().__init__()

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -34,6 +34,8 @@ class GPUCorrel(Camera):
   correlation is performed on the entire image. It is however possible to set
   a mask, so that only part of the image is considered when running the
   correlation.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -242,6 +244,22 @@ class GPUCorrel(Camera):
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
+    
+    .. versionadded:: 1.5.10 
+       *transform*, *display_images*, *displayer_backend*, 
+       *displayer_framerate*, *freq*, *save_images*, *image_generator*, 
+       *levels*, *resampling_factor*, *kernel_file*, *iterations*, *mask*, 
+       *mul* and *res* arguments
+    .. versionchanged:: 1.5.10 
+       renamed *discard_lim* argument to *discard_limit*
+    .. versionchanged:: 1.5.10 
+       renamed *imgref* argument to *img_ref*
+    .. versionremoved:: 1.5.10
+       *fps_label*, *ext*, *input_label*, *config* and *cam_kwargs* arguments
+    .. versionadded:: 2.0.0 
+       *debug*, *software_trig_label*, *img_extension*, *img_shape* and
+       *img_dtype* arguments
+    .. versionremoved:: 2.0.0 *img_name* argument
     """
 
     super().__init__(camera=camera,
@@ -307,6 +325,9 @@ class GPUCorrel(Camera):
     In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.GPUCorrelProcess` object that
     performs the GPU-accelerated image correlation.
+    
+    .. versionchanged:: 1.5.5 now accepting args and kwargs
+    .. versionchanged:: 1.5.10 not accepting arguments anymore
     """
 
     # Instantiating the GPUCorrelProcess

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -28,6 +28,8 @@ class GPUVE(Camera):
   have a much greater accuracy. The :class:`~crappy.blocks.VideoExtenso` Block
   also performs video-extensometry, but it does so by tracking spots instead
   of textured patches, and it is not GPU-accelerated.
+
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -110,7 +112,7 @@ class GPUVE(Camera):
         on the camera.
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
-        is displayed that is slows the code down. This argument allows to
+        is displayed that it slows the code down. This argument allows to
         adjust the precision of the log messages, while the ``debug`` argument
         is for enabling or disabling logging.
       freq: The target looping frequency for the Block. If :obj:`None`, loops
@@ -201,6 +203,17 @@ class GPUVE(Camera):
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
+
+    .. versionadded:: 1.5.10
+       *freq*, *save_images*, *image_generator*, *img_ref*, *kernel_file*,
+       *iterations* and *mul* arguments
+    .. versionremoved:: 1.5.10
+       *fps_label*, *ext*, *input_label*, *config* and *cam_kwargs* arguments
+    .. versionadded:: 2.0.0
+       *display_images*, *displayer_framerate*, *displayer_backend*, *debug*,
+       *software_trig_label*, *img_extension*, *img_shape* and *img_dtype*
+       arguments
+    .. versionremoved:: 2.0.0 *img_name* argument
     """
 
     super().__init__(camera=camera,
@@ -258,6 +271,9 @@ class GPUVE(Camera):
     In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.GPUVEProcess` object that
     performs the GPU-accelerated image correlation.
+    
+    .. versionchanged:: 1.5.5 now accepting args and kwargs
+    .. versionchanged:: 1.5.10 not accepting arguments anymore
     """
 
     # Instantiating the GPUVEProcess

--- a/src/crappy/blocks/grapher.py
+++ b/src/crappy/blocks/grapher.py
@@ -27,6 +27,8 @@ class Grapher(Block):
   the last values of given labels, the :class:`~crappy.blocks.LinkReader` and 
   :class:`~crappy.blocks.Dashboard` Blocks are simpler solutions that go much
   easier on the CPU. 
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -88,6 +90,11 @@ class Grapher(Block):
         graph = Grapher(('t(s)', 'F(N)'), length=30)
 
       will plot a dynamic graph displaying the last 30 chunks of data.
+
+    .. versionadded:: 1.5.6 *verbose* argument
+    .. versionadded 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+    .. versionchanged:: 2.0.0 renamed *maxpt* argument to *max_pt*
     """
 
     super().__init__()

--- a/src/crappy/blocks/hdf_recorder.py
+++ b/src/crappy/blocks/hdf_recorder.py
@@ -30,6 +30,9 @@ class HDFRecorder(Block):
     Corrupted HDF5 files are not readable at all ! If anything goes wrong 
     during a test, especially during the finish phase, it is not guaranteed 
     that the recorded data will be readable.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Hdf_recorder to HDFRecorder
   """
 
   def __init__(self,
@@ -66,6 +69,10 @@ class HDFRecorder(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded:: 1.5.10 *freq* and *verbose* arguments
+    .. versionadded 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._hfile = None

--- a/src/crappy/blocks/ioblock.py
+++ b/src/crappy/blocks/ioblock.py
@@ -28,6 +28,8 @@ class IOBlock(Block):
   ``make_zero_delay`` argument allows offsetting the acquired values to zero at
   the beginning of the test. Refer to the documentation of each argument for a
   more detailed description.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -95,6 +97,12 @@ class IOBlock(Block):
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
       **kwargs: The arguments to be passed to the :class:`~crappy.inout.InOut`.
+
+    .. versionchanged:: 1.5.10 renamed *trigger* argument to *trigger_label*
+    .. versionchanged:: 1.5.10 renamed *exit_values* argument to *exit_cmd*
+    .. versionadded:: 1.5.10 *make_zero_delay* argument
+    .. versionadded 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._device: Optional[InOut] = None

--- a/src/crappy/blocks/link_reader.py
+++ b/src/crappy/blocks/link_reader.py
@@ -17,6 +17,9 @@ class LinkReader(Block):
   :class:`~crappy.blocks.Dashboard` Block can be used for a nicer layout, and 
   the :class:`~crappy.blocks.Grapher` Block should be used for plotting data in
   a persistent way.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Reader to LinkReader
   """
 
   _index = 0
@@ -40,6 +43,12 @@ class LinkReader(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+    .. versionchanged:: 1.5.5 renamed *name* argument to *reader_name*
+    .. versionadded:: 1.5.10 *freq* and *verbose* arguments
+    .. versionchanged:: 1.5.5 renamed *reader_name* argument to *name*
+    .. versionadded 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()

--- a/src/crappy/blocks/machine.py
+++ b/src/crappy/blocks/machine.py
@@ -46,6 +46,8 @@ class Machine(Block):
   commands, and optionally the labels over which it sends its current speed
   and/or position. The driving mode (`'speed'` or `'position'`) can also be set
   independently for each Actuator.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -111,6 +113,9 @@ class Machine(Block):
           in `'position'` mode. Each time a value is received, the stored speed
           value is updated. It will also overwrite the ``speed`` key if given.
 
+    .. versionadded:: 1.5.10 *verbose* argument
+    .. versionadded 2.0.0 *debug* and *ft232h_ser_num* arguments
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._actuators: List[ActuatorInstance] = list()

--- a/src/crappy/blocks/mean.py
+++ b/src/crappy/blocks/mean.py
@@ -29,6 +29,9 @@ class MeanBlock(Block):
     of the upstream Blocks, this Block may not always return the same number of
     labels ! This can cause errors in downstream Blocks expecting a fixed
     number of labels.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Mean_block to MeanBlock
   """
 
   def __init__(self,
@@ -58,6 +61,11 @@ class MeanBlock(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded:: 1.5.10 *verbose* argument
+    .. versionchanged:: 1.5.10 renamed *t_label* argument to *time_label*
+    .. versionadded 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()
@@ -79,7 +87,10 @@ class MeanBlock(Block):
     self._last_sent_t = time()
 
   def begin(self) -> None:
-    """Initializes the time counter."""
+    """Initializes the time counter.
+    
+    .. versionadded:: 2.0.0
+    """
 
     self._last_sent_t = self.t0
 

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -39,6 +39,8 @@ class Block(Process, metaclass=MetaBlock):
   This class also contains the class methods that allow driving a script with
   Crappy. They are always called in the `__main__` Process, and drive the
   execution of all the children Blocks.
+  
+  .. versionadded:: 1.4.0
   """
 
   instances = WeakSet()
@@ -112,7 +114,10 @@ class Block(Process, metaclass=MetaBlock):
   @classmethod
   def get_name(cls, name: str) -> str:
     """Method attributing to each new Block a unique name, based on the name of
-    the class and the number of existing instances for this class."""
+    the class and the number of existing instances for this class.
+    
+    .. versionadded:: 2.0.0
+    """
 
     i = 1
     while f"crappy.{name}-{i}" in cls.names:
@@ -155,6 +160,10 @@ class Block(Process, metaclass=MetaBlock):
         execution of code that would come after Crappy, in case Crappy does not
         terminate as expected. This behavior can be disabled by setting this
         argument to :obj:`True`.
+    
+    .. versionchanged:: 2.0.0 renamed *high_prio* argument to *allow_root*
+    .. versionremoved:: 2.0.0 *t0*, *verbose*, *bg* arguments
+    .. versionadded:: 2.0.0 *log_level*, *no_raise* arguments
     """
 
     cls.prepare_all(log_level)
@@ -182,6 +191,9 @@ class Block(Process, metaclass=MetaBlock):
         set to :obj:`None`, logging is totally disabled. Refer to the 
         documentation of the :mod:`logging` module for information on the 
         possible levels.
+    
+    .. versionremoved:: 2.0.0 *verbose* argument
+    .. versionadded:: 2.0.0 *log_level* argument
     """
 
     # Flag indicating whether to perform the cleanup action or not
@@ -317,6 +329,8 @@ class Block(Process, metaclass=MetaBlock):
       allow_root: If set to :obj:`True`, tries to renice the Processes with 
         sudo privilege in Linux. It requires the Python script to be run with 
         sudo privilege, otherwise it has no effect.
+    
+    .. versionchanged:: 2.0.0 renamed *high_prio* argument to *allow_root*
     """
 
     # Flag indicating whether to perform the cleanup action or not
@@ -413,6 +427,8 @@ class Block(Process, metaclass=MetaBlock):
         execution of code that would come after Crappy, in case Crappy does not
         terminate as expected. This behavior can be disabled by setting this
         argument to :obj:`True`.
+    
+    .. versionremoved:: 2.0.0 *t0*, *verbose* and *bg* arguments
     """
 
     # Setting the no_raise flag
@@ -682,7 +698,10 @@ class Block(Process, metaclass=MetaBlock):
   @classmethod
   def stop_all(cls) -> None:
     """Method for stopping all the Blocks by setting the stop
-    :obj:`~multiprocessing.Event`."""
+    :obj:`~multiprocessing.Event`.
+    
+    .. versionremoved:: 2.0.0 *verbose* argument
+    """
 
     if cls.stop_event is not None:
       cls.stop_event.set()
@@ -722,6 +741,8 @@ class Block(Process, metaclass=MetaBlock):
     
     Ensures the Logger exists before trying to log, thus avoiding potential 
     errors.
+    
+    .. versionadded:: 2.0.0
     """
     
     if cls.logger is None:
@@ -1058,6 +1079,8 @@ class Block(Process, metaclass=MetaBlock):
     level for the Block. And if :obj:`None`, displays only the
     :obj:`~logging.CRITICAL` logging level, which is equivalent to no
     information at all.
+    
+    .. versionadded:: 2.0.0
     """
 
     return self._debug
@@ -1078,7 +1101,10 @@ class Block(Process, metaclass=MetaBlock):
   @property
   def t0(self) -> float:
     """Returns the value of t0, the exact moment when the test started that is
-    shared between all the Blocks."""
+    shared between all the Blocks.
+    
+    .. versionadded:: 2.0.0
+    """
 
     if self._instance_t0 is not None and self._instance_t0.value > 0:
       self.log(logging.DEBUG, "Start time value requested")
@@ -1105,6 +1131,8 @@ class Block(Process, metaclass=MetaBlock):
     Args:
       log_level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:
@@ -1160,7 +1188,10 @@ class Block(Process, metaclass=MetaBlock):
 
   def data_available(self) -> bool:
     """Returns :obj:`True` if there's data available for reading in at least
-    one of the input :class:`~crappy.links.Link`."""
+    one of the input :class:`~crappy.links.Link`.
+    
+    .. versionchanged:: 2.0.0 renamed from poll to data_available
+    """
 
     self.log(logging.DEBUG, "Data availability requested")
     return self.inputs and any(link.poll() for link in self.inputs)
@@ -1182,6 +1213,8 @@ class Block(Process, metaclass=MetaBlock):
     Returns:
       A :obj:`dict` whose keys are the received labels and with a single value
       for each key (usually a :obj:`float` or a :obj:`str`).
+    
+    .. versionchanged:: 2.0.0 renamed from recv_all to recv_data
     """
 
     ret = dict()
@@ -1212,6 +1245,10 @@ class Block(Process, metaclass=MetaBlock):
     Returns:
       A :obj:`dict` whose keys are the received labels and with a single value
       for each key (usually a :obj:`float` or a :obj:`str`).
+
+    .. versionremoved:: 1.5.10 *num* argument
+    .. versionadded:: 1.5.10 *blocking* argument
+    .. versionchanged:: 2.0.0 renamed from get_last to recv_last_data
     """
 
     # Initializing the buffer storing the last received values
@@ -1265,6 +1302,10 @@ class Block(Process, metaclass=MetaBlock):
       A :obj:`dict` whose keys are the received labels and with a :obj:`list`
       of received values for each key. The first item in the list is the oldest
       one available in the Link, the last item is the newest available.
+
+    .. versionremoved:: 1.5.10 *num* argument
+    .. versionadded:: 1.5.10 *blocking* argument
+    .. versionchanged:: 2.0.0 renamed from get_all_last to recv_all_data
     """
 
     ret = defaultdict(list)
@@ -1314,6 +1355,8 @@ class Block(Process, metaclass=MetaBlock):
     Returns:
       A :obj:`list` containing :obj:`dict`, whose keys are the received labels
       and with a :obj:`list` of received value for each key.
+    
+    .. versionadded:: 2.0.0
     """
 
     ret = [defaultdict(list) for _ in self.inputs]

--- a/src/crappy/blocks/meta_block/meta_block.py
+++ b/src/crappy/blocks/meta_block/meta_block.py
@@ -6,7 +6,10 @@ from ..._global import DefinitionError
 class MetaBlock(type):
   """Metaclass ensuring that two Blocks don't have the same name, and that all
   Blocks define the required methods. Also keeps track of all the Block
-  classes, including the custom user-defined ones."""
+  classes, including the custom user-defined ones.
+
+  .. versionadded:: 2.0.0
+  """
 
   existing = list()
 

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -30,6 +30,9 @@ class Multiplexer(Block):
     should only be used with care as an input to a decision-making Block. This
     is especially true when the upstream Blocks have very different sampling
     rates.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Multiplex to Multiplexer
   """
 
   def __init__(self,
@@ -59,6 +62,11 @@ class Multiplexer(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+    .. versionadded:: 1.5.9 *verbose* argument
+    .. versionchanged:: 1.5.10 renamed *key* argument to *time_label*
+    .. versionadded 2.0.0 *debug*, *out_labels* and *interp_freq* arguments
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -21,6 +21,8 @@ class PID(Block):
   a :class:`~crappy.blocks.Machine` or :class:`~crappy.blocks.IOBlock` Block
   driving a physical system. This latter Block takes the command as input, and
   returns to the PID the measured value to be compared to the target.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -90,6 +92,13 @@ class PID(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded:: 1.5.10 *verbose* argument
+    .. versionadded 2.0.0 
+       *debug*, *kp_label*, *kd_label* and *ki_label* arguments
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+    .. versionchanged:: 2.0.0
+       renamed *target_label* argument to *setpoint_label*
     """
 
     # Attributes of the parent class

--- a/src/crappy/blocks/recorder.py
+++ b/src/crappy/blocks/recorder.py
@@ -22,6 +22,8 @@ class Recorder(Block):
   be used instead. Alternatively, a :class:`~crappy.modifier.Demux` Modifier 
   can be placed between the IOBlock and the Recorder, but most of the acquired
   data won't be saved.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -49,6 +51,11 @@ class Recorder(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded 1.5.10 *freq* and *verbose* arguments
+    .. versionadded 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+    .. versionchanged:: 2.0.0 renamed *filename* argument to *file_name*
     """
 
     super().__init__()

--- a/src/crappy/blocks/sink.py
+++ b/src/crappy/blocks/sink.py
@@ -11,6 +11,8 @@ class Sink(Block):
   It is only useful for debugging, e.g. with Blocks like the
   :class:`~crappy.blocks.IOBlock` that have a different behavior when they have
   output Links.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -28,6 +30,10 @@ class Sink(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded 1.5.6 *verbose* and *freq* arguments
+    .. versionadded 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()

--- a/src/crappy/blocks/stop_block.py
+++ b/src/crappy/blocks/stop_block.py
@@ -14,6 +14,8 @@ class StopBlock(Block):
 
   Along with the :class:`~crappy.blocks.StopButton` Block, it allows to stop a
   test in a clean way without resorting to CTRL+C.
+
+  .. versionadded 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/stop_button.py
+++ b/src/crappy/blocks/stop_button.py
@@ -18,6 +18,8 @@ class StopButton(Block):
 
   Along with the :class:`~crappy.blocks.StopBlock`, it allows to stop a test in
   a clean way without resorting to CTRL+C.
+
+  .. versionadded 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -25,6 +25,8 @@ class UController(Block):
   MicroPython template located in the `tool` folder of Crappy, even though it
   is not mandatory. A given syntax needs to be followed for any data to be
   exchanged.
+  
+  .. versionadded:: 1.5.8
   """
 
   def __init__(self,
@@ -79,6 +81,9 @@ class UController(Block):
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+    
+    .. versionadded:: 2.0.0 *debug* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._bus = None

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -36,6 +36,9 @@ class VideoExtenso(Camera):
   currently not possible to specify the coordinates of the spots to track as an
   argument, so the use of the configuration window is mandatory. This might
   change in the future.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Video_extenso to VideoExtenso
   """
 
   def __init__(self,
@@ -238,6 +241,20 @@ class VideoExtenso(Camera):
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
+    
+    .. versionadded:: 1.5.10 
+       *display_images*, *displayer_backend*, *displayer_framerate*, *freq*,
+       *save_images* and *image_generator* arguments
+    .. versionremoved:: 1.5.10 
+       *ext*, *fps_label*, *wait_l0* and *input_label* arguments
+    .. versionchanged:: 1.5.10
+       renamed *show_image* argument to *display_images*
+    .. versionchanged:: 1.5.10 renamed *end* argument to *raise_on_lost_spot*
+    .. versionadded:: 2.0.0
+       *debug*, *software_trig_label*, *img_extension*, *img_shape* and
+       *img_dtype* arguments
+    .. versionremoved:: 2.0.0 *img_name* argument
+    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__(camera=camera,
@@ -292,6 +309,9 @@ class VideoExtenso(Camera):
     In addition to that it instantiates the
     :class:`~crappy.blocks.camera_processes.VideoExtensoProcess` object that
     performs the video-extensometry and the tracking.
+    
+    .. versionchanged:: 1.5.5 now accepting args and kwargs
+    .. versionchanged:: 1.5.10 not accepting arguments anymore
     """
 
     # Instantiating the SpotsDetector containing the spots to track

--- a/src/crappy/camera/cameralink/basler_ironman_cameralink.py
+++ b/src/crappy/camera/cameralink/basler_ironman_cameralink.py
@@ -29,6 +29,9 @@ class BaslerIronmanCameraLink(Camera):
     This Camera relies on a custom-written C library that hasn't been tested in
     a long time. It might not be functional anymore. This Camera also requires
     proprietary drivers to be installed.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Cl_camera to BaslerIronmanCameraLink
   """
 
   def __init__(self) -> None:
@@ -57,6 +60,11 @@ class BaslerIronmanCameraLink(Camera):
         them in a persistent way.
       camera_type: The type of camera to drive, as a :obj:`str`.
       **kwargs: All the settings to set on the camera.
+    
+    .. versionadded:: 1.5.10
+       explicitly listing the *num_device*, *config_file* and *camera_type*
+       arguments
+    .. versionchanged:: 2.0.0 renamed *numdevice* argument to *num_device*
     """
 
     # Reading the camera type from the config file, if applicable

--- a/src/crappy/camera/cameralink/jai_go_5000c_pmcl.py
+++ b/src/crappy/camera/cameralink/jai_go_5000c_pmcl.py
@@ -33,6 +33,9 @@ class JaiGO5000CPMCL8Bits(BaslerIronmanCameraLink):
     This Camera relies on a custom-written C library that hasn't been tested in
     a long time. It might not be functional anymore. This Camera also requires
     proprietary drivers to be installed.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Jai8 to JaiGO5000CPMCL8Bits
   """
 
   def __init__(self) -> None:
@@ -58,6 +61,9 @@ class JaiGO5000CPMCL8Bits(BaslerIronmanCameraLink):
         them in a persistent way.
       camera_type: The type of camera to drive, as a :obj:`str`.
       **kwargs: All the settings to set on the camera.
+
+    .. versionadded:: 1.5.10
+       explicitly listing the *config_file* and *camera_type* arguments
     """
 
     super().open(config_file=config_file,
@@ -116,6 +122,9 @@ class JaiGO5000CPMCL(JaiGO5000CPMCL8Bits):
     This Camera relies on a custom-written C library that hasn't been tested in
     a long time. It might not be functional anymore. This Camera also requires
     proprietary drivers to be installed.
+
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Jai to JaiGO5000CPMCL
   """
 
   def __init__(self) -> None:
@@ -134,6 +143,8 @@ class JaiGO5000CPMCL(JaiGO5000CPMCL8Bits):
     Args:
       camera_type: The type of camera to drive, as a :obj:`str`.
       **kwargs: All the settings to set on the camera.
+
+    .. versionadded:: 1.5.10 explicitly listing the *camera_type* argument
     """
 
     super().open(camera_type=camera_type, **kwargs)

--- a/src/crappy/camera/fake_camera.py
+++ b/src/crappy/camera/fake_camera.py
@@ -15,6 +15,9 @@ class FakeCamera(Camera):
   The generated images are just a gradient of grey levels, with a line moving
   as a function of time. It is possible to tune the dimension of the image, the
   frame rate and the speed of the moving line.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Fake_camera to FakeCamera
   """
 
   def __init__(self) -> None:
@@ -44,6 +47,9 @@ class FakeCamera(Camera):
       height: The height of the image to generate in pixels.
       speed: The evolution speed of the image, in pixels per second.
       fps: The maximum update frequency of the generated images.
+    
+    .. versionadded:: 2.0.0
+       *width*, *height*, *speed* and *fps* arguments explicitly listed
     """
 
     self.set_all(width=width, height=height, speed=speed, fps=fps)

--- a/src/crappy/camera/file_reader.py
+++ b/src/crappy/camera/file_reader.py
@@ -35,6 +35,10 @@ class FileReader(Camera):
   be that the images cannot be read fast enough to match the original
   framerate, in which case the images are read as fast as possible and the
   delay keeps growing.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10 renamed from Streamer to File_reader
+  .. versionchanged:: 2.0.0 renamed from File_reader to FileReader
   """
 
   def __init__(self) -> None:
@@ -68,6 +72,10 @@ class FileReader(Camera):
       stop_at_end: If :obj:`True` (the default), stops the Crappy script once
         the available images are all exhausted. Otherwise, simply remains idle
         while waiting for the test to finish.
+    
+    .. versionchanged:: 1.5.10 renamed *path* argument to *reader_folder*
+    .. versionadded:: 1.5.10 *reader_backend* and *stop_at_end* arguments
+    .. deprecated:: 1.5.10 *pattern*, *start_delay* and *modifier* arguments
     """
 
     # Selecting an  available backend between first sitk and then cv2

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -42,6 +42,9 @@ class CameraGstreamer(Camera):
   Note:
     This Camera requires the module :mod:`PyGObject` to be installed, as well
     as GStreamer.
+  
+  .. versionadded:: 1.5.9
+  .. versionchanged:: 2.0.0 renamed from Camera_gstreamer to CameraGstreamer
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -103,6 +103,9 @@ class CameraGstreamer(Camera):
   Note:
     This Camera requires the module :mod:`PyGObject` to be installed, as well
     as GStreamer.
+  
+  .. versionadded:: 1.5.9
+  .. versionchanged:: 2.0.0 renamed from Camera_gstreamer to CameraGstreamer
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -19,6 +19,8 @@ class Camera(metaclass=MetaCamera):
 
   The Camera objects are helper classes used by the
   :class:`~crappy.blocks.Camera` Block to interface with cameras.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self, *_, **__) -> None:
@@ -31,6 +33,8 @@ class Camera(metaclass=MetaCamera):
     :meth:`add_choice_setting`, :meth:`add_trigger_setting`, or
     :meth:`add_software_roi` methods. Refer to the documentation of these
     methods for more information.
+    
+    .. versionchanged:: 2.0.0 now accepts *args* and *kwargs*
     """
 
     self.settings: Dict[str, CameraSetting] = dict()
@@ -55,6 +59,8 @@ class Camera(metaclass=MetaCamera):
     Args:
       level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+      
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:
@@ -97,6 +103,8 @@ class Camera(metaclass=MetaCamera):
       end of the method. This is true even if no value to set was given in the
       kwargs. If :meth:`set_all` is not called, the settings won't actually be
       set on the camera.
+    
+    .. versionadded:: 1.5.10
     """
 
     self.set_all(**kwargs)
@@ -123,7 +131,9 @@ class Camera(metaclass=MetaCamera):
     the recorded images.
 
     If only a timestamp is provided, a metadata :obj:`dict` is built internally
-    but the user has no control over it
+    but the user has no control over it.
+
+    .. versionadded:: 1.5.10
     """
 
     self.log(logging.WARNING, "The get_img method was called but is not "
@@ -139,6 +149,8 @@ class Camera(metaclass=MetaCamera):
     This step is usually extremely important in order for the camera resources
     to be released. Otherwise, it might be impossible to re-open the camera
     from Crappy without resetting the hardware connection with it.
+
+    .. versionadded:: 1.5.10
     """
 
     ...
@@ -169,6 +181,8 @@ class Camera(metaclass=MetaCamera):
       setter: The method for setting the current value of the setting. If not
         given, the value to be set is simply stored.
       default: The default value to assign to the setting.
+    
+    .. versionadded:: 1.5.10
     """
 
     # Checking if the given name is valid
@@ -218,6 +232,9 @@ class Camera(metaclass=MetaCamera):
       default: The default value to assign to the setting. If not given, will
         be the average of ``lowest`` and ``highest``.
       step: The step value for the variation of the setting values.
+
+    .. versionadded:: 1.5.10
+    .. versionchanged:: 2.0.0 add the *step* argument
     """
 
     # Checking if the given name is valid
@@ -260,6 +277,8 @@ class Camera(metaclass=MetaCamera):
         given, the value to be set is simply stored.
       default: The default value to assign to the setting. If not given, will
         be the fist item in ``choices``.
+
+    .. versionadded:: 1.5.10
     """
 
     # Checking if the given name is valid
@@ -311,6 +330,8 @@ class Camera(metaclass=MetaCamera):
         given, the returned value is simply the last one that was set.
       setter: The method for setting the current value of the setting. If not
         given, the value to be set is simply stored.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self.trigger_name in self.settings:
@@ -358,6 +379,8 @@ class Camera(metaclass=MetaCamera):
     Args:
       width: The width of the acquired images, in pixels.
       height: The height of the acquired images, in pixels.
+    
+    .. versionadded:: 2.0.0
     """
 
     # Checking that the software ROI setting does not already exist
@@ -392,6 +415,8 @@ class Camera(metaclass=MetaCamera):
     Args:
       width: The width of the acquired images, in pixels.
       height: The height of the acquired images, in pixels.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._soft_roi_set:
@@ -419,6 +444,8 @@ class Camera(metaclass=MetaCamera):
     Might return :obj:`None` in case there's no pixel left on the cropped
     image. Returns the original image if the software ROI settings were not
     defined using :meth:`add_software_roi`.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._soft_roi_set:

--- a/src/crappy/camera/meta_camera/camera_setting/camera_bool_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_bool_setting.py
@@ -10,6 +10,10 @@ class CameraBoolSetting(CameraSetting):
 
   It is a child of
   :class:`~crappy.camera.meta_camera.camera_setting.CameraSetting`.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0
+     renamed from Camera_bool_setting to CameraBoolSetting
   """
 
   def __init__(self,

--- a/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
@@ -13,6 +13,10 @@ class CameraChoiceSetting(CameraSetting):
 
   It is a child of
   :class:`~crappy.camera.meta_camera.camera_setting.CameraSetting`.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0
+     renamed from Camera_choice_setting to CameraChoiceSetting
   """
 
   def __init__(self,
@@ -50,6 +54,8 @@ class CameraChoiceSetting(CameraSetting):
     cannot vary. It is thus not possible to propose more choices than those
     initially proposed. Reversely, if fewer new options ar proposed then some
     radio buttons won't be affected a value.
+    
+    .. versionadded:: 2.0.0
     """
 
     self.log(logging.DEBUG, f"Reloading the setting {self.name}")

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -19,6 +19,10 @@ class CameraScaleSetting(CameraSetting):
   well as settings that can take :obj:`float` value. The type used is
   :obj:`int` is both of the given lowest or highest values are :obj:`int`,
   otherwise :obj:`float` is used.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0
+     renamed from Camera_scale_setting to CameraScaleSetting
   """
 
   def __init__(self,
@@ -39,6 +43,8 @@ class CameraScaleSetting(CameraSetting):
       setter: The method for setting the current value of the setting.
       default: The default value to assign to the setting.
       step: The step value for the variation of the setting values.
+      
+    .. versionadded:: 2.0.0 add *step* argument
     """
 
     self.lowest = lowest
@@ -94,8 +100,11 @@ class CameraScaleSetting(CameraSetting):
              value: NbrType,
              default: Optional[NbrType] = None,
              step: Optional[NbrType] = None) -> None:
-    """Allows modifying the limits and the step of the scale bar
-    once it is already instantiated."""
+    """Allows modifying the limits and the step of the scale bar once it is 
+    already instantiated.
+    
+    .. versionadded:: 2.0.0
+    """
 
     self.log(logging.DEBUG, f"Reloading the setting {self.name}")
 
@@ -121,7 +130,10 @@ class CameraScaleSetting(CameraSetting):
 
   def _check_value(self) -> None:
     """Checks if the step value is compatible with the limit values and
-    types of the scale settings."""
+    types of the scale settings.
+    
+    .. versionadded:: 2.0.0
+    """
 
     if self.step is not None:
       if self.type == int and isinstance(self.step, float):

--- a/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
@@ -18,6 +18,9 @@ class CameraSetting:
   :class:`~crappy.camera.meta_camera.camera_setting.CameraBoolSetting`,
   :class:`~crappy.camera.meta_camera.camera_setting.CameraChoiceSetting`,
   and :class:`~crappy.camera.meta_camera.camera_setting.CameraScaleSetting`.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Camera_setting to CameraSetting
   """
 
   def __init__(self,
@@ -57,6 +60,8 @@ class CameraSetting:
     Args:
       level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:
@@ -101,6 +106,8 @@ class CameraSetting:
     GUI.
 
     Mostly helpful for adjusting the ranges of sliders.
+
+    .. versionadded:: 2.0.0
     """
 
     ...

--- a/src/crappy/camera/meta_camera/meta_camera.py
+++ b/src/crappy/camera/meta_camera/meta_camera.py
@@ -6,7 +6,12 @@ from ..._global import DefinitionError
 class MetaCamera(type):
   """Metaclass ensuring that two cameras don't have the same name, and that all
   cameras define the required methods. Also keeps track of all the Camera
-  classes, including the custom user-defined ones."""
+  classes, including the custom user-defined ones.
+
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10
+     not checking anymore for mandatory methods in :meth:`__init__`
+  """
 
   classes = {}
 

--- a/src/crappy/camera/raspberry_pi_camera.py
+++ b/src/crappy/camera/raspberry_pi_camera.py
@@ -38,6 +38,9 @@ class RaspberryPiCamera(Camera):
   Warning:
     Only works on Raspberry Pi, with the picamera API. On the latest OS release
     "Bullseye", it has to be specifically activated in the configuration menu.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Picamera to RaspberryPiCamera
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/seek_thermal_pro.py
+++ b/src/crappy/camera/seek_thermal_pro.py
@@ -63,6 +63,9 @@ class SeekThermalPro(Camera):
 MODE=\\"0777\\\"" | sudo tee seek_thermal.rules > /dev/null 2>&1
 
     in a shell opened in ``/etc/udev/rules.d``.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Seek_thermal_pro to SeekThermalPro
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/ximea_xiapi.py
+++ b/src/crappy/camera/ximea_xiapi.py
@@ -29,6 +29,9 @@ class XiAPI(Camera):
   Note:
     Both the Python module and the camera drivers have to be installed from
     Ximea's website in order for this class to run.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Xiapi to XiAPI
   """
 
   def __init__(self) -> None:
@@ -58,6 +61,8 @@ class XiAPI(Camera):
         several cameras are available, one of them will be opened randomly.
       **kwargs: Values of the settings to set before opening the camera. Mostly
        useful if the configuration window is not used.
+    
+    .. versionchanged:: 2.0.0 renamed *sn* argument to *serial_number*
     """
 
     if serial_number is not None:

--- a/src/crappy/inout/ads1115.py
+++ b/src/crappy/inout/ads1115.py
@@ -87,6 +87,9 @@ class ADS1115(InOut):
 
   Various settings can be adjusted, like the sample rate, the input mode or the
   voltage range.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Ads1115 to ADS1115
   """
 
   def __init__(self,
@@ -156,6 +159,9 @@ class ADS1115(InOut):
       AINx voltages should not be higher than `VDD+0.3V` nor lower than
       `GND-0.3V`. Setting high ``v_range`` values does not allow measuring
       voltages higher than `VDD` !!
+
+    .. versionadded:: 1.5.8 *dry_pin* argument
+    .. versionremoved:: 2.0.0 *ft232h_ser_num* argument
     """
 
     self._bus = None

--- a/src/crappy/inout/agilent_34420A.py
+++ b/src/crappy/inout/agilent_34420A.py
@@ -21,6 +21,8 @@ class Agilent34420a(InOut):
 
   May also work on similar devices from the same manufacturer, although that
   was not tested.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,

--- a/src/crappy/inout/comedi.py
+++ b/src/crappy/inout/comedi.py
@@ -38,6 +38,8 @@ class Comedi(InOut):
   Note:
     This class requires the `libcomedi` library to be installed on the
     computer.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -116,6 +118,14 @@ class Comedi(InOut):
       the same length, and same for the output channels. If that's not the
       case, all the given iterables are treated as if they had the same length
       as the shortest given one.
+
+    .. versionchanged:: 1.5.10
+       now explicitly listing the *device*, *subdevice*, *channels*,
+       *range_num*, *gain*, *offset*, *make_zero*, *out_subdevice*,
+       *out_channels*, *out_range_num*, *out_gain* and *out_offset* arguments
+    .. versionchanged:: 2.0.0 renamed *subdevice* argument to *sub_device*
+    .. versionchanged:: 2.0.0
+       renamed *out_subdevice* argument to *out_sub_device*
     """
 
     self._device = None

--- a/src/crappy/inout/daqmx.py
+++ b/src/crappy/inout/daqmx.py
@@ -36,6 +36,9 @@ class DAQmx(InOut):
   Note:
     This class requires the NIDAQmx C driver to be installed, as well as the
     :mod:`PyDAQmx` module.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Daqmx to DAQmx
   """
 
   def __init__(self,
@@ -114,6 +117,10 @@ class DAQmx(InOut):
       the same length, and same for the output channels. If that's not the
       case, all the given iterables are treated as if they had the same length
       as the shortest given one.
+
+    .. versionchanged:: 1.5.10 renamed *range* argument to *ranges*
+    .. versionchanged:: 1.5.10 renamed *out_range* argument to *out_ranges*
+    .. versionremoved:: 1.5.10 *nperscan* argument
     """
 
     self._handle = None

--- a/src/crappy/inout/fake_inout.py
+++ b/src/crappy/inout/fake_inout.py
@@ -19,6 +19,9 @@ class FakeInOut(InOut):
 
   It can read and/or modify (to a certain extent) the memory usage of the
   computer.
+  
+  .. versionadded:: 1.5.5
+  .. versionchanged:: 2.0.0 renamed from Fake_inout to FakeInOut
   """
 
   def __init__(self) -> None:
@@ -64,12 +67,18 @@ class FakeInOut(InOut):
     return [time(), virtual_memory().percent]
 
   def start_stream(self) -> None:
-    """Defining this method to avoid getting warnings in the logs."""
+    """Defining this method to avoid getting warnings in the logs.
+    
+    .. versionadded:: 2.0.0
+    """
 
     ...
 
   def stop_stream(self) -> None:
-    """Defining this method to avoid getting warnings in the logs."""
+    """Defining this method to avoid getting warnings in the logs.
+
+    .. versionadded:: 2.0.0
+    """
 
     ...
 
@@ -78,6 +87,8 @@ class FakeInOut(InOut):
     10 values at once in the streamer format.
 
     It is just a demo for showcasing the use of the streamer mode.
+    
+    .. versionadded:: 2.0.0
     """
 
     values = np.array([self.get_data() for _ in range(10)])

--- a/src/crappy/inout/ft232h/ads1115.py
+++ b/src/crappy/inout/ft232h/ads1115.py
@@ -52,6 +52,8 @@ class ADS1115FT232H(InOut):
 
   Various settings can be adjusted, like the sample rate, the input mode or the
   voltage range.
+  
+  .. versionadded:: 2.0.0
   """
 
   ft232h = True

--- a/src/crappy/inout/ft232h/gpio_switch.py
+++ b/src/crappy/inout/ft232h/gpio_switch.py
@@ -15,6 +15,8 @@ class GPIOSwitchFT232H(InOut):
 
   When the command value is `1` the GPIO is turned high, when the command is
   `0` it is turned low. Any value other than `0` and `1` raises an error.
+  
+  .. versionadded:: 2.0.0
   """
 
   ft232h = True

--- a/src/crappy/inout/ft232h/mcp9600.py
+++ b/src/crappy/inout/ft232h/mcp9600.py
@@ -72,6 +72,8 @@ class MCP9600FT232H(InOut):
   operating mode that returns Volts. Several parameters can be tuned, like the
   thermocouple type, the reading resolution or the filter coefficient. Note
   that the MCP9600 can only achieve a data rate of a few Hz.
+
+  .. versionadded:: 2.0.0
   """
 
   ft232h = True

--- a/src/crappy/inout/ft232h/mprls.py
+++ b/src/crappy/inout/ft232h/mprls.py
@@ -21,6 +21,8 @@ class MPRLSFT232H(InOut):
   converter.
 
   It communicates over I2C with the sensor.
+
+  .. versionadded:: 2.0.0
   """
 
   ft232h = True

--- a/src/crappy/inout/ft232h/nau7802.py
+++ b/src/crappy/inout/ft232h/nau7802.py
@@ -105,6 +105,8 @@ class NAU7802FT232H(InOut):
   that can read up to 320 samples per second. It communicates over the I2C
   protocol. The returned value of the InOut is in Volts by default, but can be
   converted to Newtons using the ``gain`` and ``offset`` arguments.
+
+  .. versionadded:: 2.0.0
   """
 
   ft232h = True

--- a/src/crappy/inout/ft232h/waveshare_ad_da.py
+++ b/src/crappy/inout/ft232h/waveshare_ad_da.py
@@ -81,6 +81,8 @@ class WaveshareADDAFT232H(InOut):
   read values from the 8-channels ADC and/or to set the 2-channels DAC. The hat
   can acquire up to 30000 samples per second, although this data rate is
   impossible to achieve using Crappy.
+
+  .. versionadded:: 2.0.0
   """
 
   ft232h = True

--- a/src/crappy/inout/gpio_pwm.py
+++ b/src/crappy/inout/gpio_pwm.py
@@ -21,6 +21,9 @@ class GPIOPWM(InOut):
 
   Warning:
     Only works on Raspberry Pi !
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Gpio_pwm to GPIOPWM
   """
 
   def __init__(self,

--- a/src/crappy/inout/gpio_switch.py
+++ b/src/crappy/inout/gpio_switch.py
@@ -30,6 +30,9 @@ class GPIOSwitch(InOut):
 
   When the command value is `1` the GPIO is turned high, when the command is
   `0` it is turned low. Any value other than `0` and `1` raises an error.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Gpio_switch to GPIOSwitch
   """
 
   def __init__(self,
@@ -51,6 +54,9 @@ class GPIOSwitch(InOut):
         The `'Pi4'` backend only works on the Raspberry Pis. The `'blinka'`
         backend requires installing :mod:`Adafruit-Blinka`, but this module is
         compatible with and maintained on a wide variety of boards.
+    
+    .. versionadded:: 1.5.10 *backend* and *ft232h_ser_num* arguments
+    .. versionremoved:: 2.0.0 *ft232h_ser_num* argument
     """
 
     self._pin_out = None

--- a/src/crappy/inout/kollmorgen_akd_pdmm.py
+++ b/src/crappy/inout/kollmorgen_akd_pdmm.py
@@ -39,6 +39,9 @@ class KollmorgenAKDPDMM(InOut):
 
    It can either drive it in speed or in position. Multiple axes can be driven.
    The values of the current speeds or positions can also be retrieved.
+   
+   .. versionadded:: 1.4.0
+   .. versionchanged:: 2.0.0 renamed from Koll to KollmorgenAKDPDMM
    """
 
   def __init__(self,
@@ -55,6 +58,10 @@ class KollmorgenAKDPDMM(InOut):
       host: The IP address of the variator, given as a :obj:`str`.
       port: The network port over which to communicate with the variator, as
         an :obj:`int`.
+    
+    .. versionremoved:: 1.5.10 *speed*, *acc*, *decc* and *labels* arguments
+    .. versionchanged:: 1.5.10 renamed *axis* argument to *axes*
+    .. versionchanged:: 1.5.10 renamed *data* argument to *mode*
     """
 
     self._variator = None
@@ -113,6 +120,8 @@ class KollmorgenAKDPDMM(InOut):
 
     If more commands than motors are given, the extra commands are ignored. If
     there are more motors than commands, only part of the motors will be set.
+    
+    .. versionadded:: 1.5.10
     """
 
     for axis, val in zip(self._axes, cmd):

--- a/src/crappy/inout/labjack_t7.py
+++ b/src/crappy/inout/labjack_t7.py
@@ -68,6 +68,9 @@ class LabjackT7(InOut):
 
   This class is not capable of streaming. For higher frequency, refer to the
   :class:`~crappy.inout.T7Streamer` class.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Labjack_t7 to LabjackT7
   """
 
   def __init__(self,
@@ -343,6 +346,8 @@ class LabjackT7(InOut):
     Args:
       delay: The delay during which the data should be acquired for determining
         the offset.
+    
+    .. versionadded:: 1.5.10
     """
 
     # No need to acquire data if no channel should be zeroed

--- a/src/crappy/inout/labjack_t7_streamer.py
+++ b/src/crappy/inout/labjack_t7_streamer.py
@@ -65,6 +65,9 @@ class T7Streamer(InOut):
     The ``streamer`` argument of the IOBlock controlling this InOut must be set
     to :obj:`True` to enable streaming in this class. Otherwise, only single
     point acquisition can be performed.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from T7_streamer to T7Streamer
   """
 
   def __init__(self,
@@ -215,6 +218,8 @@ class T7Streamer(InOut):
 
     It simply performs the regular zeroing, and resets the compensation for the
     channels that shouldn't be zeroed.
+    
+    .. versionadded:: 1.5.10
     """
 
     # No need to acquire data if no channel should be zeroed

--- a/src/crappy/inout/labjack_ue9.py
+++ b/src/crappy/inout/labjack_ue9.py
@@ -33,6 +33,9 @@ class LabjackUE9(InOut):
   UE9. The UE9 model has been discontinued, and replaced by the T7 model (see
   :class:`~crappy.inout.LabjackT7`). It is thus likely that this class won't be
   further improved in the future.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Labjack_ue9 to LabjackUE9
   """
 
   def __init__(self,
@@ -110,6 +113,8 @@ class LabjackUE9(InOut):
 
     It simply performs the regular zeroing, and resets the compensation to
     zero for the channels that shouldn't be zeroed.
+    
+    .. versionadded:: 1.5.10
     """
 
     # No need to acquire data if no channel should be zeroed

--- a/src/crappy/inout/mcp9600.py
+++ b/src/crappy/inout/mcp9600.py
@@ -97,6 +97,9 @@ class MCP9600(InOut):
   operating mode that returns Volts. Several parameters can be tuned, like the
   thermocouple type, the reading resolution or the filter coefficient. Note
   that the MCP9600 can only achieve a data rate of a few Hz.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Mcp9600 to MCP9600
   """
 
   def __init__(self,
@@ -164,6 +167,7 @@ class MCP9600(InOut):
           'Cold Junction Temperature',
           'Raw Data ADC'
 
+    .. versionremoved:: 2.0.0 *ft232h_ser_num* argument
     """
 
     self._bus = None

--- a/src/crappy/inout/meta_inout/inout.py
+++ b/src/crappy/inout/meta_inout/inout.py
@@ -16,12 +16,17 @@ class InOut(metaclass=MetaIO):
 
   The InOut objects are helper classes used by the
   :class:`~crappy.blocks.IOBlock` to interface with hardware.
+  
+  .. versionadded:: 1.4.0
   """
 
   ft232h: bool = False
 
   def __init__(self, *_, **__) -> None:
-    """Sets the attributes."""
+    """Sets the attributes.
+    
+    .. versionchanged:: 2.0.0 now accepts args and kwargs
+    """
 
     self._compensations: List[float] = list()
     self._compensations_dict: Dict[str, float] = dict()
@@ -35,6 +40,8 @@ class InOut(metaclass=MetaIO):
     Args:
       level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:
@@ -54,6 +61,8 @@ class InOut(metaclass=MetaIO):
     Blocks.
 
     It is fine for this method not to perform anything.
+
+    .. versionadded:: 1.5.10
     """
 
     ...
@@ -93,6 +102,8 @@ class InOut(metaclass=MetaIO):
 
     It is alright for this method to return :obj:`None` if there's no data to
     acquire.
+    
+    .. versionadded:: 1.5.10
     """
 
     self.log(logging.WARNING,
@@ -116,6 +127,8 @@ class InOut(metaclass=MetaIO):
       If ``{'t(s)': 20.5, 'value_1': 1.5, 'value_2': 3.6, 'value_3': 'OK'}`` is
       received from upstream Blocks, and ``cmd_labels=('value_3', 'value_1')``,
       then the call will be ``set_cmd('OK', 1.5)``.
+
+    .. versionadded:: 1.5.10
     """
 
     self.log(logging.WARNING,
@@ -125,7 +138,10 @@ class InOut(metaclass=MetaIO):
     return
 
   def start_stream(self) -> None:
-    """This method should start the acquisition of the stream."""
+    """This method should start the acquisition of the stream.
+
+    .. versionadded:: 1.5.10
+    """
 
     self.log(logging.WARNING, "The start_stream method was called but is not "
                               "defined !")
@@ -161,6 +177,8 @@ class InOut(metaclass=MetaIO):
       It is technically  possible to return more than two arrays, or even
       objects that are not arrays, but it is not the intended use for this
       method and might interfere with some functionalities of Crappy.
+
+    .. versionadded:: 1.5.10
     """
 
     self.log(logging.WARNING, "The get_stream method was called but is not "
@@ -169,7 +187,10 @@ class InOut(metaclass=MetaIO):
     return
 
   def stop_stream(self) -> None:
-    """This method should stop the acquisition of the stream."""
+    """This method should stop the acquisition of the stream.
+
+    .. versionadded:: 1.5.10
+    """
 
     self.log(logging.WARNING, "The stop_stream method was called but is not "
                               "defined !")
@@ -184,6 +205,8 @@ class InOut(metaclass=MetaIO):
     path, or because an exception was raised in any of the Blocks).
 
     It is fine for this method not to perform anything.
+
+    .. versionadded:: 1.5.10
     """
 
     ...
@@ -199,6 +222,8 @@ class InOut(metaclass=MetaIO):
       This method uses :meth:`get_data` for acquiring the values, so it doesn't
       work for pure streams. It also doesn't work if the acquired values do not
       support arithmetic operations (like :obj:`str`).
+
+    .. versionadded:: 1.5.10
     """
 
     buf = []
@@ -260,7 +285,10 @@ class InOut(metaclass=MetaIO):
   def return_data(self) -> Optional[Union[List[Any], Dict[str, Any]]]:
     """Returns the data from :meth:`get_data`, corrected by an offset if the
     ``make_zero_delay`` argument of the :class:`~crappy.blocks.IOBlock` is
-    set."""
+    set.
+
+    .. versionadded:: 1.5.10
+    """
 
     data = self.get_data()
 
@@ -313,7 +341,10 @@ class InOut(metaclass=MetaIO):
                                             Dict[str, np.ndarray]]]:
     """Returns the data from :meth:`get_stream`, corrected by an offset if the
     ``make_zero_delay`` argument of the :class:`~crappy.blocks.IOBlock` is
-    set."""
+    set.
+
+    .. versionadded:: 1.5.10
+    """
 
     data = self.get_stream()
 

--- a/src/crappy/inout/meta_inout/inout.py
+++ b/src/crappy/inout/meta_inout/inout.py
@@ -132,8 +132,8 @@ class InOut(metaclass=MetaIO):
 
   def get_stream(self) -> Optional[Union[Iterable[np.ndarray],
                                          Dict[str, np.ndarray]]]:
-    """This method should acquire a stream as a numpy array, and return it
-    along with an array carrying the timestamps.
+    """This method should acquire a stream as a :obj:`numpy.array`, and return
+    it along with another array carrying the timestamps.
 
     Two arrays should be created: one of dimension `(m,)` carrying the
     timestamps, and one of dimension `(m, n)` carrying the acquired data. They

--- a/src/crappy/inout/meta_inout/meta_inout.py
+++ b/src/crappy/inout/meta_inout/meta_inout.py
@@ -6,7 +6,12 @@ from ..._global import DefinitionError
 class MetaIO(type):
   """Metaclass ensuring that two InOuts don't have the same name, and that all
   InOuts define the required methods. Also keeps track of all the InOut
-  classes, including the custom user-defined ones."""
+  classes, including the custom user-defined ones.
+
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10
+     not checking anymore for mandatory methods in :meth:`__init__`
+  """
 
   classes = dict()
 

--- a/src/crappy/inout/mprls.py
+++ b/src/crappy/inout/mprls.py
@@ -43,6 +43,9 @@ class MPRLS(InOut):
   """This class can read values from an MPRLS pressure sensor.
 
   It communicates over I2C with the sensor.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Mprls to MPRLS
   """
 
   def __init__(self,
@@ -76,6 +79,11 @@ class MPRLS(InOut):
         another address.
       i2c_port: The I2C port over which the MPRLS should communicate. On most
         Raspberry Pi models the default I2C port is `1`.
+    
+    .. versionadded:: 1.5.8
+       *backend*, *eoc_pin*, *device_address*, *i2c_port* and *ft232h_ser_num*
+       arguments
+    .. versionremoved:: 2.0.0 *ft232h_ser_num* argument
     """
 
     self._bus = None

--- a/src/crappy/inout/nau7802.py
+++ b/src/crappy/inout/nau7802.py
@@ -111,6 +111,9 @@ class NAU7802(InOut):
   that can read up to 320 samples per second. It communicates over the I2C
   protocol. The returned value of the InOut is in Volts by default, but can be
   converted to Newtons using the ``gain`` and ``offset`` arguments.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Nau7802 to NAU7802
   """
 
   def __init__(self,
@@ -151,6 +154,9 @@ class NAU7802(InOut):
         :math:`output = gain * tension + offset`.
       offset: Allows to tune the output value according to the formula :
         :math:`output = gain * tension + offset`.
+      
+    .. versionadded:: 1.5.8 *int_pin* argument
+    .. versionremoved:: 2.0.0 *backend* and *ft232h_ser_num* arguments
     """
 
     self._bus = None

--- a/src/crappy/inout/ni_daqmx.py
+++ b/src/crappy/inout/ni_daqmx.py
@@ -69,6 +69,9 @@ class NIDAQmx(InOut):
   of data from analog channels, and set the voltage of analog and digital
   output channels. For analog input channels, several types of acquisition can
   be performed, like voltage, resistance, current, etc.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Nidaqmx to NIDAQmx
   """
 
   def __init__(self,
@@ -125,6 +128,9 @@ class NIDAQmx(InOut):
           internally. Also note that for the analog output channels and the
           analog input channels of type `'voltage'`, the `'min_val'` and
           `'max_val'` arguments are internally set by default to `0` and `5`.
+    
+    .. versionchanged:: 1.5.10 renamed *samplerate* argument to *sample_rate*
+    .. versionchanged:: 1.5.10 renamed *nsamples* argument to *n_samples*
     """
 
     super().__init__()

--- a/src/crappy/inout/opsens_handysens.py
+++ b/src/crappy/inout/opsens_handysens.py
@@ -19,6 +19,9 @@ class HandySens(InOut):
 
   It can read data from various fiber optics sensors like temperature,
   pressure, position or strain.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Opsens to HandySens
   """
 
   def __init__(self,

--- a/src/crappy/inout/pijuice_hat.py
+++ b/src/crappy/inout/pijuice_hat.py
@@ -49,6 +49,9 @@ class PiJuice(InOut):
 
   Warning:
     Only available on Raspberry Pi !
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Pijuice to PiJuice
   """
 
   def __init__(self,
@@ -67,6 +70,8 @@ class PiJuice(InOut):
         `'pijuice'` backend is based on the :mod:`pijuice` module.
       i2c_port: The I2C port over which the PiJuice should communicate.
       address: The I2C address of the piJuice. The default address is `0x14`.
+    
+    .. versionadded:: 1.5.10 *backend* argument
     """
 
     self._bus = None

--- a/src/crappy/inout/sim868.py
+++ b/src/crappy/inout/sim868.py
@@ -23,6 +23,9 @@ class Sim868(InOut):
   Important:
     This InOut should be associated with a :class:`~crappy.modifier.Modifier`
     to manage the messages to send.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Gsm to Sim868
   """
 
   def __init__(self,
@@ -45,6 +48,8 @@ class Sim868(InOut):
       pin_code: Optionally, a pin code to use for activating the SIM card.
       registration_timeout: The maximum number of seconds to allow for the
         Sim868 to register to a network once the SIM card has the ready status.
+    
+    .. versionadded:: 2.0.0 *pin_code* and *registration_timeout* arguments
     """
 
     self._ser = None

--- a/src/crappy/inout/spectrum_m2i4711.py
+++ b/src/crappy/inout/spectrum_m2i4711.py
@@ -19,6 +19,9 @@ class SpectrumM2I4711(InOut):
 
   This class can only acquire data by streaming, it cannot acquire single data
   points.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Spectrum to SpectrumM2I4711
   """
 
   def __init__(self,
@@ -46,6 +49,9 @@ class SpectrumM2I4711(InOut):
         the data from the card, in bytes. The default is 67MB.
       notify_size: The size of each chunk of data to copy from the card, in
         bytes. The default is 65kB.
+    
+    .. versionchanged:: 1.5.10 renamed *samplerate* argument to *sample_rate*
+    .. versionremoved:: 1.5.10 *split_chan* argument
     """
 
     self._spectrum = None

--- a/src/crappy/inout/waveshare_ad_da.py
+++ b/src/crappy/inout/waveshare_ad_da.py
@@ -96,6 +96,9 @@ class WaveshareADDA(InOut):
 
   Important:
     This class is specifically meant to be used on a Raspberry Pi.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Waveshare_ad_da to WaveshareADDA
   """
 
   def __init__(self,

--- a/src/crappy/inout/waveshare_high_precision.py
+++ b/src/crappy/inout/waveshare_high_precision.py
@@ -113,6 +113,10 @@ class WaveshareHighPrecision(InOut):
   The Waveshare HAT is originally meant to be used with a Raspberry Pi, but it
   can be used with any device supporting SPI as long as the wiring is correct
   and the 3.3 and 5V power are supplied.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0
+     renamed from Waveshare_high_precision to WaveshareHighPrecision
   """
 
   def __init__(self,

--- a/src/crappy/lamcube/biaxe.py
+++ b/src/crappy/lamcube/biaxe.py
@@ -16,6 +16,8 @@ class Biaxe(Actuator):
   It is used at the LaMcube for driving a bi-axial tensile test machine, hence
   its name. The :class:`~crappy.actuator.ServoStar300` Actuator can drive the
   same hardware, but only in position.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -64,7 +66,10 @@ class Biaxe(Actuator):
       self._speed = speed
 
   def stop(self) -> None:
-    """Sets the speed of the motor to `0`"""
+    """Sets the speed of the motor to `0`.
+    
+    .. versionadded:: 2.0.0
+    """
 
     if self._ser is not None:
       self.set_speed(0)

--- a/src/crappy/lamcube/bispectral.py
+++ b/src/crappy/lamcube/bispectral.py
@@ -83,6 +83,9 @@ class BiSpectral(BaslerIronmanCameraLink):
     This Camera relies on a custom-written C library that hasn't been tested in
     a long time. It might not be functional anymore. This Camera also requires
     proprietary drivers to be installed.
+    
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Bispectral to BiSpectral
   """
 
   def __init__(self) -> None:
@@ -102,7 +105,10 @@ class BiSpectral(BaslerIronmanCameraLink):
   def open(self,
            camera_type: str = 'SingleAreaGray2DShading',
            **kwargs) -> None:
-    """Opens the Camera and sends initialization commands."""
+    """Opens the Camera and sends initialization commands.
+    
+    .. versionadded:: 1.5.10 explicitly listing *camera_type* argument
+    """
 
     super().open(camera_type=camera_type, **kwargs)
 

--- a/src/crappy/links/link.py
+++ b/src/crappy/links/link.py
@@ -28,6 +28,8 @@ class Link:
     modify the transferred value. The Modifiers should be callables taking a
     :obj:`dict` as argument and returning a :obj:`dict`. They can be functions,
     or preferably children of :class:`~crappy.modifier.Modifier`.
+  
+  .. versionadded:: 1.4.0
   """
 
   _count = 0
@@ -48,6 +50,10 @@ class Link:
       name: Name of the Link, to differentiate it from the others when
         debugging. If no specific name is given, the Links are numbered in the
         order in which they are instantiated in the script.
+    
+    .. versionchanged:: 1.5.9 renamed *condition* argument to *conditions*
+    .. versionchanged:: 1.5.9 renamed *modifier* argument to *modifiers*
+    .. versionremoved:: 2.0.0 *conditions*, *timeout* and *action* arguments
     """
 
     if modifiers is None:
@@ -89,6 +95,8 @@ class Link:
     Args:
       log_level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:
@@ -98,7 +106,10 @@ class Link:
     self._logger.log(log_level, msg)
 
   def poll(self) -> bool:
-    """Returns :obj:`True` if there's data available for reading."""
+    """Returns :obj:`True` if there's data available for reading.
+    
+    .. versionadded:: 2.0.0
+    """
 
     return self._in.poll()
 
@@ -145,6 +156,8 @@ class Link:
     Returns:
       A :obj:`dict` whose keys are the labels being sent, and for each key a
       single value (usually a :obj:`float` or a :obj:`str`).
+      
+    .. versionremoved:: 2.0.0 *blocking* argument
     """
 
     if self._in.poll():
@@ -161,6 +174,8 @@ class Link:
     Returns:
       A :obj:`dict` whose keys are the labels being sent, and for each key a
       single value (usually a :obj:`float` or a :obj:`str`).
+    
+    .. versionremoved:: 2.0.0 *blocking* argument
     """
 
     data = dict()
@@ -177,6 +192,10 @@ class Link:
       A :obj:`dict` whose keys are the labels being sent, and for each key a
       :obj:`list` of the received values. The first item in the list is the
       oldest one available in the Link, the last item is the newest available.
+    
+    .. versionremoved:: 1.5.9 *length* argument
+    .. versionadded:: 1.5.9 *blocking* argument
+    .. versionremoved:: 2.0.0 *blocking* argument
     """
 
     ret = defaultdict(list)
@@ -214,6 +233,12 @@ def link(in_block,
     name: Name of the Link, to differentiate it from the others when debugging.
       If no specific name is given, the Links are numbered in the order in
       which they are instantiated in the script.
+      
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.9
+     explicitly listing the *condition*, *modifier*, *timeout*, *action* and
+     *name* arguments
+  .. versionremoved:: 2.0.0 *condition*, *timeout* and *action* arguments
   """
 
   # Forcing the modifiers into lists

--- a/src/crappy/modifier/demux.py
+++ b/src/crappy/modifier/demux.py
@@ -26,6 +26,8 @@ class Demux(Modifier):
     information is lost ! This Modifier is intended to format the stream data
     for low-frequency plotting, or low-frequency decision-making. To save all
     the stream data, use the :class:`~crappy.blocks.HDFRecorder` Block.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self,
@@ -49,6 +51,8 @@ class Demux(Modifier):
       time_label: The label carrying the time information.
       transpose: If :obj:`True`, each label corresponds to a row in the stream.
         Otherwise, a label corresponds to a column in the stream.
+    
+    .. versionchanged:: 1.5.10 renamed *stream* argument to *stream_label*
     """
 
     super().__init__()
@@ -64,7 +68,12 @@ class Demux(Modifier):
 
   def __call__(self, data: Dict[str, np.ndarray]) -> Dict[str, Any]:
     """Retrieves for each label its value in the stream, also gets the
-    corresponding timestamp, and returns them."""
+    corresponding timestamp, and returns them.
+    
+    .. versionchanged:: 1.5.10 
+       merge evaluate_mean and evaluate_nomean methods into evaluate
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/modifier/demux.py
+++ b/src/crappy/modifier/demux.py
@@ -16,10 +16,10 @@ class Demux(Modifier):
   the stream to make it readable by most Blocks, and also splits the stream in
   several labels if necessary.
 
-  It takes a stream as an input, i.e. a :obj:`dict` whose values are numpy
-  arrays, and outputs another :obj:`dict` whose values are :obj:`float`. If the
-  numpy arrays contains several columns (corresponding to several acquired
-  channels), it splits them into several labels.
+  It takes a stream as an input, i.e. a :obj:`dict` whose values are
+  :obj:`numpy.array`, and outputs another :obj:`dict` whose values are
+  :obj:`float`. If the numpy arrays contains several columns (corresponding to
+  several acquired channels), it splits them into several labels.
 
   Important:
     In the process of converting the stream data to regular labeled data, much

--- a/src/crappy/modifier/differentiate.py
+++ b/src/crappy/modifier/differentiate.py
@@ -8,7 +8,10 @@ from .meta_modifier import Modifier
 
 class Diff(Modifier):
   """This Modifier calculates the time derivative of a given label and adds the
-  derivative to the returned data."""
+  derivative to the returned data.
+  
+  .. versionadded:: 1.4.0
+  """
 
   def __init__(self,
                label: str,
@@ -21,6 +24,8 @@ class Diff(Modifier):
       time_label: The label carrying the time information.
       out_label: The label carrying the calculated derivative. If not given,
         defaults to ``'d_<label>'``.
+
+    .. versionchanged:: 1.5.10 renamed *time* argument to *time_label*
     """
 
     super().__init__()
@@ -33,7 +38,10 @@ class Diff(Modifier):
 
   def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
     """Gets the data from the upstream Block, updates the derivative value,
-    appends it to the data and returns the data."""
+    appends it to the data and returns the data.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/modifier/integrate.py
+++ b/src/crappy/modifier/integrate.py
@@ -8,7 +8,10 @@ from .meta_modifier import Modifier
 
 class Integrate(Modifier):
   """This Modifier integrates the data of a label over time and adds the
-  integration value to the returned data."""
+  integration value to the returned data.
+  
+  .. versionadded:: 1.4.0
+  """
 
   def __init__(self,
                label: str,
@@ -21,6 +24,8 @@ class Integrate(Modifier):
       time_label: The label carrying the time information.
       out_label: The label carrying the integration value. If not given,
         defaults to ``'i_<label>'``.
+
+    .. versionchanged:: 1.5.10 renamed *time* argument to *time_label*
     """
 
     super().__init__()
@@ -34,7 +39,10 @@ class Integrate(Modifier):
 
   def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
     """Gets the data from the upstream Block, updates the integration value,
-    adds it to the data and returns the data."""
+    adds it to the data and returns the data.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/modifier/mean.py
+++ b/src/crappy/modifier/mean.py
@@ -13,6 +13,8 @@ class Mean(Modifier):
 
   Unlike :class:`~crappy.modifier.MovingAvg`, it only returns a value once
   every ``n_points`` points.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self, n_points: int = 100) -> None:
@@ -20,6 +22,8 @@ class Mean(Modifier):
 
     Args:
       n_points: The number of points on which to compute the average.
+    
+    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
     """
 
     super().__init__()
@@ -32,6 +36,8 @@ class Mean(Modifier):
     buffer and returns the averages.
 
     If there are not enough points, doesn't return anything.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/median.py
+++ b/src/crappy/modifier/median.py
@@ -13,6 +13,8 @@ class Median(Modifier):
 
   Unlike :class:`~crappy.modifier.MovingMed`, it only returns a value once
   every ``n_points`` points.
+  
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self, n_points: int = 100) -> None:
@@ -20,6 +22,8 @@ class Median(Modifier):
 
     Args:
       n_points: The number of points on which to compute the median.
+
+    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
     """
 
     super().__init__()
@@ -32,6 +36,8 @@ class Median(Modifier):
     buffer and returns the medians.
 
     If there are not enough points, doesn't return anything.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/meta_modifier/meta_modifier.py
+++ b/src/crappy/modifier/meta_modifier/meta_modifier.py
@@ -5,7 +5,12 @@ from ..._global import DefinitionError
 
 class MetaModifier(type):
   """Metaclass keeping track of all the Modifiers, including the custom
-  user-defined ones."""
+  user-defined ones.
+
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10
+     not checking anymore for mandatory method in :meth:`__init__`
+  """
 
   classes = {}
 

--- a/src/crappy/modifier/meta_modifier/modifier.py
+++ b/src/crappy/modifier/meta_modifier/modifier.py
@@ -19,10 +19,15 @@ class Modifier(metaclass=MetaModifier):
   It is preferable for every Modifier to be a child of this class, although
   that is not mandatory. A Modifier only needs to be a callable, i.e. a class
   defining the :meth:`__call__` method or a function.
+
+  .. versionadded:: 1.4.0
   """
 
   def __init__(self, *_, **__) -> None:
-    """Sets the logger attribute."""
+    """Sets the logger attribute.
+
+    .. versionchanged:: 2.0.0 now accepts args and kwargs
+    """
 
     self._logger: Optional[logging.Logger] = None
 
@@ -42,6 +47,8 @@ class Modifier(metaclass=MetaModifier):
       Data to send to the output :class:`~crappy.blocks.Block`, as a
       :obj:`dict`. It is also fine for this method to return :obj:`None`, in
       which case no message is transmitted to the output Block.
+
+    .. versionadded:: 2.0.0
     """
 
     self.log(logging.DEBUG, f"Received {data}")
@@ -58,6 +65,8 @@ class Modifier(metaclass=MetaModifier):
     Args:
       level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:

--- a/src/crappy/modifier/moving_avg.py
+++ b/src/crappy/modifier/moving_avg.py
@@ -13,6 +13,9 @@ class MovingAvg(Modifier):
 
   Unlike :class:`~crappy.modifier.Mean`, it returns a value each time data is
   received from the upstream Block.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Moving_avg to MovingAvg
   """
 
   def __init__(self, n_points: int = 100) -> None:
@@ -20,6 +23,8 @@ class MovingAvg(Modifier):
 
     Args:
       n_points: The maximum number of points on which to compute the average.
+    
+    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
     """
 
     super().__init__()
@@ -28,7 +33,10 @@ class MovingAvg(Modifier):
 
   def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
     """Receives data from the upstream Block, computes the average of every
-    label and replaces the original data with it."""
+    label and replaces the original data with it.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/modifier/moving_med.py
+++ b/src/crappy/modifier/moving_med.py
@@ -13,6 +13,9 @@ class MovingMed(Modifier):
 
   Unlike :class:`~crappy.modifier.Median`, it returns a value each time data is
   received from the upstream Block.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Moving_med to MovingMed
   """
 
   def __init__(self, n_points: int = 100) -> None:
@@ -20,6 +23,8 @@ class MovingMed(Modifier):
 
     Args:
       n_points: The maximum number of points on which to compute the median.
+    
+    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
     """
 
     super().__init__()
@@ -28,7 +33,10 @@ class MovingMed(Modifier):
 
   def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
     """Receives data from the upstream Block, computes the median of every
-    label and replaces the original data with it."""
+    label and replaces the original data with it.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/modifier/offset.py
+++ b/src/crappy/modifier/offset.py
@@ -21,6 +21,8 @@ class Offset(Modifier):
   single data point for the offset calculation. The ``make_zero`` argument of
   the :class:`~crappy.blocks.IOBlock` is a better alternative if precision is
   required when offsetting a sensor.
+  
+  .. versionadded:: 1.5.10
   """
 
   def __init__(self,
@@ -60,7 +62,10 @@ class Offset(Modifier):
 
   def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
     """If the compensations are not set, sets them, and then offsets the
-    required labels."""
+    required labels.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/modifier/trig_on_change.py
+++ b/src/crappy/modifier/trig_on_change.py
@@ -12,6 +12,9 @@ class TrigOnChange(Modifier):
 
   It also transmits the first received data. Can be used to trigger a Block
   upon change of a label value.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Trig_on_change to TrigOnChange
   """
 
   def __init__(self, label: str) -> None:
@@ -19,6 +22,8 @@ class TrigOnChange(Modifier):
 
     Args:
       label: The name of the label to monitor.
+    
+    .. versionchanged:: 1.5.10 renamed *name* argument to *label*
     """
 
     super().__init__()
@@ -27,7 +32,10 @@ class TrigOnChange(Modifier):
 
   def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Compares the received value with the last sent one, and if they're
-    different sends the received data and stores the latest value."""
+    different sends the received data and stores the latest value.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/modifier/trig_on_value.py
+++ b/src/crappy/modifier/trig_on_value.py
@@ -11,6 +11,9 @@ class TrigOnValue(Modifier):
   carried by a given label matches a given set of accepted values.
 
   Mostly useful to trigger Blocks in predefined situations.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Trig_on_value to TrigOnValue
   """
 
   def __init__(self,
@@ -23,6 +26,8 @@ class TrigOnValue(Modifier):
       values: The values of ``label`` for which the data will be transmitted.
         Can be a single value, or an iterable of values (like a :obj:`list` or
         a :obj:`tuple`).
+
+    .. versionchanged:: 1.5.10 renamed *name* argument to *label*
     """
 
     super().__init__()
@@ -41,7 +46,10 @@ class TrigOnValue(Modifier):
 
   def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Checks if the value of ``label`` is in the predefined set of accepted
-    values, and if so transmits the data."""
+    values, and if so transmits the data.
+    
+    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    """
 
     self.log(logging.DEBUG, f"Received {data}")
 

--- a/src/crappy/tool/apply_strain_image.py
+++ b/src/crappy/tool/apply_strain_image.py
@@ -16,6 +16,8 @@ class ApplyStrainToImage:
 
   Its main use case is for generating example scripts that do not require any
   hardware to run.
+  
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -51,6 +51,9 @@ class CameraConfig(tk.Tk):
   :class:`~crappy.tool.camera_config.config_tools.HistogramProcess` tools. It
   also interacts with instances of the 
   :class:`~crappy.camera.meta_camera.camera_setting.CameraSetting` class.
+
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from Camera_config to CameraConfig
   """
 
   def __init__(self,
@@ -70,6 +73,8 @@ class CameraConfig(tk.Tk):
       max_freq: The maximum frequency this window is allowed to loop at. It is
         simply the ``freq`` attribute of the :class:`~crappy.blocks.Camera`
         Block.
+    
+    .. versionadded:: 2.0.0 *log_queue*, *log_level* and *max_freq* arguments
     """
 
     super().__init__()
@@ -124,7 +129,10 @@ class CameraConfig(tk.Tk):
 
   def main(self) -> None:
     """Constantly updates the image and the information on the GUI, until asked
-    to stop."""
+    to stop.
+    
+    .. versionadded:: 1.5.10
+    """
 
     # Starting the histogram calculation process
     self._histogram_process.start()
@@ -154,6 +162,8 @@ class CameraConfig(tk.Tk):
     Args:
       level: An :obj:`int` indicating the logging level of the message.
       msg: The message to log, as a :obj:`str`.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._logger is None:
@@ -164,7 +174,10 @@ class CameraConfig(tk.Tk):
 
   def report_callback_exception(self, exc: Exception, val: str, tb) -> None:
     """Method displaying an error message in case an exception is raised in a
-    :mod:`tkinter` callback."""
+    :mod:`tkinter` callback.
+
+    .. versionadded:: 2.0.0
+    """
 
     self._logger.exception(f"Caught exception in {type(self).__name__}: "
                            f"{exc.__name__}({val})", exc_info=tb)
@@ -174,6 +187,8 @@ class CameraConfig(tk.Tk):
     """Method called when the user tries to close the configuration window.
 
     Mostly intended for being overwritten.
+    
+    .. versionadded:: 2.0.0
     """
 
     self.stop()
@@ -182,6 +197,8 @@ class CameraConfig(tk.Tk):
     """Method called for gracefully stopping the GUI.
 
     Stops the process calculating the histogram, and destroys the GUI.
+
+    .. versionadded:: 2.0.0
     """
 
     # Stopping the event loop and the histogram process

--- a/src/crappy/tool/camera_config/camera_config_boxes.py
+++ b/src/crappy/tool/camera_config/camera_config_boxes.py
@@ -21,6 +21,10 @@ class CameraConfigBoxes(CameraConfig):
   implements useful methods for drawing one or several Boxes. If instantiated,
   this class behaves the exact same way as its parent class. It is not used as
   is by any Block in Crappy.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0
+     renamed from Camera_config_with_boxes to CameraConfigBoxes
   """
 
   def __init__(self,
@@ -40,6 +44,8 @@ class CameraConfigBoxes(CameraConfig):
       max_freq: The maximum frequency this window is allowed to loop at. It is
         simply the ``freq`` attribute of the :class:`~crappy.blocks.Camera`
         Block.
+
+    .. versionadded:: 2.0.0 *log_queue*, *log_level* and *max_freq* arguments
     """
 
     self._spots = SpotsBoxes()

--- a/src/crappy/tool/camera_config/config_tools/box.py
+++ b/src/crappy/tool/camera_config/config_tools/box.py
@@ -20,6 +20,8 @@ class Box(Overlay):
 
   It can represent either the box drawn when selecting a region, or the
   bounding box of a tracked area.
+  
+  .. versionadded:: 2.0.0
   """
 
   x_start: Optional[int] = None

--- a/src/crappy/tool/camera_config/config_tools/histogram_process.py
+++ b/src/crappy/tool/camera_config/config_tools/histogram_process.py
@@ -21,6 +21,8 @@ class HistogramProcess(Process):
   its children to delegate and parallelize the calculation of the histogram. It
   allows to gain a few frames per second on the display in the configuration
   window.
+  
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/tool/camera_config/config_tools/overlay_object.py
+++ b/src/crappy/tool/camera_config/config_tools/overlay_object.py
@@ -17,6 +17,8 @@ class Overlay:
 
   It is mainly useful for providing the :meth:`log` method, and creating a
   clear architecture. It is also relevant to use for type-hinting.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self) -> None:

--- a/src/crappy/tool/camera_config/config_tools/spots_boxes.py
+++ b/src/crappy/tool/camera_config/config_tools/spots_boxes.py
@@ -16,6 +16,8 @@ class SpotsBoxes:
 
   It can also instantiate the Box objects by parsing a list of tuples
   containing enough information.
+
+  .. versionadded:: 2.0.0
   """
 
   spot_1: Optional[Box] = None

--- a/src/crappy/tool/camera_config/config_tools/spots_detector.py
+++ b/src/crappy/tool/camera_config/config_tools/spots_detector.py
@@ -33,6 +33,8 @@ class SpotsDetector:
   the detected spots, to pass them later on to the
   :class:`~crappy.tool.image_processing.video_extenso.VideoExtensoTool` along
   with other variables once the CameraConfig window is closed.
+
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/tool/camera_config/config_tools/zoom.py
+++ b/src/crappy/tool/camera_config/config_tools/zoom.py
@@ -10,6 +10,8 @@ class Zoom:
 
   It also allows updating them when the user changes the zoom ratio or drags
   the image with the mouse.
+
+  .. versionadded:: 2.0.0
   """
 
   x_low: float = 0.

--- a/src/crappy/tool/camera_config/dic_ve_config.py
+++ b/src/crappy/tool/camera_config/dic_ve_config.py
@@ -29,6 +29,9 @@ class DICVEConfig(CameraConfigBoxes):
   It relies on the :class:`~crappy.tool.camera_config.config_tools.Box` and 
   :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` tools. It is
   meant to be used for configuring the :class:`~crappy.blocks.DICVE` Block.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0 renamed from DISVE_config to DICVEConfig
   """
 
   def __init__(self,
@@ -52,6 +55,8 @@ class DICVEConfig(CameraConfigBoxes):
       patches: An instance of
         :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` containing
         the patches to follow for image correlation.
+    
+    .. versionadded:: 2.0.0 *log_queue*, *log_level* and *max_freq* arguments
     """
 
     self._patch_size: Optional[CameraScaleSetting] = None
@@ -67,6 +72,8 @@ class DICVEConfig(CameraConfigBoxes):
     Check that patches were selected on the image. If not, warns the user and
     prevents him from exiting except with CTRL+C. If not already done by the
     user, also saves the initial length between the patches.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._spots.empty():

--- a/src/crappy/tool/camera_config/dis_correl_config.py
+++ b/src/crappy/tool/camera_config/dis_correl_config.py
@@ -28,6 +28,9 @@ class DISCorrelConfig(CameraConfigBoxes):
   It relies on the :class:`~crappy.tool.camera_config.config_tools.Box` tool. 
   It is meant to be used for configuring the :class:`~crappy.blocks.DISCorrel` 
   Block.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from DISConfig to DISCorrelConfig
   """
 
   def __init__(self,
@@ -51,6 +54,9 @@ class DISCorrelConfig(CameraConfigBoxes):
       patch: The :class:`~crappy.tool.camera_config.config_tools.Box` container
         that will save the information on the patch where to perform image
         correlation.
+        
+    .. versionadded:: 2.0.0
+       *patch*, *log_queue*, *log_level* and *max_freq* arguments
     """
 
     self._correl_box = patch
@@ -61,7 +67,10 @@ class DISCorrelConfig(CameraConfigBoxes):
   @property
   def box(self) -> Box:
     """Returns the :class:`~crappy.tool.camera_config.config_tools.Box` object
-    containing the region of interest."""
+    containing the region of interest.
+    
+    .. versionadded:: 1.5.10
+    """
 
     return self._correl_box
 
@@ -70,6 +79,8 @@ class DISCorrelConfig(CameraConfigBoxes):
 
     Checks that a patch was selected on the image. If not, warns the user and
     prevents him from exiting except with CTRL+C.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self.box.no_points():

--- a/src/crappy/tool/camera_config/video_extenso_config.py
+++ b/src/crappy/tool/camera_config/video_extenso_config.py
@@ -31,6 +31,9 @@ class VideoExtensoConfig(CameraConfigBoxes):
   :class:`~crappy.tool.camera_config.config_tools.SpotsDetector` tools. It is
   meant to be used for configuring the :class:`~crappy.blocks.VideoExtenso`
   Block.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from VE_config to VideoExtensoConfig
   """
 
   def __init__(self,
@@ -55,6 +58,11 @@ class VideoExtensoConfig(CameraConfigBoxes):
         :class:`~crappy.tool.camera_config.config_tools.SpotsDetector` used for
         detecting spots on the images received from the
         :class:`~crappy.camera.Camera`.
+
+    .. versionchanged:: 1.5.10 renamed *ve* argument to *video_extenso*
+    .. versionadded:: 2.0.0
+       *detector*, *log_queue*, *log_level* and *max_freq* arguments
+    .. versionremoved:: 2.0.0 *video_extenso* argument
     """
 
     super().__init__(camera, log_queue, log_level, max_freq)
@@ -67,6 +75,8 @@ class VideoExtensoConfig(CameraConfigBoxes):
     Checks that spots were detected on the image. If not, warns the user and
     prevents him from exiting except with CTRL+C. Also, saves the initial
     length if not already done by the user.
+    
+    .. versionadded:: 2.0.0
     """
 
     if self._detector.spots.empty():

--- a/src/crappy/tool/ft232h/ft232h.py
+++ b/src/crappy/tool/ft232h/ft232h.py
@@ -114,7 +114,12 @@ ft232h_i2c_speed = {100E3: ft232h_i2c_timings(4.0E-6, 4.7E-6, 4.0E-6, 4.7E-6),
 
 class FindSerialNumber:
   """A class used for finding USB devices matching a given serial number, using
-     the usb.core.find method."""
+     the usb.core.find method.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0
+     renamed from Find_serial_number to FindSerialNumber
+  """
 
   def __init__(self, serial_number: str) -> None:
     self.serial_number = serial_number
@@ -158,6 +163,9 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     necessary to set their USB serial numbers. Otherwise, an error will be
     raised. This can be done using the crappy utility
     ``set_ft232h_serial_nr.py``.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0 renamed from ft232h to FT232H
   """
 
   class BitMode(IntEnum):

--- a/src/crappy/tool/ft232h/ft232h_server.py
+++ b/src/crappy/tool/ft232h/ft232h_server.py
@@ -104,6 +104,8 @@ class DelayedKeyboardInterrupt:
 
   It is meant to avoid having a I2C or SPI communication interrupted, which 
   could cause devices to bug and not be able to properly finish.
+  
+  .. versionadded:: 2.0.0
   """
 
   def __enter__(self) -> None:
@@ -168,6 +170,9 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     necessary to set their USB serial numbers. Otherwise, an error will be
     raised. This can be done using the crappy utility
     ``set_ft232h_serial_nr.py``.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0 renamed from ft232h_server to FT232HServer
   """
 
   def __init__(self,
@@ -234,7 +239,11 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
         due to different hardware requirements for the two protocols. Trying to
         do so will most likely raise an error or lead to inconsistent behavior.
 
-        """
+    .. versionchanged:: 2.0.0 renamed *block_number* argument to *block_index*
+    .. versionchanged:: 2.0.0
+       renamed *current_file* argument to *current_block*
+    .. versionchanged:: 2.0.0 renamed *current_lock* argument to *shared_lock*
+    """
 
     self._block_index = block_index
     self._current_block = current_block

--- a/src/crappy/tool/ft232h/i2c_message.py
+++ b/src/crappy/tool/ft232h/i2c_message.py
@@ -10,6 +10,9 @@ class I2CMessage:
   It is used for communication with the
   :class:`~crappy.tool.ft232h.FT232HServer`, only by the
   :class:`~crappy.inout.MPRLS` InOut.
+  
+  .. versionadded:: 1.5.10
+  .. versionchanged:: 2.0.0 renamed from i2c_msg_ft232h to I2CMessage
   """
 
   def __init__(self,

--- a/src/crappy/tool/ft232h/usb_server.py
+++ b/src/crappy/tool/ft232h/usb_server.py
@@ -57,6 +57,9 @@ class USBServer(Process):
   down.
 
   The server is a child of :obj:`multiprocessing.Process`.
+  
+  .. versionadded:: 1.5.2
+  .. versionchanged:: 2.0.0 renamed from Usb_server to USBServer
   """
 
   initialized = False
@@ -136,6 +139,8 @@ class USBServer(Process):
       A :obj:`tuple` containing the necessary information for other objects to
       communicate with the server. This information is for example given as
       arguments to :class:`~crappy.tool.ft232h.FT232HServer` objects.
+    
+    .. versionadded:: 2.0.0
     """
 
     # Initializing the synchronization objects
@@ -179,6 +184,8 @@ class USBServer(Process):
         in Windows.
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
+
+    .. versionadded:: 2.0.0 *log_queue* and *log_level* arguments
     """
 
     cls.process = cls(current_block=cls.current_block,
@@ -193,7 +200,10 @@ class USBServer(Process):
   @classmethod
   def stop_server(cls) -> None:
     """If the server was started, tries to stop it gently and if not successful
-    terminates it."""
+    terminates it.
+
+    .. versionadded:: 2.0.0
+    """
 
     if cls.process is not None:
       cls.stop_event.set()
@@ -230,6 +240,8 @@ class USBServer(Process):
     Args:
       level: The logging level of the message, as an :obj:`int`.
       msg: The message to log, as a :obj:`str`.
+
+    .. versionadded:: 2.0.0
     """
 
     if cls.logger is None:
@@ -251,6 +263,8 @@ class USBServer(Process):
     Returns:
       :obj:`True` if the Lock was successfully acquired, :obj:`False`
       otherwise.
+
+    .. versionadded:: 2.0.0
     """
 
     ret = False
@@ -304,6 +318,8 @@ class USBServer(Process):
     command, sends it to the correct USB device, reads the answer from the USB 
     device and sends it back to the Block in control. Then, does the same with 
     the next Block getting control over the server.
+
+    .. versionadded:: 2.0.0
     """
 
     self._set_logger()

--- a/src/crappy/tool/image_processing/dic_ve.py
+++ b/src/crappy/tool/image_processing/dic_ve.py
@@ -21,6 +21,9 @@ class DICVETool:
   Different algorithms are available depending on the needs. This tool is
   mainly used to perform video-extensometry on speckled surfaces, although it
   could as well be of use for other applications.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from DISVE to DICVETool
   """
 
   def __init__(self,
@@ -74,6 +77,11 @@ class DICVETool:
         image, and raises an error if that's the case.
       follow: It :obj:`True`, the patches will move to follow the displacement
         of the image.
+    
+    .. versionchanged:: 1.5.9
+       renamed *gditerations* argument to *gradient_iterations*
+    .. versionadded:: 1.5.9 *method* argument
+    .. versionremoved:: 1.5.10 *img0* and *show_image* arguments
     """
 
     # These attributes are accessed by the parent class
@@ -105,7 +113,10 @@ class DICVETool:
       self._dis = None
 
   def set_img0(self, img0: np.ndarray) -> None:
-    """Sets the reference image for the cross-correlation."""
+    """Sets the reference image for the cross-correlation.
+    
+    .. versionadded:: 1.5.10
+    """
 
     self._img0 = img0
     self._height, self._width, *_ = img0.shape
@@ -122,6 +133,8 @@ class DICVETool:
 
     Also updates the patch offsets if required, and updates the window for
     following the patches if any.
+
+    .. versionadded:: 1.5.9
     """
 
     # Making sure the reference image exists

--- a/src/crappy/tool/image_processing/dis_correl.py
+++ b/src/crappy/tool/image_processing/dis_correl.py
@@ -20,6 +20,9 @@ class DISCorrelTool:
   Dense Inverse Search correlation on each new image to get fields of interest. 
   It relies on DISFlow for the image correlation, handles the projection of the 
   image on the chosen fields, and calculates the residuals.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from DISCorrel to DISCorrelTool
   """
 
   def __init__(self,
@@ -62,6 +65,10 @@ class DISCorrelTool:
         (in pixels).
       patch_stride: Stride between neighbor patches in DISFlow. Must be
         less than patch size.
+    
+    .. versionchanged:: 1.5.10
+       renamed *gditerations* argument to *gradient_iterations*
+    .. versionadded:: 2.0.0 *box* argument
     """
 
     if fields is not None and not all((field in allowed_fields
@@ -91,7 +98,10 @@ class DISCorrelTool:
     self._dis.setPatchStride(patch_stride)
 
   def set_img0(self, img0: np.ndarray) -> None:
-    """Sets the initial image to use for the correlation."""
+    """Sets the initial image to use for the correlation.
+    
+    .. versionadded:: 1.5.10
+    """
 
     self._img0 = img0
     self._height, self._width, *_ = img0.shape
@@ -99,7 +109,11 @@ class DISCorrelTool:
 
   def set_box(self) -> None:
     """Sets the region of interest to use for the correlation, and initializes
-    other attributes."""
+    other attributes.
+
+    .. versionadded:: 1.5.10
+    .. versionremoved:: 2.0.0 *box* argument
+    """
 
     # Sets the bounding box
     x_top, x_bottom, y_left, y_right = self.box.sorted()
@@ -131,6 +145,8 @@ class DISCorrelTool:
     Returns:
       A :obj:`list` containing the data to calculate, and the residuals at the
       end if requested.
+
+    .. versionadded:: 1.5.10
     """
 
     # Making sure the reference image and the base fields were set

--- a/src/crappy/tool/image_processing/fields.py
+++ b/src/crappy/tool/image_processing/fields.py
@@ -28,6 +28,9 @@ def get_field(field_string: str,
       image for correlation.
     h: The height of the image, as an :obj:`int`.
     w: The width of the image, as an :obj:`int`.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10 renamed *s* argument to *field_string*
   """
 
   if field_string == 'x':
@@ -89,6 +92,11 @@ def get_res(ref: np.ndarray, img: np.ndarray, flow: np.ndarray) -> np.ndarray:
     ref: The reference image for calculating the optical flow.
     img: The current image for calculating the optical flow.
     flow: The calculated optical flow
+    
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10 renamed *a* argument to *img*
+  .. versionchanged:: 1.5.10 renamed *b* argument to *flow*
+  .. versionchanged:: 1.5.10 renamed *r* argument to *ref*
   """
 
   x, y = np.meshgrid(np.arange(img.shape[1]), np.arange(img.shape[0]))

--- a/src/crappy/tool/image_processing/gpu_correl.py
+++ b/src/crappy/tool/image_processing/gpu_correl.py
@@ -36,6 +36,8 @@ def interp_nearest(arr: np.ndarray, ny: int, nx: int) -> np.ndarray:
   Returns:
     A reshaped version of the input array obtained with the nearest
     interpolation.
+    
+  .. versionadded:: 1.4.0
   """
 
   # If the shape is already fine, nothing more to do
@@ -60,6 +62,14 @@ class CorrelStage:
 
   This class actually performs the GPU computation, while the calling classes
   only manage the data.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10
+     now explicitly listing the *verbose*, *iterations*, *mul* and
+     *kernel_file* arguments
+  .. versionchanged:: 1.5.10 renamed *Nfields* argument to *n_fields*
+  .. versionremoved:: 1.5.10 *show_diff*, *img*, *mask* and *fields* arguments
+  .. versionadded:: 2.0.0 *logger_name* argument
   """
 
   def __init__(self,
@@ -496,6 +506,9 @@ class GPUCorrelTool:
   obtained at stages with low resolution to initialize the computation on
   stages with higher resolution. A Newton method is used to converge towards
   an optimal solution.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from GPUCorrel to GPUCorrelTool
   """
 
   context = None
@@ -556,6 +569,14 @@ class GPUCorrelTool:
         was found to be an acceptable value in most cases, but it is
         recommended to tune this value for each application so that the
         convergence is neither too slow nor too fast.
+    
+    .. versionchanged:: 1.5.10 
+       now explicitly listing the *verbose*, *levels*, *resampling_factor*,
+       *kernel_file*, *iterations*, *fields*, *mask* and *mul* arguments
+    .. versionchanged:: 1.5.10 renamed *img* argument to *ref_img*
+    .. versionadded:: 1.5.10 *context* argument
+    .. versionremoved:: 1.5.10 *show_diff* and *img_size* arguments
+    .. versionadded:: 2.0.0 *logger_name* argument
     """
 
     self._context = context

--- a/src/crappy/tool/image_processing/video_extenso/tracker.py
+++ b/src/crappy/tool/image_processing/video_extenso/tracker.py
@@ -37,6 +37,8 @@ class Tracker(Process):
   returns the updated position of the detected spot. It is meant to be used in
   association with the 
   :class:`~crappy.tool.image_processing.video_extenso.VideoExtensoTool`.
+  
+  .. versionadded:: 2.0.0
   """
 
   names = list()

--- a/src/crappy/tool/image_processing/video_extenso/video_extenso.py
+++ b/src/crappy/tool/image_processing/video_extenso/video_extenso.py
@@ -27,6 +27,10 @@ class VideoExtensoTool:
 
   It is possible to track only one spot, in which case only the position of its
   center is returned and the strain values are left to `0`.
+  
+  .. versionadded:: 1.4.0
+  .. versionchanged:: 1.5.10 renamed from Video_extenso to VideoExtenso
+  .. versionchanged:: 2.0.0 renamed from VideoExtenso to VideoExtensoTool
   """
 
   def __init__(self,
@@ -85,6 +89,10 @@ class VideoExtensoTool:
         takes a bit more time compared to no blurring. Passed to the 
         :class:`~crappy.tool.image_processing.video_extenso.tracker.Tracker`
         and not used in this class.
+
+    .. versionremoved:: 2.0.0 *num_spots* and *min_area* arguments
+    .. versionadded:: 2.0.0
+       *spots*, *thresh*, *log_level* and *log_queue* arguments
     """
 
     # These attributes will be used later
@@ -175,6 +183,8 @@ class VideoExtensoTool:
     Returns:
       A :obj:`list` containing :obj:`tuple` with the coordinates of the centers 
       of the detected spots, and the calculated x and y strain values.
+    
+    .. versionchanged:: 1.5.10 renamed from get_def to get_data
     """
 
     # Sending the latest sub-image containing the spot to track


### PR DESCRIPTION
This PR brings a final touch to the documentation of Crappy, that has already been greatly completed and enhanced by #52. As detailed in #66, this PR contains the following improvements:

- [x] Use the `kbd` directive when describing a keyboard combination
- [x] Use the `versionadded`, `versionchanged` and `versionremoved` directives for signaling the version when a class, method, or argument was added, changed, or removed
- [x] Add `sectionauthor` directives for signaling the author(s) of documentation sections
- [x] Add the link to numpy, matplotlib, and psutil documentation in intersphinx
- [x] Add collapse menus to the documentation for hiding large sections of code

The changes will be included in version 2.0.1. 
This PR closes #66.