### PR TITLE
Release of version 2.0.3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@
 from time import gmtime, strftime
 from re import match
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 
 # -- Project information -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "crappy"
 dynamic = ["readme"]
-version = "2.0.2"
+version = "2.0.3"
 description = "Command and Real-time Acquisition in Parallelized Python"
 license = {file = "LICENSE"}
 keywords = ["control", "command", "acquisition", "multiprocessing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,17 +66,15 @@ main = [
 ]
 
 [tool.setuptools]
-include-package-data = true
+package-dir = {"" = "src"}
+include-package-data = false
 
 [tool.setuptools.dynamic]
 readme = {file = "README.md", content-type = "text/markdown"}
 
-[tool.setuptools.package-dir]
-crappy = "src/crappy"
-
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["*"]
+include = ["crappy*"]
 exclude = []
 namespaces = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["setuptools >= 61.0", "numpy >= 1.21"]
+requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "crappy"
-dynamic = ["version", "readme"]
+dynamic = ["readme"]
+version = "2.0.2"
 description = "Command and Real-time Acquisition in Parallelized Python"
 license = {file = "LICENSE"}
 keywords = ["control", "command", "acquisition", "multiprocessing"]
@@ -68,7 +69,6 @@ main = [
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = {attr = "crappy.__version__"}
 readme = {file = "README.md", content-type = "text/markdown"}
 
 [tool.setuptools.package-dir]

--- a/src/crappy/__init__.py
+++ b/src/crappy/__init__.py
@@ -5,10 +5,6 @@
 It imports all the modules and other resources, and defines aliases.
 """
 
-from pkg_resources import resource_string, resource_filename
-from numpy import frombuffer, uint8
-from webbrowser import open
-
 # Importing the modules of crappy
 from . import actuator
 from . import blocks
@@ -21,7 +17,7 @@ from . import tool
 
 # Importing other features
 from .__version__ import __version__
-from ._global import OptionalModule
+from ._global import OptionalModule, docs
 
 # Useful aliases
 link = links.link
@@ -39,53 +35,3 @@ launch = Block.launch_all
 start = Block.start_all
 renice = Block.renice_all
 reset = Block.reset
-
-
-# Quick access to documentation
-def docs():
-  """Opens the online documentation of Crappy.
-
-  It opens the latest version, and of course requires an internet access.
-  
-  .. versionadded:: 1.5.5
-  .. versionchanged:: 2.0.0 renamed from doc to docs
-  """
-
-  open('https://crappy.readthedocs.io/en/latest/')
-
-
-# Data aliases
-class resources:
-  """This class defines aliases for quick access to the resources in the
-  `tool/data/` folder.
-
-  These aliases are then used in the examples provided on the GitHub
-  repository, but could also be used in custom user scripts.
-
-  .. versionadded:: 1.5.3
-  """
-
-  try:
-    # Defining aliases to the images themselves
-    from cv2 import imdecode
-    speckle = imdecode(frombuffer(resource_string('crappy',
-                                                  'tool/data/speckle.png'),
-                                  uint8), flags=0)
-
-    ve_markers = imdecode(frombuffer(
-      resource_string('crappy', 'tool/data/ve_markers.tif'), uint8), flags=0)
-
-    pad = imdecode(frombuffer(resource_string('crappy', 'tool/data/pad.png'),
-                              uint8), flags=0)
-
-  # In case the module opencv-python is missing
-  except (ModuleNotFoundError, ImportError):
-    speckle = OptionalModule('opencv-python')
-    ve_markers = OptionalModule('opencv-python')
-    pad = OptionalModule('opencv-python')
-
-  # Also getting the paths to the images
-  paths = {'pad': resource_filename('crappy', 'tool/data/pad.png'),
-           'speckle': resource_filename('crappy', 'tool/data/speckle.png'),
-           've_markers': resource_filename('crappy',
-                                           'tool/data/ve_markers.tif')}

--- a/src/crappy/__version__.py
+++ b/src/crappy/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'

--- a/src/crappy/_global.py
+++ b/src/crappy/_global.py
@@ -2,6 +2,22 @@
 
 from typing import Optional, NoReturn, Any
 from importlib import import_module
+import webbrowser
+from pkg_resources import resource_string, resource_filename
+from numpy import frombuffer, uint8
+
+
+# Quick access to documentation
+def docs():
+  """Opens the online documentation of Crappy.
+
+  It opens the latest version, and of course requires an internet access.
+
+  .. versionadded:: 1.5.5
+  .. versionchanged:: 2.0.0 renamed from doc to docs
+  """
+
+  webbrowser.open('https://crappy.readthedocs.io/en/latest/')
 
 
 class OptionalModule:
@@ -74,6 +90,43 @@ class OptionalModule:
     """Method raising an exception indicating that the module is missing."""
 
     raise RuntimeError(f"Missing module: {self._name}\n{self._msg}")
+
+
+# Data aliases
+class resources:
+  """This class defines aliases for quick access to the resources in the
+  `tool/data/` folder.
+
+  These aliases are then used in the examples provided on the GitHub
+  repository, but could also be used in custom user scripts.
+
+  .. versionadded:: 1.5.3
+  """
+
+  try:
+    # Defining aliases to the images themselves
+    from cv2 import imdecode
+    speckle = imdecode(frombuffer(resource_string('crappy',
+                                                  'tool/data/speckle.png'),
+                                  uint8), flags=0)
+
+    ve_markers = imdecode(frombuffer(
+      resource_string('crappy', 'tool/data/ve_markers.tif'), uint8), flags=0)
+
+    pad = imdecode(frombuffer(resource_string('crappy', 'tool/data/pad.png'),
+                              uint8), flags=0)
+
+  # In case the module opencv-python is missing
+  except (ModuleNotFoundError, ImportError):
+    speckle = OptionalModule('opencv-python')
+    ve_markers = OptionalModule('opencv-python')
+    pad = OptionalModule('opencv-python')
+
+  # Also getting the paths to the images
+  paths = {'pad': resource_filename('crappy', 'tool/data/pad.png'),
+           'speckle': resource_filename('crappy', 'tool/data/speckle.png'),
+           've_markers': resource_filename('crappy',
+                                           'tool/data/ve_markers.tif')}
 
 
 class LinkDataError(ValueError):

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -62,10 +62,10 @@ class ImageSaver(CameraProcess):
       save_backend: The backend to use for saving the images. Should be one of:
         ::
 
-          'sitk', 'cv2', 'pil', 'npy'
+          'sitk', 'pil', 'cv2', 'npy'
 
-        They correspond to the modules :mod:`SimpleITK`, :mod:`cv2` (OpenCV),
-        :mod:`PIL` (Pillow Fork), and :mod:`numpy`. Depending on the machine,
+        They correspond to the modules :mod:`SimpleITK`, :mod:`PIL` (Pillow
+        Fork), :mod:`cv2` (OpenCV), and :mod:`numpy`. Depending on the machine,
         some may be faster or slower. The ``img_extension`` is ignored for the
         backend ``'npy'``, that saves the images as raw numpy arrays.
     """
@@ -78,9 +78,9 @@ class ImageSaver(CameraProcess):
       if not isinstance(Sitk, OptionalModule):
         self._save_backend = 'sitk'
       elif not isinstance(PIL, OptionalModule):
-        self._save_backend = 'cv2'
-      elif not isinstance(PIL, OptionalModule):
         self._save_backend = 'pil'
+      elif not isinstance(cv2, OptionalModule):
+        self._save_backend = 'cv2'
       else:
         self._save_backend = 'npy'
     elif save_backend in ('sitk', 'pil', 'cv2', 'npy'):

--- a/src/crappy/inout/daqmx.py
+++ b/src/crappy/inout/daqmx.py
@@ -237,7 +237,7 @@ class DAQmx(InOut):
                                   PyDAQmx.DAQmx_Val_FiniteSamps,
                                   2)
     PyDAQmx.DAQmxStartTask(self._handle)
-    data = np.empty((len(self._channels), 1), dtype=np.float64)
+    data = np.empty(len(self._channels), dtype=np.float64)
 
     # Reading the acquired values and stopping the task
     t0 = time()
@@ -247,7 +247,7 @@ class DAQmx(InOut):
                                PyDAQmx.byref(self._n_reads), None)
     PyDAQmx.DAQmxStopTask(self._handle)
 
-    return [t0] + [data[i, :] * chan.gain + chan.offset
+    return [t0] + [data[i] * chan.gain + chan.offset
                    for i, chan in enumerate(self._channels)]
 
   def set_cmd(self, *cmd: float) -> None:

--- a/src/crappy/inout/daqmx.py
+++ b/src/crappy/inout/daqmx.py
@@ -47,7 +47,7 @@ class DAQmx(InOut):
                gain: Optional[Iterable[float]] = None,
                offset: Optional[Iterable[float]] = None,
                ranges: Optional[Iterable[float]] = None,
-               make_zero: Optional[Iterable[bool]] = True,
+               make_zero: Optional[Iterable[bool]] = None,
                sample_rate: float = 10000,
                out_channels: Optional[Iterable[str]] = None,
                out_gain: Optional[Iterable[float]] = None,


### PR DESCRIPTION
The release 2.0.3 is a bug fix release that addresses several minor problems:

* The `cv2` backend for the [`ImageSaver`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b276d7833a94733526ee1431e29805cb9bdf7190/src/crappy/blocks/camera_processes/record.py) object was relegated from second to third choice as it is much slower than the `pil` and `sitk` backends (07accf35).
* Two minor bugs were making the [`DAQmx`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b276d7833a94733526ee1431e29805cb9bdf7190/src/crappy/inout/daqmx.py) InOut impossible to use (41c911c8 and b696b1ae).
* Some attributes of numpy were used in the top-level [`__init__.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b276d7833a94733526ee1431e29805cb9bdf7190/src/crappy/__init__.py) and therefore directly accessible to the user (e.g. `from crappy import uint8`). The problematic objects were moved to the [`_global.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b276d7833a94733526ee1431e29805cb9bdf7190/src/crappy/_global.py) file (12ee73a0).
* `numpy` was a dependency of Crappy at build-time, because of the dynamic check of the project version. The version is now statically specified in [`pyproject.toml`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b276d7833a94733526ee1431e29805cb9bdf7190/pyproject.toml) (d42328c7).
* Fixed minor warnings at build-time by refactoring some lines in [`pyproject.toml`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b276d7833a94733526ee1431e29805cb9bdf7190/pyproject.toml) (d5dc29ce).