### PR TITLE
Change name of images recorded by the `Camera` Block

### DIFF
--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -208,11 +208,11 @@ class ImageSaver(CameraProcess):
 
     # Only include the extension for the image file if applicable
     if self._img_extension:
-      path = str(self._save_folder / f"{self.metadata['ImageUniqueID']}_"
+      path = str(self._save_folder / f"{self.metadata['ImageUniqueID']:06d}_"
                                      f"{self.metadata['t(s)']:.3f}."
                                      f"{self._img_extension}")
     else:
-      path = str(self._save_folder / f"{self.metadata['ImageUniqueID']}_"
+      path = str(self._save_folder / f"{self.metadata['ImageUniqueID']:06d}_"
                                      f"{self.metadata['t(s)']:.3f}")
 
     # Saving the image at the destination path using the chosen backend


### PR DESCRIPTION
As reported in #98, the name of the images saved by the [`Camera` Block](https://github.com/LaboratoireMecaniqueLille/crappy/blob/f7ceb73e95cc42737005649b843c01a9859873d3/src/crappy/blocks/camera.py#L21) (via the [`ImageSaver` `CameraProcess`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/f7ceb73e95cc42737005649b843c01a9859873d3/src/crappy/blocks/camera_processes/record.py#L32)) is currently in the format `f'{index}_{time:.3f}.{ext}'`. Example image names: `1_0.100`, `2_0.200`, `21_2.100`, etc. This poses problems for navigating in file explorers, or for compatibility with third -party processing software, as the first character in the name is used for sorting.

This PR changes the name of the recorded images to `f'{index:06d}_{time:.3f}.{ext}'`, therefore adding a zero-padding as a prefix to the index to get at least 6 digits. The example names become `000001_0.100`, `000002_0.200`, `000021_2.100`, etc. This PR fixes the sorting issue with file explorers and third-party software when less than 1 millions images are acquired. It preserves compatibility with the [`FileReader` Camera](https://github.com/LaboratoireMecaniqueLille/crappy/blob/f7ceb73e95cc42737005649b843c01a9859873d3/src/crappy/camera/file_reader.py#L23) without requiring changes in this file.