### PR TITLE
Wrong type hint for the image shape argument

### DIFF
--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -68,7 +68,8 @@ class Camera(Block):
                save_backend: Optional[str] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
-               img_shape: Optional[Tuple[int, int]] = None,
+               img_shape: Optional[Union[Tuple[int, int],
+                                         Tuple[int, int, int]]] = None,
                img_dtype: Optional[str] = None,
                **kwargs) -> None:
     """Sets the arguments and initializes the parent class.

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -87,7 +87,7 @@ class CameraProcess(Process):
                  lock: RLock,
                  barrier: Barrier,
                  event: Event,
-                 shape: Tuple[int, int],
+                 shape: Union[Tuple[int, int], Tuple[int, int, int]],
                  dtype,
                  to_draw_conn: Optional[Connection],
                  outputs: List[Link],

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -6,7 +6,7 @@ from _tkinter import TclError
 from platform import system
 import numpy as np
 from time import time, sleep
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 from pkg_resources import resource_string
 from io import BytesIO
 import logging
@@ -79,7 +79,7 @@ class CameraConfig(tk.Tk):
 
     super().__init__()
     self._camera = camera
-    self.shape = None
+    self.shape: Optional[Union[Tuple[int, int], Tuple[int, int, int]]] = None
     self.dtype = None
     self._logger: Optional[logging.Logger] = None
 


### PR DESCRIPTION
In the [`Camera` Block](https://github.com/LaboratoireMecaniqueLille/crappy/blob/f7ceb73e95cc42737005649b843c01a9859873d3/src/crappy/blocks/camera.py#L21) and [`CameraProcess` class](https://github.com/LaboratoireMecaniqueLille/crappy/blob/f7ceb73e95cc42737005649b843c01a9859873d3/src/crappy/blocks/camera_processes/camera_process.py#L23), the `img_shape` argument was type-hinted as `Tuple[int, int]`. This was correct for gray level images, but incorrect for color images.

With this PR, the type hints are updated to `Union[Tuple[int, int], Tuple[int, int, int]]` to also consider the image colors.