### PR TITLE
Missing `resources` class in `__init__.py`

### DIFF
--- a/src/crappy/__init__.py
+++ b/src/crappy/__init__.py
@@ -17,7 +17,7 @@ from . import tool
 
 # Importing other features
 from .__version__ import __version__
-from ._global import OptionalModule, docs
+from ._global import OptionalModule, docs, resources
 
 # Useful aliases
 link = links.link


### PR DESCRIPTION
In versions `2.0.3` and `2.0.4`, the [`resources`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/be9ce7a89cb9f471367e1a98acdb9caf837d8ac8/src/crappy/_global.py#L96) class was moved to the [`_global.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/be9ce7a89cb9f471367e1a98acdb9caf837d8ac8/src/crappy/_global.py#L96) file (12ee73a081ce643cef0560b6159b18c3b2e18fd6). However, there was an omission to import this class in the [`__init__.py`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/be9ce7a89cb9f471367e1a98acdb9caf837d8ac8/src/crappy/__init__.py) file. Consequently, all the examples relying on the `resources` class (mostly the ones handling example images) were broken.

This PR simply adds back the correct import in `__init__.py`, therefore fixing the broken examples. The `2.0.3` and `2.0.4` versions will be yanked on PyPI once `2.0.5` is released.