### PR TITLE
Add workflow for checking the installation and import of Crappy

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,0 +1,38 @@
+# Installs the Python dependencies, installs Crappy, and checks that it imports
+name: Python Package
+
+on:
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: ["master"]
+
+  # May also be started manually
+  workflow_dispatch:
+
+  # Runs automatically every first day of the month
+  schedule:
+    - cron: '0 12 1 * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip wheel build setuptools
+    - name: Install Crappy
+      run: python -m pip install .
+    - name: Import Crappy
+      run: python -c "import crappy; print(crappy.__version__)"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -5,7 +5,7 @@ on:
   # Runs on pull requests targeting the default branch
   pull_request:
     types: [opened, edited, reopened, synchronize]
-    branches: ["master"]
+    branches: ["master", "develop"]
 
   # May also be started manually
   workflow_dispatch:


### PR DESCRIPTION
In an effort to detect bugs in the code as early as possible, this PR adds a GitHub workflow to the project. This workflow installs Crappy, and checks that it imports as expected. The checks are performed on Linux, macOS and Windows, on all the Python versions supported by Crappy. It runs whenever a Pull Request is opened or modified on the `main` or `develop` branch, and on each first day of the month.

This workflow is a first step towards a more extensive test suite for Crappy, to be integrated at a later point (#57). It is a step towards completion of #63.