### PR TITLE
Various style refactorings and fixes on `CameraGstreamer` and `CameraOpencv` objects

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,6 @@
 
 # PIERROOOTT owns the Opencv cameras
 /src/crappy/camera/opencv_* @WeisLeDocto @PIERROOOTT
+
+# PIERROOOTT owns the base v4l2 class
+/src/crappy/camera/_v4l2_base.py @WeisLeDocto @PIERROOOTT

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -254,7 +254,10 @@ videoconvert ! autovideosink
                                   f'type are implemented. ')
           raise NotImplementedError
 
-      self.add_choice_setting(name="channels", choices=('1', '3'), default='1')
+      # No need to add the channels setting if there's only one channel
+      if self._nb_channels > 1:
+        self.add_choice_setting(name="channels", choices=('1', '3'),
+                                default='1')
 
       # Adding the software ROI selection settings
       if self._formats:
@@ -439,7 +442,9 @@ videoconvert ! autovideosink
                       "the format.\n(here BGR would be for 3 channels)")
 
     # Converting to gray level if needed
-    if self._user_pipeline is None and self.channels == '1':
+    if (self._user_pipeline is None
+        and hasattr(self, 'channels')
+        and self.channels == '1'):
       numpy_frame = cv2.cvtColor(numpy_frame, cv2.COLOR_BGR2GRAY)
 
     # Cleaning up the buffer mapping

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -188,22 +188,26 @@ videoconvert ! autovideosink
 
       self._get_available_formats(self._device)
 
-      # Finally, creating the parameter if applicable
+      # Checking if the formats are supported with the installed libraries
       if self._formats:
-        if not run(['gst-inspect-1.0', 'avdec_h264'],
-                   capture_output=True, text=True).stdout:
+        h264_available = bool(run(['gst-inspect-1.0', 'avdec_h264'],
+                                  capture_output=True, text=True).stdout)
+        h265_available = bool(run(['gst-inspect-1.0', 'avdec_h265'],
+                                  capture_output=True, text=True).stdout)
+        if not h264_available and any(form.split()[0] == 'H264'
+                                      for form in self._formats):
           self._formats = [form for form in self._formats
                            if form.split()[0] != 'H264']
-          self.log(logging.WARNING, "The format H264 is not available"
-                                    "It could be if gstreamer1.0-libav "
-                                    "was installed !")
-        if not run(['gst-inspect-1.0', 'avdec_h265'],
-                   capture_output=True, text=True).stdout:
+          self.log(logging.WARNING, "The video format H264 could be available "
+                                    "for the selected camera if "
+                                    "gstreamer1.0-libav was installed !")
+        if not h265_available and any(form.split()[0] == 'HEVC'
+                                      for form in self._formats):
           self._formats = [form for form in self._formats
                            if form.split()[0] != 'HEVC']
-          self.log(logging.WARNING, "The format HEVC is not available"
-                                    "It could be if gstreamer1.0-libav "
-                                    "was installed !")
+          self.log(logging.WARNING, "The video format H265 could be available "
+                                    "for the selected camera if "
+                                    "gstreamer1.0-libav was installed !")
 
         # The format integrates the size selection
         if ' ' in self._formats[0]:

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -222,38 +222,37 @@ videoconvert ! autovideosink
 
       # Creating the different settings
       for param in self._parameters:
-        if not param.flags:
-          if param.type == 'int':
-            self.add_scale_setting(
+        if param.type == 'int':
+          self.add_scale_setting(
+            name=param.name,
+            lowest=int(param.min),
+            highest=int(param.max),
+            getter=self._add_scale_getter(param.name, self._device),
+            setter=self._add_setter(param.name, self._device),
+            default=param.default,
+            step=int(param.step))
+
+        elif param.type == 'bool':
+          self.add_bool_setting(
+            name=param.name,
+            getter=self._add_bool_getter(param.name, self._device),
+            setter=self._add_setter(param.name, self._device),
+            default=bool(int(param.default)))
+
+        elif param.type == 'menu':
+          if param.options:
+            self.add_choice_setting(
               name=param.name,
-              lowest=int(param.min),
-              highest=int(param.max),
-              getter=self._add_scale_getter(param.name, self._device),
+              choices=param.options,
+              getter=self._add_menu_getter(param.name, self._device),
               setter=self._add_setter(param.name, self._device),
-              default=param.default,
-              step=int(param.step))
+              default=param.default)
 
-          elif param.type == 'bool':
-            self.add_bool_setting(
-              name=param.name,
-              getter=self._add_bool_getter(param.name, self._device),
-              setter=self._add_setter(param.name, self._device),
-              default=bool(int(param.default)))
-
-          elif param.type == 'menu':
-            if param.options:
-              self.add_choice_setting(
-                name=param.name,
-                choices=param.options,
-                getter=self._add_menu_getter(param.name, self._device),
-                setter=self._add_setter(param.name, self._device),
-                default=param.default)
-
-          else:
-            self.log(logging.ERROR, f'The type {param.type} is not yet'
-                                    f' implemented. Only int, bool and menu '
-                                    f'type are implemented. ')
-            raise NotImplementedError
+        else:
+          self.log(logging.ERROR, f'The type {param.type} is not yet'
+                                  f' implemented. Only int, bool and menu '
+                                  f'type are implemented. ')
+          raise NotImplementedError
 
       self.add_choice_setting(name="channels", choices=('1', '3'), default='1')
 

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -367,8 +367,12 @@ videoconvert ! autovideosink
     else:
       device = ''
 
-    # Getting the format index
-    img_format = img_format if img_format is not None else self.format
+    # Getting the format string if not provided as an argument
+    if img_format is None and hasattr(self, 'format'):
+      img_format = self.format
+    # In case it goes wrong, just try without specifying the format
+    if img_format is None:
+      img_format = ''
 
     try:
       format_name, img_size, fps = findall(r"(\w+)\s(\w+)\s\((\d+.\d+) fps\)",

--- a/src/crappy/camera/opencv_camera_v4l2.py
+++ b/src/crappy/camera/opencv_camera_v4l2.py
@@ -65,6 +65,8 @@ class CameraOpencv(Camera, V4L2Helper):
     self._cap = cv2.VideoCapture(device_num)
     self._device_num = device_num
 
+    # Getting the available formats for the selected device and filtering the
+    # supported ones
     self._get_available_formats(device_num)
     supported = ('MJPG', 'YUYV')
     unavailable_formats = set([_format.split()[0] for _format in self._formats
@@ -73,64 +75,55 @@ class CameraOpencv(Camera, V4L2Helper):
                            f"available but not implemented in Crappy")
     self._formats = [_format for _format in self._formats
                      if _format.split()[0] in supported]
-    if self._formats:
-      # The format integrates the size selection
-      if ' ' in self._formats[0]:
-        self.add_choice_setting(name='format',
-                                choices=tuple(self._formats),
-                                getter=self._get_format_size,
-                                setter=self._set_format)
-      # The size is independent of the format
-      else:
-        self.add_choice_setting(name='format',
-                                choices=tuple(self._formats),
-                                getter=self._get_fourcc,
-                                setter=self._set_format)
 
+    # Instantiating the format setting if there are formats left
+    if self._formats:
+      self.add_choice_setting(name='format',
+                              choices=tuple(self._formats),
+                              getter=self._get_format_size,
+                              setter=self._set_format)
+
+    # Getting the available parameters for the camera
     self._get_param(device_num)
 
-    # Create the different settings
+    # Creating the different settings
     for param in self._parameters:
-      if not param.flags:
-        if param.type == 'int':
-          self.add_scale_setting(
+      if param.type == 'int':
+        self.add_scale_setting(
+          name=param.name,
+          lowest=int(param.min),
+          highest=int(param.max),
+          getter=self._add_scale_getter(param.name, self._device_num),
+          setter=self._add_setter(param.name, self._device_num),
+          default=param.default,
+          step=int(param.step))
+
+      elif param.type == 'bool':
+        self.add_bool_setting(
+          name=param.name,
+          getter=self._add_bool_getter(param.name, self._device_num),
+          setter=self._add_setter(param.name, self._device_num),
+          default=bool(int(param.default)))
+
+      elif param.type == 'menu':
+        if param.options:
+          self.add_choice_setting(
             name=param.name,
-            lowest=int(param.min),
-            highest=int(param.max),
-            getter=self._add_scale_getter(param.name, self._device_num),
+            choices=param.options,
+            getter=self._add_menu_getter(param.name, self._device_num),
             setter=self._add_setter(param.name, self._device_num),
-            default=param.default,
-            step=int(param.step))
+            default=param.default)
 
-        elif param.type == 'bool':
-          self.add_bool_setting(
-            name=param.name,
-            getter=self._add_bool_getter(param.name, self._device_num),
-            setter=self._add_setter(param.name, self._device_num),
-            default=bool(int(param.default)))
-
-        elif param.type == 'menu':
-          if param.options:
-            self.add_choice_setting(
-              name=param.name,
-              choices=param.options,
-              getter=self._add_menu_getter(param.name, self._device_num),
-              setter=self._add_setter(param.name, self._device_num),
-              default=param.default)
-
-        else:
-          self.log(logging.ERROR, f'The type {param.type} is not yet'
-                                  f' implemented. Only int, bool and menu '
-                                  f'type are implemented. ')
-          raise NotImplementedError
+      else:
+        self.log(logging.ERROR, f'The type {param.type} is not yet'
+                                f' implemented. Only int, bool and menu '
+                                f'type are implemented. ')
+        raise NotImplementedError
 
     self.add_choice_setting(name="channels", choices=('1', '3'), default='1')
 
     # Adding the software ROI selection settings
-    if 'width' in self.settings and 'height' in self.settings:
-      width, height = self._get_width(), self._get_height()
-      self.add_software_roi(width, height)
-    elif 'format' in self.settings:
+    if 'format' in self.settings:
       width, height = search(r'(\d+)x(\d+)', self._get_format_size()).groups()
       self.add_software_roi(int(width), int(height))
 
@@ -161,13 +154,6 @@ class CameraOpencv(Camera, V4L2Helper):
     if self._cap is not None:
       self.log(logging.INFO, "Closing the image stream from the camera")
       self._cap.release()
-
-  def _get_fourcc(self) -> str:
-    """Returns the current fourcc string of the video encoding."""
-
-    fcc = int(self._cap.get(cv2.CAP_PROP_FOURCC))
-    return f"{fcc & 0xFF:c}{(fcc >> 8) & 0xFF:c}" \
-           f"{(fcc >> 16) & 0xFF:c}{(fcc >> 24) & 0xFF:c}"
 
   def _get_width(self) -> int:
     """Returns the current image width."""
@@ -204,26 +190,22 @@ class CameraOpencv(Camera, V4L2Helper):
   def _set_format(self, img_format: str) -> None:
     """Sets the format of the image according to the user's choice."""
 
-    # The format might be made of a name and a dimension, or just a name
-    try:
-      format_name, img_size, fps = findall(r"(\w+)\s(\w+)\s\((\d+.\d+) fps\)",
-                                           img_format)[0]
-    except ValueError:
-      format_name, img_size, fps = img_format, None, None
+    # The format is made of a name, a size and a framerate
+    format_name, img_size, fps = findall(r"(\w+)\s(\w+)\s\((\d+.\d+) fps\)",
+                                         img_format)[0]
 
     # Setting the format
     self._cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*format_name))
 
-    if img_size is not None:
-      # Getting the width and height from the second half of the string
-      width, height = map(int, img_size.split('x'))
+    # Getting the width and height from the second half of the string
+    width, height = map(int, img_size.split('x'))
 
-      # Setting the size
-      self._set_width(width)
-      self._set_height(height)
+    # Setting the size
+    self._set_width(width)
+    self._set_height(height)
 
-    if fps is not None:
-      self._cap.set(cv2.CAP_PROP_FPS, float(fps))
+    # Setting the acquisition frequency
+    self._cap.set(cv2.CAP_PROP_FPS, float(fps))
 
     # Reloading the software ROI selection settings
     if self._soft_roi_set:
@@ -232,20 +214,23 @@ class CameraOpencv(Camera, V4L2Helper):
       self.reload_software_roi(int(width), int(height))
 
   def _get_format_size(self) -> str:
-    """Parses the ``v4l2-ctl -V`` command to get the current image format as a
-    :obj:`str`."""
+    """Parses the ``v4l2-ctl -all`` command to get the current image format as
+    a :obj:`str`."""
 
     # Sending the v4l2-ctl command
     command = ['v4l2-ctl', '-d', str(self._device_num), '--all']
-    check = run(command, capture_output=True, text=True).stdout
+    self.log(logging.DEBUG, f"Getting the current image formats with "
+                            f"command {' '.join(command)}")
+    ret = run(command, capture_output=True, text=True).stdout
+    self.log(logging.DEBUG, f"Got the following image formats: {ret}")
 
     # Parsing the answer
     format_ = width = height = fps = ''
-    if search(r"Pixel Format\s*:\s*'(\w+)'", check) is not None:
-      format_, *_ = search(r"Pixel Format\s*:\s*'(\w+)'", check).groups()
-    if search(r"Width/Height\s*:\s*(\d+)/(\d+)", check) is not None:
-      width, height = search(r"Width/Height\s*:\s*(\d+)/(\d+)", check).groups()
-    if search(r"Frames per second\s*:\s*(\d+.\d+)", check) is not None:
-      fps, *_ = search(r"Frames per second\s*:\s*(\d+.\d+)", check).groups()
+    if search(r"Pixel Format\s*:\s*'(\w+)'", ret) is not None:
+      format_, *_ = search(r"Pixel Format\s*:\s*'(\w+)'", ret).groups()
+    if search(r"Width/Height\s*:\s*(\d+)/(\d+)", ret) is not None:
+      width, height = search(r"Width/Height\s*:\s*(\d+)/(\d+)", ret).groups()
+    if search(r"Frames per second\s*:\s*(\d+.\d+)", ret) is not None:
+      fps, *_ = search(r"Frames per second\s*:\s*(\d+.\d+)", ret).groups()
 
     return f'{format_} {width}x{height} ({fps} fps)'

--- a/src/crappy/camera/opencv_camera_v4l2.py
+++ b/src/crappy/camera/opencv_camera_v4l2.py
@@ -69,10 +69,11 @@ class CameraOpencv(Camera, V4L2Helper):
     # supported ones
     self._get_available_formats(device_num)
     supported = ('MJPG', 'YUYV')
-    unavailable_formats = set([_format.split()[0] for _format in self._formats
-                               if _format.split()[0] not in supported])
-    self.log(logging.INFO, f"The formats {', '.join(unavailable_formats)} are "
-                           f"available but not implemented in Crappy")
+    unavailable = set([_format.split()[0] for _format in self._formats
+                       if _format.split()[0] not in supported])
+    if unavailable:
+      self.log(logging.WARNING, f"The formats {', '.join(unavailable)} "
+                                f"are available but not implemented in Crappy")
     self._formats = [_format for _format in self._formats
                      if _format.split()[0] in supported]
 


### PR DESCRIPTION
In #76, a few improvements were brought to the [`gstreamer_camera_basic.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/430b0ed8416e152089b1ccb456709c260ce58d5f/src/crappy/camera/gstreamer_camera_basic.py) file. The branch on which these changes were brought was however not up to date with `develop`, and the improvements could not be propagated as is to other camera files.

With this PR, the changes in `gstreamer_camera_basic.py` are propagated to [`gstreamer_camera_v4l2.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/430b0ed8416e152089b1ccb456709c260ce58d5f/src/crappy/camera/gstreamer_camera_v4l2.py), and similar style corrections and minor fixes are also brought to [`opencv_camera_v4l2.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/430b0ed8416e152089b1ccb456709c260ce58d5f/src/crappy/camera/opencv_camera_v4l2.py) and [`_v4l2_base.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/430b0ed8416e152089b1ccb456709c260ce58d5f/src/crappy/camera/_v4l2_base.py).