### PR TITLE
Add a class attribute to check switches state in the open method

### DIFF
--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -81,6 +81,12 @@ class Phidget4AStepper(Actuator):
     self._remote = remote
     self._switch_ports = switch_ports
     self._switches = list()
+
+    # The following attribute is set to True to automatically check the state
+    # of the switches in the open method to keep the motor to move if a switch
+    # has been disconnected or hit.
+    # Nevertheless, this check can be bypassed if the motor is used outside
+    # from a Crappy loop by setting the attribute to False.
     self._check_switch = True
 
     self._absolute_mode = absolute_mode
@@ -155,10 +161,9 @@ class Phidget4AStepper(Actuator):
     self._motor.setEngaged(True)
 
     # Check the state of the switches
-    if self._check_switch:
-      for switch in self._switches:
-        if switch.getState() is False:
-          raise ValueError(f"A switch is already hit or disconnected")
+    if self._check_switch and not all(
+      switch.getState() for switch in self._switches):
+      raise ValueError(f"A switch is already hit or disconnected !")
 
   def set_speed(self, speed: float) -> None:
     """Sets the requested speed for the motor.
@@ -303,10 +308,9 @@ class Phidget4AStepper(Actuator):
     self.log(logging.DEBUG, f"Position changed to {position}")
     self._last_position = position
 
-  def _on_end(self, _: DigitalInput, __) -> None:
+  def _on_end(self, _: DigitalInput, state) -> None:
     """Callback when a switch is hit."""
 
-    for switch in self._switches:
-      if switch.getState() is False:
-        self.stop()
-        raise ValueError(f"A switch has been hit or disconnected")
+    if bool(state) is False:
+      self.stop()
+      raise ValueError(f"A switch has been hit or disconnected !")

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -81,6 +81,7 @@ class Phidget4AStepper(Actuator):
     self._remote = remote
     self._switch_ports = switch_ports
     self._switches = list()
+    self._check_switch = True
 
     self._absolute_mode = absolute_mode
     if self._absolute_mode:
@@ -154,9 +155,10 @@ class Phidget4AStepper(Actuator):
     self._motor.setEngaged(True)
 
     # Check the state of the switches
-    for switch in self._switches:
-      if switch.getState() is False:
-        raise ValueError(f"The switch is already hit or disconnected")
+    if self._check_switch:
+      for switch in self._switches:
+        if switch.getState() is False:
+          raise ValueError(f"A switch is already hit or disconnected")
 
   def set_speed(self, speed: float) -> None:
     """Sets the requested speed for the motor.
@@ -304,4 +306,7 @@ class Phidget4AStepper(Actuator):
   def _on_end(self, _: DigitalInput, __) -> None:
     """Callback when a switch is hit."""
 
-    self.stop()
+    for switch in self._switches:
+      if switch.getState() is False:
+        self.stop()
+        raise ValueError(f"A switch has been hit or disconnected")

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -311,6 +311,6 @@ class Phidget4AStepper(Actuator):
   def _on_end(self, _: DigitalInput, state) -> None:
     """Callback when a switch is hit."""
 
-    if bool(state) is False:
+    if not bool(state):
       self.stop()
       raise ValueError(f"A switch has been hit or disconnected !")


### PR DESCRIPTION
Currently, the state of the switches are always checked in the `open` method of the Phidget4AStepper to keep the motor to move if a switch has been disconnected or hit. Nevertheless, it could be useful to pass this check if you know already know the a switch has been hit and you want to drive the motor away from the switch.

That's why in this PR, a class attribute has been implemented (6beedcc) in order to choose if you want to perform this check or not.