### PR TITLE
build: update project version from 2.0.3 to 2.0.4

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@
 from time import gmtime, strftime
 from re import match
 
-__version__ = '2.0.3'
+__version__ = '2.0.4'
 
 # -- Project information -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "crappy"
 dynamic = ["readme"]
-version = "2.0.3"
+version = "2.0.4"
 description = "Command and Real-time Acquisition in Parallelized Python"
 license = {file = "LICENSE"}
 keywords = ["control", "command", "acquisition", "multiprocessing"]

--- a/src/crappy/__version__.py
+++ b/src/crappy/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-__version__ = '2.0.3'
+__version__ = '2.0.4'


### PR DESCRIPTION
The new 2.0.4 release brings various minor improvements to Crappy:
* It adds the [`Phidget4AStepper`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b7daa6ba3ef80527b75b6b604ece1802cb1d25b7/src/crappy/actuator/phidgets_stepper4a.py) Actuator, for controlling  a Phidget stepper motor driver (#88)
* It adds the [`PhidgetWheatstoneBridge`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b7daa6ba3ef80527b75b6b604ece1802cb1d25b7/src/crappy/inout/phidgets_wheatstone_bridge.py) InOut, for driving a Phidget load cell conditioner (#88)
* It adds an automated [GitHub workflow](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b7daa6ba3ef80527b75b6b604ece1802cb1d25b7/.github/workflows/python_package.yml) checking that Crappy builds and installs on the supported OS and Python versions (#89)
* It adds the [`DownSampler`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/b7daa6ba3ef80527b75b6b604ece1802cb1d25b7/src/crappy/modifier/downsampler.py) Modifier, that reduces the data rate on a given Link (#90)