### PR TITLE
Enhancement of the format detection in camera gstreamer basic

### DIFF
--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -185,30 +185,30 @@ videoconvert ! autovideosink
 
       # Checking the available formats with the Gst device monitor
       cam = None
-      form = ''
-      cam_id = []
       device_monitor = Gst.DeviceMonitor.new()
       device_monitor.start()
-
       devices = device_monitor.get_devices()
-      for (id_, device) in enumerate(devices):
-        # Finding the camera
-        if device.get_device_class() == "Video/Source":
-          properties = device.get_properties()
-          api = properties.get_value('device.api')
-          dev = properties.get_value('object.path')
-          cam_id.append((id_, dev))
-          if dev == f'{api}:{self._device}':
-            cam = device
 
-      # Defining a default camera if the device is not found or not specified
-      if cam is None:
-        cam = devices[cam_id[0][0]]
-        default_device = cam_id[0][1].split(':')[1]
-        self.log(logging.WARNING, f"The device has not been found or is None. "
-                                  f"Using device: {default_device}.")
+      # Finding the specified device in the available ones
+      if self._device is not None:
+        for device in devices:
+          if device.get_device_class() == "Video/Source":
+            properties = device.get_properties()
+            api = properties.get_value('device.api')
+            dev = properties.get_value('object.path')
+            if dev == f'{api}:{self._device}':
+              cam = device
+              break
 
-      # Getting the formats
+
+      # Defining a default camera if the device is not specified
+      if self._device is None:
+        cam = devices[0]
+        path = cam.get_properties().get_value('object.path')
+        self.log(logging.WARNING, f"No specific camera to open specified, "
+                                  f"opening {path.split(':')[1]} by default")
+
+      # Getting the available image formats
       caps = cam.get_caps()
       nb_formats = caps.get_size()
       for i in range(nb_formats):

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -189,6 +189,11 @@ videoconvert ! autovideosink
       device_monitor.start()
       devices = device_monitor.get_devices()
 
+      # Stop right here if there is no connected camera
+      if not devices:
+        self.log(logging.ERROR, "No camera devices available for reading !")
+        raise IOError
+
       # Finding the specified device in the available ones
       if self._device is not None:
         for device in devices:
@@ -200,6 +205,11 @@ videoconvert ! autovideosink
               cam = device
               break
 
+      # Raising an exception if the specified device cannot be found
+      if self._device is not None and cam is None:
+        self.log(logging.ERROR, f"Could not open the specified camera "
+                                f"at: {self._device}")
+        raise IOError
 
       # Defining a default camera if the device is not specified
       if self._device is None:

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -284,7 +284,7 @@ videoconvert ! autovideosink
                     contrast: Optional[float] = None,
                     hue: Optional[float] = None,
                     saturation: Optional[float] = None,
-                    img_format: Optional[int] = None) -> str:
+                    img_format: Optional[str] = None) -> str:
     """Method that generates a pipeline, according to the given settings.
 
     If a user-defined pipeline was given, it will always be returned.

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -248,22 +248,26 @@ videoconvert ! autovideosink
 
       device_monitor.stop()
 
-      # Checking if the formats are applicable
+      # Checking if the formats are supported with the installed libraries
       if self._formats:
-        if not run(['gst-inspect-1.0', 'avdec_h264'],
-                   capture_output=True, text=True).stdout:
+        h264_available = bool(run(['gst-inspect-1.0', 'avdec_h264'],
+                                  capture_output=True, text=True).stdout)
+        h265_available = bool(run(['gst-inspect-1.0', 'avdec_h265'],
+                                  capture_output=True, text=True).stdout)
+        if not h264_available and any(form.split()[0] == 'H264'
+                                      for form in self._formats):
           self._formats = [form for form in self._formats
                            if form.split()[0] != 'H264']
-          self.log(logging.WARNING, "The format H264 is not available"
-                                    "It could be if gstreamer1.0-libav "
-                                    "was installed !")
-        if not run(['gst-inspect-1.0', 'avdec_h265'],
-                   capture_output=True, text=True).stdout:
+          self.log(logging.WARNING, "The video format H264 could be available "
+                                    "for the selected camera if "
+                                    "gstreamer1.0-libav was installed !")
+        if not h265_available and any(form.split()[0] == 'HEVC'
+                                      for form in self._formats):
           self._formats = [form for form in self._formats
                            if form.split()[0] != 'HEVC']
-          self.log(logging.WARNING, "The format HEVC is not available"
-                                    "It could be if gstreamer1.0-libav "
-                                    "was installed !")
+          self.log(logging.WARNING, "The video format H265 could be available "
+                                    "for the selected camera if "
+                                    "gstreamer1.0-libav was installed !")
 
       if self._formats:
         # Creating the format parameter

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -242,7 +242,8 @@ videoconvert ! autovideosink
           width = struct.get_value('width')
           height = struct.get_value('height')
           framerates = findall(r'(\d+/\d+)', struct.to_string())
-          for fps in framerates:
+          for fps_str in framerates:
+            fps = f"{float(Fraction(fps_str)):.3f}"
             self._formats.append(f"{form} {width}x{height} ({fps} fps)")
 
       device_monitor.stop()

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -221,6 +221,24 @@ videoconvert ! autovideosink
               self._formats.append(f"{form} {width}x{height} ({fps} fps)")
 
       device_monitor.stop()
+
+      # Checking if the formats are applicable
+      if self._formats:
+        if not run(['gst-inspect-1.0', 'avdec_h264'],
+                   capture_output=True, text=True).stdout:
+          self._formats = [form for form in self._formats
+                           if form.split()[0] != 'H264']
+          self.log(logging.WARNING, "The format H264 is not available"
+                                    "It could be if gstreamer1.0-libav "
+                                    "was installed !")
+        if not run(['gst-inspect-1.0', 'avdec_h265'],
+                   capture_output=True, text=True).stdout:
+          self._formats = [form for form in self._formats
+                           if form.split()[0] != 'HEVC']
+          self.log(logging.WARNING, "The format HEVC is not available"
+                                    "It could be if gstreamer1.0-libav "
+                                    "was installed !")
+
       if self._formats:
         # Creating the format parameter
         self.add_choice_setting(name='format',

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -222,17 +222,23 @@ videoconvert ! autovideosink
       caps = cam.get_caps()
       nb_formats = caps.get_size()
       for i in range(nb_formats):
+        form = None
         struct = caps.get_structure(i)
-        if struct.get_name() == 'image/jpeg':
+        name = struct.get_name()
+        if name == 'image/jpeg':
           form = 'MJPG'
-        elif struct.get_name() == 'video/x-h264':
+        elif name == 'video/x-h264':
           form = 'H264'
-        elif struct.get_name() == 'video/x-hevc':
+        elif name == 'video/x-hevc':
           form = 'HEVC'
-        elif struct.get_name() == 'video/x-raw':
+        elif name == 'video/x-raw':
           form = struct.get_value('format')
+        else:
+          self.log(logging.WARNING, f"Found unsupported cap format: {name}, "
+                                    f"ignoring it")
 
-        if form:
+        # Formatting the format into the v4l2 syntax
+        if form is not None:
           width = struct.get_value('width')
           height = struct.get_value('height')
           framerates = findall(r'(\d+/\d+)', struct.to_string())

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -427,6 +427,8 @@ videoconvert ! autovideosink
     except ValueError:
       format_name, img_size, fps = img_format, None, None
 
+    # Default color is BGR in most cases
+    color = 'BGR'
     # Adding the decoder to the pipeline if needed
     if format_name == 'MJPG':
       img_format = '! jpegdec'
@@ -434,7 +436,15 @@ videoconvert ! autovideosink
       img_format = '! h264parse ! avdec_h264'
     elif format_name == 'HEVC':
       img_format = '! h265parse ! avdec_h265'
-    elif format_name == 'YUYV' or format_name == 'YUY2':
+    elif format_name in ('YUYV', 'YUY2'):
+      img_format = ''
+    elif format_name == 'GRAY8':
+      img_format = ''
+      color = 'GRAY8'
+    else:
+      self.log(logging.WARNING, f"Unsupported format name: {format_name}, "
+                                f"trying without explicitly setting the "
+                                f"decoder in the pipeline")
       img_format = ''
 
     # Getting the width and height from the second half of the string
@@ -452,7 +462,7 @@ videoconvert ! autovideosink
       fps_str = ''
     # Finally, generate a single pipeline containing all the user settings
     return f"""{source} {device} name=source {img_format} ! videoconvert ! 
-           video/x-raw,format=BGR{img_size}{fps_str} ! videobalance 
+           video/x-raw,format={color}{img_size}{fps_str} ! videobalance 
            brightness={brightness if brightness is not None 
                        else self.brightness:.3f} 
            contrast={contrast if contrast is not None else self.contrast:.3f} 

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -276,7 +276,9 @@ videoconvert ! autovideosink
                                 setter=self._set_format)
 
       # These settings are always available no matter the platform
-      self.add_choice_setting(name="channels", choices=('1', '3'), default='1')
+      if self._nb_channels > 1:
+        self.add_choice_setting(name="channels", choices=('1', '3'),
+                                default='1')
       self.add_scale_setting(name='brightness', lowest=-1., highest=1.,
                              setter=self._set_brightness, default=0.)
       self.add_scale_setting(name='contrast', lowest=0., highest=2.,
@@ -493,7 +495,9 @@ videoconvert ! autovideosink
                       "the format.\n(here BGR would be for 3 channels)")
 
     # Converting to gray level if needed
-    if self._user_pipeline is None and self.channels == '1':
+    if (self._user_pipeline is None
+        and hasattr(self, 'channels')
+        and self.channels == '1'):
       numpy_frame = cv2.cvtColor(numpy_frame, cv2.COLOR_BGR2GRAY)
 
     # Cleaning up the buffer mapping

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -414,8 +414,12 @@ videoconvert ! autovideosink
     else:
       device = ''
 
-    # Getting the format index
-    img_format = img_format if img_format is not None else self.format
+    # Getting the format string if not provided as an argument
+    if img_format is None and hasattr(self, 'format'):
+      img_format = self.format
+    # In case it goes wrong, just try without specifying the format
+    if img_format is None:
+      img_format = ''
 
     try:
       format_name, img_size, fps = findall(r"(\w+)\s(\w+)\s\((\d+.\d+) fps\)",

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -448,7 +448,7 @@ videoconvert ! autovideosink
     self.log(logging.INFO, "Starting the GST pipeline")
     self._pipeline.set_state(Gst.State.PLAYING)
 
-  def _get_pipeline(self, img_format: Optional[int] = None) -> str:
+  def _get_pipeline(self, img_format: Optional[str] = None) -> str:
     """Method that generates a pipeline, according to the given settings.
 
     If a user-defined pipeline was given, it will always be returned.


### PR DESCRIPTION
Currently, there is no format detection in the camera gstreamer basic and formats are guessed. The user can then just choose the image format among a non exhaustive list, even if some more are available. 
This is not optimal for the user.

In this PR, the available formats are detected by using the Gst device monitor (032f79f). Then, the list of the available formats is inspected in order to check if those formats are applicable (9daf836).

Closes #58.