### PR TITLE
Add new options on Phidget4AStepper

### DIFF
--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -118,18 +118,11 @@ class Phidget4AStepper(Actuator):
         self._switches.append(switch)
 
     # Setting the remote or local status
-    if self._remote:
-      self._motor.setIsLocal(False)
-      self._motor.setIsRemote(True)
-      for switch in self._switches:
-        switch.setIsLocal(False)
-        switch.setIsRemote(True)
-    else:
-      self._motor.setIsLocal(True)
-      self._motor.setIsRemote(False)
-      for switch in self._switches:
-        switch.setIsLocal(True)
-        switch.setIsRemote(False)
+    self._motor.setIsLocal(not self._remote)
+    self._motor.setIsRemote(self._remote)
+    for switch in self._switches:
+      switch.setIsLocal(not self._remote)
+      switch.setIsRemote(self._remote)
 
     # Setting up the callbacks
     self.log(logging.DEBUG, "Setting the callbacks")
@@ -234,9 +227,9 @@ class Phidget4AStepper(Actuator):
 
     if not self._absolute_mode:
       return self._last_position
-    else:
-      if self._last_position is None:
-        return self._last_position
+
+    # Cannot perform addition if no known last position
+    elif self._last_position is not None:
       return self._last_position + self._ref_pos
 
   def stop(self) -> None:

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -38,10 +38,10 @@ class Phidget4AStepper(Actuator):
                current_limit: float,
                max_acceleration: Optional[float] = None,
                remote: bool = False,
-               absolute_mode: Optional[bool] = False,
+               absolute_mode: bool = False,
                reference_pos: Optional[float] = 0,
                switch_ports: Optional[Tuple[int, ...]] = None,
-               save_last_pos: Optional[bool] = False,
+               save_last_pos: bool = False,
                save_pos_folder: Optional[str] = './') -> None:
     """Sets the args and initializes the parent class.
 

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -59,15 +59,16 @@ class Phidget4AStepper(Actuator):
         or to :obj:`False` to drive it via a USB VINT Hub.
       absolute_mode: If :obj:`True`, the target position of the motor will be
         calculated from a reference position. If :obj:`False`, the target
-        position of the motor will be calculated from its actual position.
-      reference_pos: The position considered as the reference position for the
-        absolute mode at the beginning of the test.
-      switch_ports: The port numbers of the VINT Hub where the switches are
+        position of the motor will be calculated from its current position.
+      reference_pos: The position considered as the reference position at the
+        beginning of the test. Only takes effect if ``absolute_mode`` is
+        :obj:`True`.
+      switch_ports: The indexes of the VINT Hub ports where the switches are
         connected.
       save_last_pos: If :obj:`True`, the last position of the actuator will be
         saved in a .npy file.
       save_pos_folder: The path to the folder where to save the last position
-        of the motor.
+        of the motor. Only takes effect if ``save_last_pos`` is :obj:`True`.
     """
 
     self._motor: Optional[Stepper] = None
@@ -85,6 +86,8 @@ class Phidget4AStepper(Actuator):
     if self._absolute_mode:
       self._ref_pos = reference_pos
 
+    # Determining the path where to save the last position
+    # It depends on the current operating system
     self._path: Optional[Path] = None
     if save_last_pos:
       if save_pos_folder is not None:

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -77,8 +77,7 @@ class Phidget4AStepper(Actuator):
     self._max_acceleration = max_acceleration
     self._remote = remote
     self._switch_ports = switch_ports
-    if self._switch_ports is not None:
-      self._switches = []
+    self._switches = []
     self._absolute_mode = absolute_mode
     if self._absolute_mode is True:
       self._ref_pos = reference_pos
@@ -113,17 +112,15 @@ class Phidget4AStepper(Actuator):
     if self._remote is True:
       self._motor.setIsLocal(False)
       self._motor.setIsRemote(True)
-      if self._switch_ports is not None:
-        for switch in self._switches:
-          switch.setIsLocal(False)
-          switch.setIsRemote(True)
+      for switch in self._switches:
+        switch.setIsLocal(False)
+        switch.setIsRemote(True)
     else:
       self._motor.setIsLocal(True)
       self._motor.setIsRemote(False)
-      if self._switch_ports is not None:
-        for switch in self._switches:
-          switch.setIsLocal(True)
-          switch.setIsRemote(False)
+      for switch in self._switches:
+        switch.setIsLocal(True)
+        switch.setIsRemote(False)
 
     # Setting up the callbacks
     self.log(logging.DEBUG, "Setting the callbacks")
@@ -131,9 +128,8 @@ class Phidget4AStepper(Actuator):
     self._motor.setOnErrorHandler(self._on_error)
     self._motor.setOnVelocityChangeHandler(self._on_velocity_change)
     self._motor.setOnPositionChangeHandler(self._on_position_change)
-    if self._switch_ports is not None:
-      for switch in self._switches:
-        switch.setOnStateChangeHandler(self._on_end)
+    for switch in self._switches:
+      switch.setOnStateChangeHandler(self._on_end)
 
     # Opening the connection to the motor driver
     try:
@@ -143,22 +139,20 @@ class Phidget4AStepper(Actuator):
       raise TimeoutError("Waited too long for the motor to attach !")
 
     # Opening the connection to the switches
-    if self._switch_ports is not None:
-      for switch in self._switches:
-        try:
-          self.log(logging.DEBUG, "Trying to attach the switch")
-          switch.openWaitForAttachment(10000)
-        except PhidgetException:
-          raise TimeoutError("Waited too long for the switch to attach !")
+    for switch in self._switches:
+      try:
+        self.log(logging.DEBUG, "Trying to attach the switch")
+        switch.openWaitForAttachment(10000)
+      except PhidgetException:
+        raise TimeoutError("Waited too long for the switch to attach !")
 
     # Energizing the motor
     self._motor.setEngaged(True)
 
     # Check the state of the switches
-    if self._switch_ports is not None:
-      for switch in self._switches:
-        if switch.getState() is False:
-          raise ValueError(f"The switch is already hit or disconnected")
+    for switch in self._switches:
+      if switch.getState() is False:
+        raise ValueError(f"The switch is already hit or disconnected")
 
   def set_speed(self, speed: float) -> None:
     """Sets the requested speed for the motor.
@@ -249,9 +243,8 @@ class Phidget4AStepper(Actuator):
         np.save(self._save_folder + 'last_pos', self.get_position())
       self._motor.close()
 
-    if self._switch_ports is not None:
-      for switch in self._switches:
-        switch.close()
+    for switch in self._switches:
+      switch.close()
 
   def _on_attach(self, _: Stepper) -> None:
     """Callback called when the motor driver attaches to the program.

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -304,4 +304,5 @@ class Phidget4AStepper(Actuator):
 
   def _on_end(self, _: DigitalInput, state) -> None:
     """Callback when a switch is hit."""
+
     self.stop()

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -211,17 +211,18 @@ class Phidget4AStepper(Actuator):
       else:
         self._motor.setVelocityLimit(abs(speed))
 
+    # Ensuring that the requested position is valid
+    min_pos = self._motor.getMinPosition()
+    max_pos = self._motor.getMaxPosition()
+    if not min_pos <= position <= max_pos:
+      raise ValueError(f"The position value must be between {min_pos} and "
+                       f"{max_pos}, got {position} !")
+
+    # Setting the position depending on the driving mode
     if not self._absolute_mode:
-      # Setting the requested position
-      min_pos = self._motor.getMinPosition()
-      max_pos = self._motor.getMaxPosition()
-      if not min_pos <= position <= max_pos:
-        raise ValueError(f"The position value must be between {min_pos} and "
-                         f"{max_pos}, got {position} !")
-      else:
-        self._motor.setTargetPosition(position)
+      self._motor.setTargetPosition(position)
     else:
-      self._motor.setTargetPosition(position-self._ref_pos)
+      self._motor.setTargetPosition(position - self._ref_pos)
 
   def get_speed(self) -> Optional[float]:
     """Returns the last known speed of the motor."""

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -2,7 +2,9 @@
 
 import logging
 import numpy as np
-from typing import Optional, Tuple
+from pathlib import Path
+from platform import system
+from typing import Optional, Tuple, Union
 
 from .meta_actuator import Actuator
 from .._global import OptionalModule
@@ -39,7 +41,7 @@ class Phidget4AStepper(Actuator):
                max_acceleration: Optional[float] = None,
                remote: bool = False,
                absolute_mode: bool = False,
-               reference_pos: Optional[float] = 0,
+               reference_pos: float = 0,
                switch_ports: Optional[Tuple[int, ...]] = None,
                save_last_pos: bool = False,
                save_pos_folder: Optional[str] = './') -> None:

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -42,7 +42,7 @@ class Phidget4AStepper(Actuator):
                remote: bool = False,
                absolute_mode: bool = False,
                reference_pos: float = 0,
-               switch_ports: Optional[Tuple[int, ...]] = None,
+               switch_ports: Tuple[int, ...] = tuple(),
                save_last_pos: bool = False,
                save_pos_folder: Optional[Union[str, Path]] = None) -> None:
     """Sets the args and initializes the parent class.
@@ -110,12 +110,11 @@ class Phidget4AStepper(Actuator):
     self._motor = Stepper()
 
     # Setting up the switches
-    if self._switch_ports is not None:
-      for port in self._switch_ports:
-        switch = DigitalInput()
-        switch.setIsHubPortDevice(True)
-        switch.setHubPort(port)
-        self._switches.append(switch)
+    for port in self._switch_ports:
+      switch = DigitalInput()
+      switch.setIsHubPortDevice(True)
+      switch.setHubPort(port)
+      self._switches.append(switch)
 
     # Setting the remote or local status
     self._motor.setIsLocal(not self._remote)

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -77,9 +77,10 @@ class Phidget4AStepper(Actuator):
     self._max_acceleration = max_acceleration
     self._remote = remote
     self._switch_ports = switch_ports
-    self._switches = []
+    self._switches = list()
+
     self._absolute_mode = absolute_mode
-    if self._absolute_mode is True:
+    if self._absolute_mode:
       self._ref_pos = reference_pos
     self._save_last_pos = save_last_pos
     if self._save_last_pos is True:
@@ -109,7 +110,7 @@ class Phidget4AStepper(Actuator):
         self._switches.append(switch)
 
     # Setting the remote or local status
-    if self._remote is True:
+    if self._remote:
       self._motor.setIsLocal(False)
       self._motor.setIsRemote(True)
       for switch in self._switches:
@@ -202,7 +203,7 @@ class Phidget4AStepper(Actuator):
       else:
         self._motor.setVelocityLimit(abs(speed))
 
-    if self._absolute_mode is not True:
+    if not self._absolute_mode:
       # Setting the requested position
       min_pos = self._motor.getMinPosition()
       max_pos = self._motor.getMaxPosition()
@@ -222,7 +223,7 @@ class Phidget4AStepper(Actuator):
   def get_position(self) -> Optional[float]:
     """Returns the last known position of the motor."""
 
-    if self._absolute_mode is not True:
+    if not self._absolute_mode:
       return self._last_position
     else:
       if self._last_position is None:
@@ -295,7 +296,7 @@ class Phidget4AStepper(Actuator):
     self.log(logging.DEBUG, f"Position changed to {position}")
     self._last_position = position
 
-  def _on_end(self, _: DigitalInput, state) -> None:
+  def _on_end(self, _: DigitalInput, __) -> None:
     """Callback when a switch is hit."""
 
     self.stop()


### PR DESCRIPTION
Currently, limit switches are not implemented for the Phidget4AStepper. It is a problem because limit switches are an important safety feature on a tensile test machine.
Also, the motor position is always driven and calculated from its current position. It can be problematic in some situations, and taking a fix absolute position as a reference might be needed.

In this PR, limit switches are implemented (228d347) and can now stop the motor when hit. An absolute mode is also added (3052e75) with the possibility to save the last position of the motor (e32147f) in order to, for example, use it later as a reference position.