### PR TITLE
Not setting shape and dtype in config window when no image acquired

### DIFF
--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -1018,8 +1018,12 @@ class CameraConfig(tk.Tk):
 
     ret = self._camera.get_image()
 
+    # Flag raised if no image could be grabbed
+    no_img = False
+
     # If no frame could be grabbed from the camera
     if ret is None:
+      no_img = True
       # If it's the first call, generate error image to initialize the window
       if not self._n_loops:
         self.log(logging.WARNING, "Could not get an image from the camera, "
@@ -1036,9 +1040,9 @@ class CameraConfig(tk.Tk):
     self._n_loops += 1
     _, img = ret
 
-    if img.dtype != self.dtype:
+    if not no_img and img.dtype != self.dtype:
       self.dtype = img.dtype
-    if self.shape != img.shape:
+    if not no_img and img.shape != self.shape:
       self.shape = img.shape
 
     self._cast_img(img)


### PR DESCRIPTION
When using the Camera Configuration window ([`CameraConfig`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/f7ceb73e95cc42737005649b843c01a9859873d3/src/crappy/tool/camera_config/camera_config.py#L29)), the shape and data type of the last acquired image is saved. It is then passed to the parent [`Camera` Block](https://github.com/LaboratoireMecaniqueLille/crappy/blob/f7ceb73e95cc42737005649b843c01a9859873d3/src/crappy/blocks/camera.py#L21), for initializing internal data structures. When no image can be grabbed, an information image is displayed in the configuration window. However, until now, the shape and dtype of this information image was being saved and passed to the `Camera` Block. This was causing cryptic bugs for users.

With this PR, the shape and dtype is never saved when the information image is displayed. If no real image can be acquired before exiting the configuration window, an error signaling that the shape and dtype are missing is raised and stops the test.