### PR TITLE
Refactor change-set information

### DIFF
--- a/src/crappy/_global.py
+++ b/src/crappy/_global.py
@@ -14,7 +14,7 @@ def docs():
   It opens the latest version, and of course requires an internet access.
 
   .. versionadded:: 1.5.5
-  .. versionchanged:: 2.0.0 renamed from doc to docs
+  .. versionchanged:: 2.0.0 renamed from *doc* to *docs*
   """
 
   webbrowser.open('https://crappy.readthedocs.io/en/latest/')
@@ -43,8 +43,8 @@ class OptionalModule:
       lazy_import: If :obj:`True`, the module won't be imported directly even
         if it is installed. Instead, it will be imported only when necessary.
         Allows reducing the import time, especially on Window.
-    
-    .. versionadded:: 2.0.0 *lazy_import* argument
+
+        .. versionadded:: 2.0.0
     """
 
     self._name = module_name

--- a/src/crappy/actuator/fake_dc_motor.py
+++ b/src/crappy/actuator/fake_dc_motor.py
@@ -12,7 +12,7 @@ class FakeDCMotor(Actuator):
   It is mainly intended for testing scripts without requiring any hardware.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 Renamed from Fake_motor to FakeDCMotor
+  .. versionchanged:: 2.0.0 Renamed from *Fake_motor* to *FakeDCMotor*
   """
 
   def __init__(self,
@@ -34,11 +34,11 @@ class FakeDCMotor(Actuator):
       fv: The internal fluid friction coefficient of the motor, no unit.
       simulation_speed: Speed factor of the simulation, to speed it up or slow
         it down.
+
+        .. versionchanged:: 2.0.0
+           renamed from *sim_speed* to *simulation_speed*
       initial_speed: The initial speed of the motor, in RPM.
       initial_pos: The initial position of the motor, in turns.
-    
-    .. versionchanged:: 2.0.0
-       renamed *sim_speed* argument to *simulation_speed*
     """
 
     super().__init__()
@@ -74,7 +74,7 @@ class FakeDCMotor(Actuator):
   def get_position(self) -> float:
     """Returns the position of the motor, in rounds.
 
-    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    .. versionchanged:: 1.5.2 renamed from *get_pos* to *get_position*
     """
 
     self._update()

--- a/src/crappy/actuator/jvl_mac_140.py
+++ b/src/crappy/actuator/jvl_mac_140.py
@@ -36,7 +36,7 @@ class JVLMac140(Actuator):
     Args:
       port: Path to the serial port to use for communication.
 
-    .. deprecated:: 2.0.0 *baudrate* argument
+    .. versionremoved:: 2.0.0 *baudrate* argument
     """
 
     self._ser = None
@@ -87,8 +87,8 @@ class JVLMac140(Actuator):
       position: The target position, in `mm`.
       speed: The target speed for reaching the desired position, in `mm/min`.
         The speed must be given, otherwise an exception is raised.
-    
-    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
+
+        .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     """
 
     if speed is None:
@@ -117,7 +117,7 @@ class JVLMac140(Actuator):
   def get_position(self) -> float:
     """Reads and returns the current position of the servomotor, in `mm`.
 
-    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    .. versionchanged:: 1.5.2 renamed from *get_pos* to *get_position*
     """
 
     # We have 20 attempts for reading the position

--- a/src/crappy/actuator/kollmorgen_servostar_300.py
+++ b/src/crappy/actuator/kollmorgen_servostar_300.py
@@ -21,7 +21,7 @@ class ServoStar300(Actuator):
   in speed.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Servostar to ServoStar300
+  .. versionchanged:: 2.0.0 renamed from *Servostar* to *ServoStar300*
   """
 
   def __init__(self,
@@ -32,13 +32,12 @@ class ServoStar300(Actuator):
 
     Args:
       port: Path to the serial port used for communication.
+
+        .. versionchanged:: renamed from *device* to *port*
       baudrate: The serial baud rate to use, as an :obj:`int`.
       mode: The driving mode to use when starting the test. Can be `'analog'`
         or `'serial'`. It can be changed afterward while the test is running,
         by sending the right command.
-    
-    .. deprecated:: 2.0.0 *device argument*
-    .. versionchanged:: 2.0.0 use *port* instead of *device*
     """
 
     self._ser = None
@@ -90,9 +89,10 @@ class ServoStar300(Actuator):
         sets the driving mode to analog.
       speed: The speed at which the actuator should reach its target position.
         If no speed is specified, the default is `20000`.
+
+        .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     
-    .. deprecated:: 2.0.0 remove *acc* and *dec* arguments
-    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
+    .. versionremoved:: 2.0.0 *acc* and *dec* arguments
     """
 
     if speed is None:
@@ -129,7 +129,7 @@ class ServoStar300(Actuator):
   def get_position(self) -> Optional[float]:
     """Reads and returns the current position of the motor.
 
-    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    .. versionchanged:: 1.5.2 renamed from *get_pos* to *get_position*
     """
 
     # Requesting a position reading

--- a/src/crappy/actuator/meta_actuator/actuator.py
+++ b/src/crappy/actuator/meta_actuator/actuator.py
@@ -118,9 +118,10 @@ class Actuator(metaclass=MetaActuator):
       speed: The speed at which to move to the desired position, as a
         :obj:`float`, or :obj:`None` if no speed is specified.
 
+        .. versionchanged:: 2.0.0
+          *speed* is now a mandatory argument even if it is :obj:`None`
+
     .. versionadded:: 1.5.10
-    .. versionchanged:: 2.0.0
-       *speed* is now a mandatory argument even if it is :obj:`None`
     """
 
     self.log(logging.WARNING, f"The set_position method was called but is not "

--- a/src/crappy/actuator/newport_tra6ppd.py
+++ b/src/crappy/actuator/newport_tra6ppd.py
@@ -27,7 +27,7 @@ class NewportTRA6PPD(Actuator):
     This Actuator ignores new position commands while it is moving.
   
   .. versionadded:: 1.5.10
-  .. versionchanged:: 2.0.0 renamed from TRA6PPD to NewportTRA6PPD
+  .. versionchanged:: 2.0.0 renamed from *TRA6PPD* to *NewportTRA6PPD*
   """
 
   def __init__(self,

--- a/src/crappy/actuator/oriental_ard_k.py
+++ b/src/crappy/actuator/oriental_ard_k.py
@@ -22,7 +22,7 @@ class OrientalARDK(Actuator):
   of its instances at a time, corresponding to different axes to drive.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Oriental to OrientalARDK
+  .. versionchanged:: 2.0.0 renamed from *Oriental* to *OrientalARDK*
   """
 
   def __init__(self,
@@ -137,8 +137,8 @@ class OrientalARDK(Actuator):
       position: The target position to reach, in arbitrary units.
       speed: The speed to use for reaching the target position, in arbitrary
         units. A speed must be given, otherwise an exception is raised.
-    
-    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
+
+        .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     """
 
     if speed is None:
@@ -153,7 +153,7 @@ class OrientalARDK(Actuator):
   def get_position(self) -> float:
     """Reads and returns the current position of the motor.
 
-    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    .. versionchanged:: 1.5.2 renamed from *get_pos* to *get_position*
     """
 
     # Sending the read command

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -33,6 +33,8 @@ class Phidget4AStepper(Actuator):
 
   The distance unit is the `mm` and the time unit is the `s`, so speeds are in
   `mm/s` and accelerations in `mm/s²`.
+
+  .. versionadded:: 2.0.3
   """
 
   def __init__(self,
@@ -60,15 +62,25 @@ class Phidget4AStepper(Actuator):
       absolute_mode: If :obj:`True`, the target position of the motor will be
         calculated from a reference position. If :obj:`False`, the target
         position of the motor will be calculated from its current position.
+
+        .. versionadded:: 2.0.4
       reference_pos: The position considered as the reference position at the
         beginning of the test. Only takes effect if ``absolute_mode`` is
         :obj:`True`.
+
+        .. versionadded:: 2.0.4
       switch_ports: The indexes of the VINT Hub ports where the switches are
         connected.
+
+        .. versionadded:: 2.0.4
       save_last_pos: If :obj:`True`, the last position of the actuator will be
         saved in a .npy file.
+
+        .. versionadded:: 2.0.4
       save_pos_folder: The path to the folder where to save the last position
         of the motor. Only takes effect if ``save_last_pos`` is :obj:`True`.
+
+        .. versionadded:: 2.0.4
     """
 
     self._motor: Optional[Stepper] = None

--- a/src/crappy/actuator/pololu_tic.py
+++ b/src/crappy/actuator/pololu_tic.py
@@ -271,7 +271,7 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
     in a shell opened in ``/etc/udev/rules.d``.
     
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Pololu_tic to PololuTic
+  .. versionchanged:: 2.0.0 renamed from *Pololu_tic* to *PololuTic*
   """
 
   def __init__(self,
@@ -728,7 +728,7 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
     Returns:
       The position in `mm`
     
-    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    .. versionchanged:: 1.5.2 renamed from *get_pos* to *get_position*
     """
 
     if self._backend == 'ticcmd':
@@ -753,14 +753,14 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
         in `mm/s` Giving a speed other than :obj:`None` will set the maximum
         speed of the motor to that speed.
 
+        .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
+
     Note:
       - ``speed``:
         The only way to reach a position at a given speed is to change the
         maximum speed. The Tic will try to accelerate to the maximum speed but
         may remain slower if it doesn't have time to do so before reaching the
         given position.
-    
-    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
     """
 
     if speed is not None:

--- a/src/crappy/actuator/schneider_mdrive_23.py
+++ b/src/crappy/actuator/schneider_mdrive_23.py
@@ -20,7 +20,7 @@ class SchneiderMDrive23(Actuator):
   It communicates with the motor over a serial connection.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from CM_drive to SchneiderMDrive23
+  .. versionchanged:: 2.0.0 renamed from *CM_drive* to *SchneiderMDrive23*
   """
 
   def __init__(self,
@@ -78,9 +78,10 @@ class SchneiderMDrive23(Actuator):
     Args:
       position: The target position to reach, in `mm`.
       _: The speed argument is ignored.
-    
-    .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
-    .. deprecated:: 2.0.0 *motion_type* argument
+
+        .. versionchanged:: 2.0.0 *speed* is now a mandatory argument
+
+    .. versionremoved:: 2.0.0 *motion_type* argument
     """
 
     # Closing and reopening to get rid of errors
@@ -96,7 +97,7 @@ class SchneiderMDrive23(Actuator):
   def get_position(self) -> float:
     """Reads, displays and returns the current position in `mm`.
     
-    .. versionchanged:: 1.5.2 renamed from get_pos to get_position
+    .. versionchanged:: 1.5.2 renamed from *get_pos* to *get_position*
     """
 
     # Closing and reopening to get rid of errors

--- a/src/crappy/blocks/auto_drive_video_extenso.py
+++ b/src/crappy/blocks/auto_drive_video_extenso.py
@@ -24,7 +24,7 @@ class AutoDriveVideoExtenso(Block):
   labels. It can then be used by downstream Blocks.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from AutoDrive to AutoDriveVideoExtenso
+  .. versionchanged:: 2.0.0 renamed from *AutoDrive* to *AutoDriveVideoExtenso*
   """
 
   def __init__(self,
@@ -48,26 +48,30 @@ class AutoDriveVideoExtenso(Block):
       gain: The gain for driving the Actuator in speed. The speed command is
         simply the difference in pixels between the center of the image and the
         center of the spots, multiplied by this gain.
+
+        .. versionchanged:: 1.5.10 renamed from *P* to *gain*
       direction: Indicates which axis to consider for driving the Actuator, and
         whether the action should be inverted. The first character is the axis
         (`X` or `Y`) and second character is the inversion (`+` or `-`). The
         inversion depends on whether a positive speed will bring the spots
         closer or farther.
       pixel_range: The size of the image (in pixels) along the chosen axis.
+
+        .. versionchanged:: 1.5.10 renamed from *range* to *pixel_range*
       max_speed: The absolute maximum speed value that can be sent to the
         Actuator.
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionadded:: 2.0.0
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionchanged:: 1.5.10 renamed *P* argument to *gain*
-    .. versionchanged:: 1.5.10 renamed *range* argument to *pixel_range*
-    .. versionadded:: 2.0.0 *display_freq* and *debug* arguments
+
+        .. versionadded:: 2.0.0
     """
 
     self._device: Optional[Actuator] = None

--- a/src/crappy/blocks/button.py
+++ b/src/crappy/blocks/button.py
@@ -27,7 +27,7 @@ class Button(Block):
   the experimenter has completed a task, for example.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from GUI to Button
+  .. versionchanged:: 2.0.0 renamed from *GUI* to *Button*
   """
 
   def __init__(self,
@@ -44,23 +44,28 @@ class Button(Block):
       send_0: If :obj:`True`, the value `0` will be sent automatically when
         starting the Block. Otherwise, `1` will be sent at the first click.
         Only relevant when ``spam`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       label: The label carrying the information on the number of clicks,
         default is ``'step'``.
       time_label: The label carrying the time information, default is
         ``'t(s)'``.
+
+        .. versionadded:: 1.5.10
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
       spam: If :obj:`True`, sends the current step value at each loop,
         otherwise only sends it at each click.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionadded:: 2.0.0
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded:: 1.5.10 *send_0* and *time_label* arguments
-    .. versionadded:: 2.0.0 *display_freq* and *debug* arguments
+
+        .. versionadded:: 2.0.0
     """
 
     self._root: Optional[tk.Tk] = None

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -86,6 +86,8 @@ class Camera(Block):
         transformed image is displayed and/or saved and/or further processed.
         The transform operation is not parallelized, so it might negatively
         affect the acquisition framerate if it is too heavy.
+
+        .. versionadded:: 1.5.10
       config: If :obj:`True`, a 
         :class:`~crappy.tool.camera_config.CameraConfig` window is displayed
         before the test starts. There, the user can interactively adjust the 
@@ -95,6 +97,8 @@ class Camera(Block):
         visualize the acquired images. The test starts when closing the 
         configuration window. If not enabled, the ``img_dtype`` and 
         ``img_shape`` arguments must be provided.
+
+        .. versionadded:: 1.5.10
       display_images: If :obj:`True`, displays the acquired images in a
         dedicated window, using the backend given in ``displayer_backend`` and
         at the frequency specified in ``displayer_framerate``. This option
@@ -102,16 +106,23 @@ class Camera(Block):
         intended to be very fast nor to display high-quality images. The
         maximum resolution of the displayed images in `640x480`, the images
         might be downscaled to fit in this format.
+
+        .. versionchanged:: 1.5.10
+           renamed from *show_image* to *display_images*
       displayer_backend: The backend to use for displaying the images. Can be
         either ``'cv2'`` or ``'mpl'``, to use respectively :mod:`cv2` (OpenCV)
         or :mod:`matplotlib`. ``'cv2'`` usually allows achieving a higher
         display frequency. Ignored if ``display_images`` is :obj:`False`. If
         not given and ``display_images`` is :obj:`True`, ``'cv2'`` is tried
         first and ``'mpl'`` second, and the first available one is used.
+
+        .. versionadded:: 1.5.10
       displayer_framerate: The maximum update frequency of the image displayer, 
         as an :obj:`int`. This value usually lies between 5 and 30Hz, the 
         default is 5. The achieved update frequency might be lower than
         requested. Ignored if ``display_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       software_trig_label: The name of a label used as a software trigger for 
         the :class:`~crappy.camera.Camera`. If given, images will only be 
         acquired when receiving data over this label. The received value does
@@ -119,14 +130,22 @@ class Camera(Block):
         is recommended not to rely on it for a trigger frequency greater than
         10Hz, in which case a hardware trigger should be preferred if available
         on the camera.
+
+        .. versionadded:: 2.0.0
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       save_images: If :obj:`True`, the acquired images are saved to the folder
         specified in ``save_folder``, in the format specified in 
         ``img_extension``, using the backend specified in ``save_backend``, and
@@ -139,12 +158,16 @@ class Camera(Block):
         the :meth:`loop` method of this Block. Depending on the framerate of
         the camera and the performance of the computer, it is not guaranteed 
         that all the acquired images will be recorded.
+
+        .. versionadded:: 1.5.10
       img_extension: The file extension for the recorded images, as a
         :obj:`str` and without the dot. Common file extensions include `tiff`,
         `png`, `jpg`, etc. Depending on the used ``save_backend``, some 
         extensions might not be available. It is currently not possible to
         customize the save parameters further than choosing the file extension.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 2.0.0
       save_folder: Path to the folder where to save the images, either as a 
         :obj:`str` or as a :obj:`pathlib.Path`. Can be an absolute or a 
         relative path, pointing to a folder. If the folder does not exist, it 
@@ -154,11 +177,15 @@ class Camera(Block):
         a suffix is appended. Ignored if ``save_images`` is :obj:`False`. If
         not provided and ``save_images`` is :obj:`True`, the images are saved
         to the folder ``Crappy_images``, created next to the running script.
+
+        .. versionadded:: 1.5.10
       save_period: Must be given as an :obj:`int`. Only one out of that number 
         images at most will be saved. Allows to have a known periodicity in 
         case the framerate is too high to record all the images. Or simply to 
         reduce the number of recorded images if saving them all is not needed.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       save_backend: If ``save_images`` is :obj:`True`, the backend to use for 
         recording the images. It should be one of:
         ::
@@ -173,6 +200,8 @@ class Camera(Block):
         Python must of course be installed. If not provided and ``save_images``
         is :obj:`True`, the backends are tried in the same order as given above
         and the first available one is used. ``'npy'`` is always available.
+
+        .. versionadded:: 1.5.10
       image_generator: A callable taking two :obj:`float` as arguments and
         returning an image as a :obj:`numpy.array`. **This argument is intended
         for use in the examples of Crappy, to apply an artificial strain on a
@@ -180,31 +209,30 @@ class Camera(Block):
         argument is ignored and the images are acquired from the generator. To
         apply a strain on the image, strain values (in `%`) should be sent to 
         the Camera Block over the labels ``'Exx(%)'`` and ``'Eyy(%)'``.
+
+        .. versionadded:: 1.5.10
       img_shape: The shape of the images returned by the 
         :class:`~crappy.camera.Camera` object as a :obj:`tuple` of :obj:`int`.
         It should correspond to the value returned by :obj:`numpy.shape`. 
         **This argument is mandatory in case** ``config`` **is** :obj:`False`.
         It is otherwise ignored.
+
+        .. versionadded:: 2.0.0
       img_dtype: The `dtype` of the images returned by the
         :class:`~crappy.camera.Camera` object, as a :obj:`str`. It should
         correspond to a valid data type in :mod:`numpy`, e.g. ``'uint8'``.
         **This argument is mandatory in case** ``config`` **is** :obj:`False`.
         It is otherwise ignored.
+
+        .. versionadded:: 2.0.0
       **kwargs: Any additional argument will be passed to the 
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
     
     .. versionadded:: 1.5.2 *no_loop* argument
-    .. versionadded:: 1.5.10 
-       *display_images*, *displayer_backend*, *displayer_framerate*, 
-       *software_trig_label*, *freq*, *save_images* and *image_generator*
-       arguments
-    .. versionremoved::
-       1.5.10 *fps_label*, *ext*, *input_label* and *no_loop* arguments
-    .. versionadded:: 2.0.0
-       *debug*, *img_extension*, *img_shape* and *img_dtype* arguments
+    .. versionremoved:: 1.5.10
+       *fps_label*, *ext*, *input_label* and *no_loop* arguments
     .. versionremoved:: 2.0.0 *img_name* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._save_proc: Optional[ImageSaver] = None

--- a/src/crappy/blocks/canvas.py
+++ b/src/crappy/blocks/canvas.py
@@ -55,7 +55,7 @@ class DotText:
   """Like :class:`Text`, but with a colored dot to visualize a numerical value.
 
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Dot_text to DotText
+  .. versionchanged:: 2.0.0 renamed from *Dot_text* to *DotText*
   """
 
   def __init__(self,
@@ -153,7 +153,7 @@ class Canvas(Block):
   :class:`~crappy.blocks.LinkReader` Blocks should be preferred.
 
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Drawing to Canvas
+  .. versionchanged:: 2.0.0 renamed from *Drawing* to *Canvas*
   """
 
   def __init__(self,
@@ -175,6 +175,8 @@ class Canvas(Block):
         defining what to draw. See below for more details.
       color_range: A :obj:`tuple` containing the lowest and highest values for
         the color bar.
+
+        .. versionchanged:: 1.5.10 renamed from *crange* to *color_range*
       title: The title of the window containing the drawing.
       window_size: The `x` and `y` dimension of the window, following
         :mod:`matplotlib` nomenclature.
@@ -183,10 +185,15 @@ class Canvas(Block):
         as fast as possible.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
 
     Note:
       - Information about the ``draw`` keys:
@@ -205,11 +212,6 @@ class Canvas(Block):
         - ``label``: Mandatory for `'text'` and `'dot_text'` only, the label of
           the data to display. It will try to retrieve this data in the
           incoming Links. The ``text`` will then be updated with this data.
-    
-    .. versionchanged:: 1.5.10 renamed *crange* argument to *color_range*
-    .. versionadded:: 1.5.10 *verbose* argument
-    .. versionadded:: 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__()

--- a/src/crappy/blocks/client_server.py
+++ b/src/crappy/blocks/client_server.py
@@ -38,7 +38,7 @@ class ClientServer(Block):
   programs on a same machine, etc.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Client_server to ClientServer
+  .. versionchanged:: 2.0.0 renamed from *Client_server* to *ClientServer*
   """
 
   def __init__(self,
@@ -95,15 +95,24 @@ class ClientServer(Block):
         once in the topics.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       spam: If :obj:`True`, sends the last received values at each loop even if
         no new values were received from the broker. When set to :obj:`True`,
         the ``init_output`` must be provided.
+
+        .. versionadded:: 1.5.10
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
 
     Note:
       - ``broker``:
@@ -207,10 +216,6 @@ class ClientServer(Block):
         ::
 
           ('sign',)
-
-    .. versionadded:: 1.5.10 *verbose*, *freq* and *spam* arguments
-    .. versionadded:: 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._client: Optional[mqtt.Client] = None

--- a/src/crappy/blocks/dashboard.py
+++ b/src/crappy/blocks/dashboard.py
@@ -11,7 +11,8 @@ class DashboardWindow(tk.Tk):
   """The GUI for displaying the label values.
   
   .. versionadded:: 1.5.7
-  .. versionchanged:: 2.0.0 renamed from Dashboard_window to DashboardWindow
+  .. versionchanged:: 2.0.0
+     renamed from *Dashboard_window* to *DashboardWindow*
   """
 
   def __init__(self, labels: List[str]) -> None:
@@ -84,16 +85,19 @@ class Dashboard(Block):
       nb_digits: Number of decimals to show.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionadded:: 1.5.7
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.7
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded:: 1.5.7 *verbose* and *freq* arguments
-    .. versionadded:: 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+
+        .. versionadded:: 2.0.0
     """
 
     self._dashboard: Optional[DashboardWindow] = None

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -47,7 +47,7 @@ class DICVE(Camera):
   already specified as an argument.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from DISVE to DICVE
+  .. versionchanged:: 2.0.0 renamed from *DISVE* to *DICVE*
   """
 
   def __init__(self,
@@ -100,6 +100,8 @@ class DICVE(Camera):
         transformed image is displayed and/or saved and/or further processed.
         The transform operation is not parallelized, so it might negatively
         affect the acquisition framerate if it is too heavy.
+
+        .. versionadded:: 1.5.10
       config: If :obj:`True`, a
         :class:`~crappy.tool.camera_config.DICVEConfig` window is displayed
         before the test starts. There, the user can interactively adjust the
@@ -110,6 +112,8 @@ class DICVE(Camera):
         been given in the ``patches`` argument. The test starts when closing
         the configuration window. If not enabled, the ``img_dtype``,
         ``img_shape`` and ``patches`` arguments must be provided.
+
+        .. versionadded:: 1.5.10
       display_images: If :obj:`True`, displays the acquired images in a
         dedicated window, using the backend given in ``displayer_backend`` and
         at the frequency specified in ``displayer_framerate``. This option
@@ -119,16 +123,23 @@ class DICVE(Camera):
         might be downscaled to fit in this format. In addition to the acquired
         frames, the tracked patches are also displayed on the image as an
         overlay.
+
+        .. versionchanged:: 1.5.10
+           renamed from *show_image* to *display_images*
       displayer_backend: The backend to use for displaying the images. Can be
         either ``'cv2'`` or ``'mpl'``, to use respectively :mod:`cv2` (OpenCV)
         or :mod:`matplotlib`. ``'cv2'`` usually allows achieving a higher
         display frequency. Ignored if ``display_images`` is :obj:`False`. If
         not given and ``display_images`` is :obj:`True`, ``'cv2'`` is tried
         first and ``'mpl'`` second, and the first available one is used.
+
+        .. versionadded:: 1.5.10
       displayer_framerate: The maximum update frequency of the image displayer,
         as an :obj:`int`. This value usually lies between 5 and 30Hz, the
         default is 5. The achieved update frequency might be lower than
         requested. Ignored if ``display_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       software_trig_label: The name of a label used as a software trigger for
         the :class:`~crappy.camera.Camera`. If given, images will only be
         acquired when receiving data over this label. The received value does
@@ -136,14 +147,22 @@ class DICVE(Camera):
         is recommended not to rely on it for a trigger frequency greater than
         10Hz, in which case a hardware trigger should be preferred if available
         on the camera.
+
+        .. versionadded:: 2.0.0
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       save_images: If :obj:`True`, the acquired images are saved to the folder
         specified in ``save_folder``, in the format specified in
         ``img_extension``, using the backend specified in ``save_backend``, and
@@ -157,12 +176,16 @@ class DICVE(Camera):
         :class:`~crappy.blocks.Camera` Block. Depending on the framerate of the
         camera and the performance of the computer, it is not guaranteed that
         all the acquired images will be recorded.
+
+        .. versionadded:: 1.5.10
       img_extension: The file extension for the recorded images, as a
         :obj:`str` and without the dot. Common file extensions include `tiff`,
         `png`, `jpg`, etc. Depending on the used ``save_backend``, some
         extensions might not be available. It is currently not possible to
         customize the save parameters further than choosing the file extension.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 2.0.0
       save_folder: Path to the folder where to save the images, either as a
         :obj:`str` or as a :obj:`pathlib.Path`. Can be an absolute or a
         relative path, pointing to a folder. If the folder does not exist, it
@@ -172,11 +195,15 @@ class DICVE(Camera):
         a suffix is appended. Ignored if ``save_images`` is :obj:`False`. If
         not provided and ``save_images`` is :obj:`True`, the images are saved
         to the folder ``Crappy_images``, created next to the running script.
+
+        .. versionadded:: 1.5.10
       save_period: Must be given as an :obj:`int`. Only one out of that number
         images at most will be saved. Allows to have a known periodicity in
         case the framerate is too high to record all the images. Or simply to
         reduce the number of recorded images if saving them all is not needed.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       save_backend: If ``save_images`` is :obj:`True`, the backend to use for
         recording the images. It should be one of:
         ::
@@ -191,6 +218,8 @@ class DICVE(Camera):
         Python must of course be installed. If not provided and ``save_images``
         is :obj:`True`, the backends are tried in the same order as given above
         and the first available one is used. ``'npy'`` is always available.
+
+        .. versionadded:: 1.5.10
       image_generator: A callable taking two :obj:`float` as arguments and
         returning an image as a :obj:`numpy.array`. **This argument is intended
         for use in the examples of Crappy, to apply an artificial strain on a
@@ -198,16 +227,22 @@ class DICVE(Camera):
         argument is ignored and the images are acquired from the generator. To
         apply a strain on the image, strain values (in `%`) should be sent to
         the Camera Block over the labels ``'Exx(%)'`` and ``'Eyy(%)'``.
+
+        .. versionadded:: 1.5.10
       img_shape: The shape of the images returned by the
         :class:`~crappy.camera.Camera` object as a :obj:`tuple` of :obj:`int`.
         It should correspond to the value returned by :obj:`numpy.shape`.
         **This argument is mandatory in case** ``config`` **is** :obj:`False`.
         It is otherwise ignored.
+
+        .. versionadded:: 2.0.0
       img_dtype: The `dtype` of the images returned by the
         :class:`~crappy.camera.Camera` object, as a :obj:`str`. It should
         correspond to a valid data type in :mod:`numpy`, e.g. ``'uint8'``.
         **This argument is mandatory in case** ``config`` **is** :obj:`False`.
         It is otherwise ignored.
+
+        .. versionadded:: 2.0.0
       patches: The coordinates of the several patches to track, as an iterable
         (like a :obj:`list` or a :obj:`tuple`) containing one or several
         :obj:`tuple` of exactly :obj:`int` values. These integers correspond to
@@ -241,6 +276,8 @@ class DICVE(Camera):
         meant for debugging. ``'Parabola'`` refines the result of
         ``'Pixel precision'`` by interpolating the neighborhood of the maximum,
         and has thus a sub-pixel resolution.
+
+        .. versionadded:: 1.5.9
       alpha: Weight of the smoothness term in DISFlow, as a :obj:`float`.
         Ignored if ``method`` is not ``'Disflow'``.
       delta: Weight of the color constancy term in DISFlow, as a :obj:`float`.
@@ -260,6 +297,9 @@ class DICVE(Camera):
         the patch inverse search stage in DISFlow, as an :obj:`int`. Higher
         values may improve the quality. Ignored if ``method`` is not
         ``'Disflow'``.
+
+        .. versionchanged:: 1.5.10
+          renamed from *gditerations* to *gradient_iterations*
       patch_size: The size of an image patch for matching in DISFlow, in pixels
         as an :obj:`int`. Ignored if ``method`` is not ``'Disflow'``.
       patch_stride: The stride between two neighbor patches in DISFlow, in
@@ -274,6 +314,8 @@ class DICVE(Camera):
       safe: If :obj:`True`, checks at each new image if the patches are not
         exiting the frame. Otherwise, the patches might exit the image which
         can lead to an unexpected behavior without raising an error.
+
+        .. versionadded:: 1.5.7
       follow: If :obj:`True`, the position of each patch on the images is
         adjusted at each new image based on the previous computed displacement
         of this patch. If a displacement of 1 in the `x` direction was
@@ -283,30 +325,20 @@ class DICVE(Camera):
         expected displacement in pixels is big compared to the patch size. The
         only downside is that the patches may exit the frame if something goes
         wrong with the tracking.
+
+        .. versionadded:: 1.5.7
       raise_on_patch_exit: If :obj:`True`, raises an exception when a tracked
         patch exits the border of the image, which stops the entire test.
         Otherwise, just logs a warning message and sleeps until the test is
         stopped in another way.
+
+        .. versionadded:: 2.0.0
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
 
-    .. versionadded:: 1.5.7 *safe* and *follow* arguments
     .. versionremoved:: 1.5.9 *fields* argument
-    .. versionadded:: 1.5.9 *method* argument
-    .. versionadded:: 1.5.10 
-       *transform*, *config*, *displayer_backend*, *displayer_framerate*, 
-       *verbose*, *freq*, *save_images*, *img_name*, *save_folder*, 
-       *save_period*, *save_backend* and *image_generator* arguments
-    .. versionchanged:: 1.5.10 
-       renamed *gditerations* argument to *gradient_iterations*
-    .. versionchanged:: 1.5.10 
-       renamed *show_image* argument to *display_images*
-    .. versionadded:: 2.0.0 
-       *debug*, *software_trig_label*, *img_extension*, *raise_on_patch_exit*,
-       *img_size* and *img_dtype* arguments
     .. versionremoved:: 2.0.0 *img_name* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     if not config and patches is None:

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -90,6 +90,8 @@ class DISCorrel(Camera):
         transformed image is displayed and/or saved and/or further processed.
         The transform operation is not parallelized, so it might negatively
         affect the acquisition framerate if it is too heavy.
+
+        .. versionadded:: 1.5.10
       config: If :obj:`True`, a
         :class:`~crappy.tool.camera_config.DISCorrelConfig` window is displayed
         before the test starts. There, the user can interactively adjust the
@@ -100,6 +102,8 @@ class DISCorrel(Camera):
         been given in the ``patch`` argument. The test starts when closing
         the configuration window. If not enabled, the ``img_dtype``,
         ``img_shape`` and ``patch`` arguments must be provided.
+
+        .. versionadded:: 1.5.10
       display_images: If :obj:`True`, displays the acquired images in a
         dedicated window, using the backend given in ``displayer_backend`` and
         at the frequency specified in ``displayer_framerate``. This option
@@ -109,16 +113,23 @@ class DISCorrel(Camera):
         might be downscaled to fit in this format. In addition to the acquired
         frames, the tracked patch is also displayed on the image as an
         overlay.
+
+        .. versionchanged:: 1.5.10
+           renamed from *show_image* to *display_images*
       displayer_backend: The backend to use for displaying the images. Can be
         either ``'cv2'`` or ``'mpl'``, to use respectively :mod:`cv2` (OpenCV)
         or :mod:`matplotlib`. ``'cv2'`` usually allows achieving a higher
         display frequency. Ignored if ``display_images`` is :obj:`False`. If
         not given and ``display_images`` is :obj:`True`, ``'cv2'`` is tried
         first and ``'mpl'`` second, and the first available one is used.
+
+        .. versionadded:: 1.5.10
       displayer_framerate: The maximum update frequency of the image displayer,
         as an :obj:`int`. This value usually lies between 5 and 30Hz, the
         default is 5. The achieved update frequency might be lower than
         requested. Ignored if ``display_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       software_trig_label: The name of a label used as a software trigger for
         the :class:`~crappy.camera.Camera`. If given, images will only be
         acquired when receiving data over this label. The received value does
@@ -126,14 +137,22 @@ class DISCorrel(Camera):
         is recommended not to rely on it for a trigger frequency greater than
         10Hz, in which case a hardware trigger should be preferred if available
         on the camera.
+
+        .. versionadded:: 2.0.0
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       save_images: If :obj:`True`, the acquired images are saved to the folder
         specified in ``save_folder``, in the format specified in
         ``img_extension``, using the backend specified in ``save_backend``, and
@@ -147,12 +166,16 @@ class DISCorrel(Camera):
         :class:`~crappy.blocks.Camera` Block. Depending on the framerate of the
         camera and the performance of the computer, it is not guaranteed that
         all the acquired images will be recorded.
+
+        .. versionadded:: 1.5.10
       img_extension: The file extension for the recorded images, as a
         :obj:`str` and without the dot. Common file extensions include `tiff`,
         `png`, `jpg`, etc. Depending on the used ``save_backend``, some
         extensions might not be available. It is currently not possible to
         customize the save parameters further than choosing the file extension.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 2.0.0
       save_folder: Path to the folder where to save the images, either as a
         :obj:`str` or as a :obj:`pathlib.Path`. Can be an absolute or a
         relative path, pointing to a folder. If the folder does not exist, it
@@ -162,11 +185,15 @@ class DISCorrel(Camera):
         a suffix is appended. Ignored if ``save_images`` is :obj:`False`. If
         not provided and ``save_images`` is :obj:`True`, the images are saved
         to the folder ``Crappy_images``, created next to the running script.
+
+        .. versionadded:: 1.5.10
       save_period: Must be given as an :obj:`int`. Only one out of that number
         images at most will be saved. Allows to have a known periodicity in
         case the framerate is too high to record all the images. Or simply to
         reduce the number of recorded images if saving them all is not needed.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       save_backend: If ``save_images`` is :obj:`True`, the backend to use for
         recording the images. It should be one of:
         ::
@@ -181,6 +208,8 @@ class DISCorrel(Camera):
         Python must of course be installed. If not provided and ``save_images``
         is :obj:`True`, the backends are tried in the same order as given above
         and the first available one is used. ``'npy'`` is always available.
+
+        .. versionadded:: 1.5.10
       image_generator: A callable taking two :obj:`float` as arguments and
         returning an image as a :obj:`numpy.array`. **This argument is intended
         for use in the examples of Crappy, to apply an artificial strain on a
@@ -188,22 +217,30 @@ class DISCorrel(Camera):
         argument is ignored and the images are acquired from the generator. To
         apply a strain on the image, strain values (in `%`) should be sent to
         the Camera Block over the labels ``'Exx(%)'`` and ``'Eyy(%)'``.
+
+        .. versionadded:: 1.5.10
       img_shape: The shape of the images returned by the
         :class:`~crappy.camera.Camera` object as a :obj:`tuple` of :obj:`int`.
         It should correspond to the value returned by :obj:`numpy.shape`.
         **This argument is mandatory in case** ``config`` **is** :obj:`False`.
         It is otherwise ignored.
+
+        .. versionadded:: 2.0.0
       img_dtype: The `dtype` of the images returned by the
         :class:`~crappy.camera.Camera` object, as a :obj:`str`. It should
         correspond to a valid data type in :mod:`numpy`, e.g. ``'uint8'``.
         **This argument is mandatory in case** ``config`` **is** :obj:`False`.
         It is otherwise ignored.
+
+        .. versionadded:: 2.0.0
       patch: The coordinates of the patch to track, as a :obj:`tuple` of
         exactly 4 :obj:`int`. These integers correspond to the `y` position of
         the top-left corner of the patch, the `x` position of the top-left
         corner of the patch, the height of the patch, and the width of the
         patch. Only one patch can be tracked. This argument must be provided if
         ``config`` is :obj:`False`.
+
+        .. versionadded:: 2.0.0
       fields: The several fields to calculate on the acquired images. They
         should be given as an iterable containing :obj:`str`. Each string
         represents one field to calculate, so the more fields are given the
@@ -241,6 +278,9 @@ class DISCorrel(Camera):
       gradient_iterations: The maximum number of gradient descent iterations in
         the patch inverse search stage in DISFlow, as an :obj:`int`. Higher
         values may improve the quality.
+
+        .. versionchanged:: 1.5.10
+          renamed from *gditerations* to *gradient_iterations*
       init: If :obj:`True`, the last calculated optical flow is used for
         initializing the calculation of the next one.
       patch_size: The size of an image patch for matching in DISFlow, in pixels
@@ -257,20 +297,9 @@ class DISCorrel(Camera):
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
 
-    .. versionadded:: 1.5.10 
-       *transform*, *config*, *displayer_backend*, *displayer_framerate*, 
-       *verbose*, *freq*, *save_images*, *img_name*, *save_folder*, 
-       *save_period*, *save_backend* and *image_generator* arguments
-    .. versionchanged:: 1.5.10 
-       renamed *gditerations* argument to *gradient_iterations*
-    .. versionchanged:: 1.5.10 
-       renamed *show_image* argument to *display_images*
+    .. versionadded:: 1.5.10 *img_name* argument
     .. versionremoved:: 1.5.10 *residual_full* argument
-    .. versionadded:: 2.0.0
-       *debug*, *patch*, *software_trig_label*, *img_extension*, *img_size* and
-       *img_dtype* arguments
     .. versionremoved:: 2.0.0 *img_name* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     if not config and patch is None:

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -35,7 +35,7 @@ class FakeMachine(Block):
   also be used to test a script without actually interacting with hardware.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Fake_machine to FakeMachine
+  .. versionchanged:: 2.0.0 renamed from *Fake_machine* to *FakeMachine*
   """
 
   def __init__(self,
@@ -55,10 +55,14 @@ class FakeMachine(Block):
 
     Args:
       rigidity: The rigidity of the material, in N, so that 
-        :math:`force = k * strain`.
+        :math:`force = rigidity * strain`.
+
+        .. versionchanged:: 2.0.0 renamed from *k* to *rigidity*
       l0: The initial length of the fake sample to test, in mm.
       max_strain: The maximum strain the material can withstand before
         breaking.
+
+        .. versionchanged:: 1.5.10 renamed from *maxstrain* to *max_strain*
       mode: Whether the command sent to the fake machine is a speed or a
         position command. Can be ``'speed'`` or ``'position'``.
       plastic_law: A callable taking the maximum reached strain and returning
@@ -71,18 +75,19 @@ class FakeMachine(Block):
       cmd_label: The label carrying the command of the fake machine.
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionchanged:: 1.5.10 renamed *maxstrain* argument to *max_strain*
-    .. versionadded:: 1.5.10 *freq* and *verbose* arguments
-    .. versionadded:: 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *k* argument to *rigidity*
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator.py
+++ b/src/crappy/blocks/generator.py
@@ -74,6 +74,8 @@ class Generator(Block):
         Block switched to the next Path.
       display_freq: if :obj:`True`, displays the looping frequency of the 
         Block.
+        
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       end_delay: When all the Paths are exhausted, waits this many seconds
         before stopping the entire script. Can be set to :obj:`None`,
         in which case the Generator won't stop the program when finishing.
@@ -81,15 +83,14 @@ class Generator(Block):
         upstream Blocks before sending the first value of the signal.
         Otherwise, the first value might be sent without checking the
         associated condition if its depends on labels from other Blocks.
+        
+        .. versionadded:: 1.5.10
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionremoved:: 1.5.10 *cmd* and *trig_link* argument
-    .. versionadded:: 1.5.10 *safe_start* argument
-    .. versionadded:: 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+        
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/conditional.py
+++ b/src/crappy/blocks/generator_path/conditional.py
@@ -15,6 +15,7 @@ class Conditional(Path):
   from overheating, or a motor from driving too far.
   
   .. versionadded:: 1.4.0
+  .. versionchanged:: 2.0.0 renamed from *Protection* to *Conditional*
   """
 
   def __init__(self,
@@ -45,7 +46,6 @@ class Conditional(Path):
     .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
     .. versionremoved:: 1.5.10 *verbose* argument
     .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
-    .. versionchanged:: 2.0.0 renamed from Protection to Conditional
     """
 
     super().__init__()

--- a/src/crappy/blocks/generator_path/custom.py
+++ b/src/crappy/blocks/generator_path/custom.py
@@ -31,11 +31,12 @@ class Custom(Path):
         Path. Can be either a :obj:`str` or a :obj:`pathlib.Path`. The file
         must contain two columns: the first one containing timestamps (starting
         from 0), the other one containing the values.
+
+        .. versionchanged:: 2.0.0 renamed from *filename* to *file_name*
       delimiter: The delimiter between columns in the file, usually a coma.
     
     .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
     .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
-    .. versionchanged:: 2.0.0 renamed *filename* argument to *file_name*
     .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 

--- a/src/crappy/blocks/generator_path/cyclic_ramp.py
+++ b/src/crappy/blocks/generator_path/cyclic_ramp.py
@@ -16,7 +16,7 @@ class CyclicRamp(Path):
   :class:`~crappy.blocks.generator_path.Ramp` Paths.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Cyclic_ramp to CyclicRamp
+  .. versionchanged:: 2.0.0 renamed from *Cyclic_ramp* to *CyclicRamp*
   """
 
   def __init__(self,
@@ -45,6 +45,8 @@ class CyclicRamp(Path):
         starting point for the first ramp. In the specific case when this Path
         is the first one in the Generator Paths, this argument must be given !
 
+        .. versionadded:: 1.5.10
+
     Note:
       ::
 
@@ -60,7 +62,6 @@ class CyclicRamp(Path):
     .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
     .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
     .. versionremoved:: 1.5.10 *verbose* argument
-    .. versionadded:: 1.5.10 *init_value* argument
     .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 

--- a/src/crappy/blocks/generator_path/integrator.py
+++ b/src/crappy/blocks/generator_path/integrator.py
@@ -18,7 +18,7 @@ class Integrator(Path):
   :math:`v(t) = v(t0) - [I(t0 -> t)f(t)dt] / m`.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Inertia to Integrator
+  .. versionchanged:: 2.0.0 renamed from *Inertia* to *Integrator*
   """
 
   def __init__(self,
@@ -37,17 +37,20 @@ class Integrator(Path):
         In the above formula, it is the value of `m`. The larger this value,
         the slower the changes in the signal value.
       func_label: The name of the label of the input value to integrate.
+
+        .. versionchanged:: 1.5.10 renamed from *flabel* to *func_label*
       time_label: The name of the time label for the integration.
+
+        .. versionchanged:: 1.5.10 renamed from *tlabel* to *time_label*
       init_value: If given, overwrites the last value of the signal as the
         starting point for the inertia path. In the specific case when this
         path is the first one in the Generator Paths, this argument must be
         given !
+
+        .. versionchanged:: 1.5.10 renamed from *value* to *init_value*
     
     .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
     .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
-    .. versionchanged:: 1.5.10 renamed *flabel* argument to *func_label*
-    .. versionchanged:: 1.5.10 renamed *tlabel* argument to *time_label*
-    .. versionchanged:: 1.5.10 renamed *value* argument to *init_value*
     .. versionremoved:: 1.5.10 *const* argument
     .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """

--- a/src/crappy/blocks/generator_path/ramp.py
+++ b/src/crappy/blocks/generator_path/ramp.py
@@ -28,10 +28,11 @@ class Ramp(Path):
       init_value: If given, overwrites the last value of the signal as the
         starting point for the ramp. In the specific case when this path is the
         first one in the Generator Paths, this argument must be given !
+
+        .. versionadded:: 1.5.10
     
     .. versionchanged:: 1.5.10 renamed *time* argument to *_last_time*
     .. versionchanged:: 1.5.10 renamed *cmd* argument to *_last_cmd*
-    .. versionadded:: 1.5.10 *init_value* argument
     .. versionremoved:: 2.0.0 *_last_time* and *_last_cmd* arguments
     """
 

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -100,6 +100,8 @@ class GPUCorrel(Camera):
         transformed image is displayed and/or saved and/or further processed.
         The transform operation is not parallelized, so it might negatively
         affect the acquisition framerate if it is too heavy.
+
+        .. versionadded:: 1.5.10
       display_images: If :obj:`True`, displays the acquired images in a
         dedicated window, using the backend given in ``displayer_backend`` and
         at the frequency specified in ``displayer_framerate``. This option
@@ -107,16 +109,23 @@ class GPUCorrel(Camera):
         intended to be very fast nor to display high-quality images. The
         maximum resolution of the displayed images in `640x480`, the images
         might be downscaled to fit in this format.
+
+        .. versionchanged:: 1.5.10
+           renamed from *show_image* to *display_images*
       displayer_backend: The backend to use for displaying the images. Can be
         either ``'cv2'`` or ``'mpl'``, to use respectively :mod:`cv2` (OpenCV)
         or :mod:`matplotlib`. ``'cv2'`` usually allows achieving a higher
         display frequency. Ignored if ``display_images`` is :obj:`False`. If
         not given and ``display_images`` is :obj:`True`, ``'cv2'`` is tried
         first and ``'mpl'`` second, and the first available one is used.
+
+        .. versionadded:: 1.5.10
       displayer_framerate: The maximum update frequency of the image displayer,
         as an :obj:`int`. This value usually lies between 5 and 30Hz, the
         default is 5. The achieved update frequency might be lower than
         requested. Ignored if ``display_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       software_trig_label: The name of a label used as a software trigger for
         the :class:`~crappy.camera.Camera`. If given, images will only be
         acquired when receiving data over this label. The received value does
@@ -124,17 +133,23 @@ class GPUCorrel(Camera):
         is recommended not to rely on it for a trigger frequency greater than
         10Hz, in which case a hardware trigger should be preferred if available
         on the camera.
+
+        .. versionadded:: 2.0.0
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
-        is displayed that is slows the code down. This argument allows to
+        is displayed that it slows the code down. This argument allows to
         adjust the precision of the log messages, while the ``debug`` argument
         is for enabling or disabling logging.
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
       save_images: If :obj:`True`, the acquired images are saved to the folder
         specified in ``save_folder``, in the format specified in
         ``img_extension``, using the backend specified in ``save_backend``, and
@@ -148,12 +163,16 @@ class GPUCorrel(Camera):
         :class:`~crappy.blocks.Camera` Block. Depending on the framerate of the
         camera and the performance of the computer, it is not guaranteed that
         all the acquired images will be recorded.
+
+        .. versionadded:: 1.5.10
       img_extension: The file extension for the recorded images, as a
         :obj:`str` and without the dot. Common file extensions include `tiff`,
         `png`, `jpg`, etc. Depending on the used ``save_backend``, some
         extensions might not be available. It is currently not possible to
         customize the save parameters further than choosing the file extension.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 2.0.0
       save_folder: Path to the folder where to save the images, either as a
         :obj:`str` or as a :obj:`pathlib.Path`. Can be an absolute or a
         relative path, pointing to a folder. If the folder does not exist, it
@@ -163,11 +182,15 @@ class GPUCorrel(Camera):
         a suffix is appended. Ignored if ``save_images`` is :obj:`False`. If
         not provided and ``save_images`` is :obj:`True`, the images are saved
         to the folder ``Crappy_images``, created next to the running script.
+
+        .. versionadded:: 1.5.10
       save_period: Must be given as an :obj:`int`. Only one out of that number
         images at most will be saved. Allows to have a known periodicity in
         case the framerate is too high to record all the images. Or simply to
         reduce the number of recorded images if saving them all is not needed.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       save_backend: If ``save_images`` is :obj:`True`, the backend to use for
         recording the images. It should be one of:
         ::
@@ -182,6 +205,8 @@ class GPUCorrel(Camera):
         Python must of course be installed. If not provided and ``save_images``
         is :obj:`True`, the backends are tried in the same order as given above
         and the first available one is used. ``'npy'`` is always available.
+
+        .. versionadded:: 1.5.10
       image_generator: A callable taking two :obj:`float` as arguments and
         returning an image as a :obj:`numpy.array`. **This argument is intended
         for use in the examples of Crappy, to apply an artificial strain on a
@@ -189,6 +214,8 @@ class GPUCorrel(Camera):
         argument is ignored and the images are acquired from the generator. To
         apply a strain on the image, strain values (in `%`) should be sent to
         the Camera Block over the labels ``'Exx(%)'`` and ``'Eyy(%)'``.
+
+        .. versionadded:: 1.5.10
       labels: The labels to use for sending data to downstream Blocks. If not
         given, the default labels are ``'t(s)', 'meta'`` followed by the names
         of the given ``fields``. They carry for each image its timestamp, a
@@ -202,6 +229,9 @@ class GPUCorrel(Camera):
         correlation is not sent to the downstream Blocks if the residuals for
         the current image are greater than ``discard_limit`` times the average
         residual for the last ``discard_ref`` images.
+
+        .. versionchanged:: 1.5.10
+          renamed from *discard_lim* to *discard_limit*
       discard_ref: If ``res`` is :obj:`True`, the result of the
         correlation is not sent to the downstream Blocks if the residuals for
         the current image are greater than ``discard_limit`` times the average
@@ -211,25 +241,37 @@ class GPUCorrel(Camera):
         the test can start from the first acquired frame. If not given, the
         first acquired image will be set as the reference, which will slow down
         the beginning of the test.
+
+        .. versionchanged:: 1.5.10 renamed from *imgref* to *img_ref*
       levels: Number of levels of the pyramid. More levels may help converging
         on images with large strain, but may fail on images that don't contain
         low spatial frequency. Fewer levels mean that the program runs faster.
+
+        .. versionadded:: 1.5.10
       resampling_factor: The factor by which the resolution is divided between
         each stage of the pyramid. A low factor ensures coherence between the
         stages, but is more computationally intensive. A high factor allows
         reaching a finer detail level, but may lead to a coherence loss between
         the stages.
+
+        .. versionadded:: 1.5.10
       kernel_file: The path to the file containing the kernels to use for the
         correlation. Can be a :obj:`pathlib.Path` object or a :obj:`str`. If
         not provided, the default :ref:`GPU Kernels` are used.
+
+        .. versionadded:: 1.5.10
       iterations: The maximum number of iterations to run before returning the
         results. The results may be returned before if the residuals start
         increasing.
+
+        .. versionadded:: 1.5.10
       mask: The mask used for weighting the region of interest on the image. It
         is generally used to prevent unexpected behavior on the border of the
         image. Also allows to select a sub-region of the image if the
         correlation should not be performed on the entire image, as this Block
         does not accept a `patch` argument.
+
+        .. versionadded:: 1.5.10
       mul: The scalar by which the direction will be multiplied before being
         added to the solution. If it's too high, the convergence will be fast
         but there's a risk to go past the solution and to diverge. If it's too
@@ -237,28 +279,20 @@ class GPUCorrel(Camera):
         was found to be an acceptable value in most cases, but it is
         recommended to tune this value for each application so that the
         convergence is neither too slow nor too fast.
+
+        .. versionadded:: 1.5.10
       res: If :obj:`True`, calculates the residuals after performing the
         correlation and returns the residuals along with the correlation data.
         The residuals are always returned under the label ``'res'``, and this
         label should not be included in the ``labels`` argument.
+
+        .. versionadded:: 1.5.10
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
-    
-    .. versionadded:: 1.5.10 
-       *transform*, *display_images*, *displayer_backend*, 
-       *displayer_framerate*, *freq*, *save_images*, *image_generator*, 
-       *levels*, *resampling_factor*, *kernel_file*, *iterations*, *mask*, 
-       *mul* and *res* arguments
-    .. versionchanged:: 1.5.10 
-       renamed *discard_lim* argument to *discard_limit*
-    .. versionchanged:: 1.5.10 
-       renamed *imgref* argument to *img_ref*
+
     .. versionremoved:: 1.5.10
        *fps_label*, *ext*, *input_label*, *config* and *cam_kwargs* arguments
-    .. versionadded:: 2.0.0 
-       *debug*, *software_trig_label*, *img_extension*, *img_shape* and
-       *img_dtype* arguments
     .. versionremoved:: 2.0.0 *img_name* argument
     """
 

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -84,6 +84,8 @@ class GPUVE(Camera):
         transformed image is displayed and/or saved and/or further processed.
         The transform operation is not parallelized, so it might negatively
         affect the acquisition framerate if it is too heavy.
+
+        .. versionadded:: 1.5.10
       display_images: If :obj:`True`, displays the acquired images in a
         dedicated window, using the backend given in ``displayer_backend`` and
         at the frequency specified in ``displayer_framerate``. This option
@@ -93,16 +95,23 @@ class GPUVE(Camera):
         might be downscaled to fit in this format. In addition to the acquired
         frames, the tracked patches are also displayed on the image as an
         overlay.
+
+        .. versionchanged:: 1.5.10
+           renamed from *show_image* to *display_images*
       displayer_backend: The backend to use for displaying the images. Can be
         either ``'cv2'`` or ``'mpl'``, to use respectively :mod:`cv2` (OpenCV)
         or :mod:`matplotlib`. ``'cv2'`` usually allows achieving a higher
         display frequency. Ignored if ``display_images`` is :obj:`False`. If
         not given and ``display_images`` is :obj:`True`, ``'cv2'`` is tried
         first and ``'mpl'`` second, and the first available one is used.
+
+        .. versionadded:: 1.5.10
       displayer_framerate: The maximum update frequency of the image displayer,
         as an :obj:`int`. This value usually lies between 5 and 30Hz, the
         default is 5. The achieved update frequency might be lower than
         requested. Ignored if ``display_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       software_trig_label: The name of a label used as a software trigger for
         the :class:`~crappy.camera.Camera`. If given, images will only be
         acquired when receiving data over this label. The received value does
@@ -110,6 +119,8 @@ class GPUVE(Camera):
         is recommended not to rely on it for a trigger frequency greater than
         10Hz, in which case a hardware trigger should be preferred if available
         on the camera.
+
+        .. versionadded:: 2.0.0
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
         is displayed that it slows the code down. This argument allows to
@@ -117,10 +128,14 @@ class GPUVE(Camera):
         is for enabling or disabling logging.
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
       save_images: If :obj:`True`, the acquired images are saved to the folder
         specified in ``save_folder``, in the format specified in
         ``img_extension``, using the backend specified in ``save_backend``, and
@@ -134,12 +149,16 @@ class GPUVE(Camera):
         :class:`~crappy.blocks.Camera` Block. Depending on the framerate of the
         camera and the performance of the computer, it is not guaranteed that
         all the acquired images will be recorded.
+
+        .. versionadded:: 1.5.10
       img_extension: The file extension for the recorded images, as a
         :obj:`str` and without the dot. Common file extensions include `tiff`,
         `png`, `jpg`, etc. Depending on the used ``save_backend``, some
         extensions might not be available. It is currently not possible to
         customize the save parameters further than choosing the file extension.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 2.0.0
       save_folder: Path to the folder where to save the images, either as a
         :obj:`str` or as a :obj:`pathlib.Path`. Can be an absolute or a
         relative path, pointing to a folder. If the folder does not exist, it
@@ -149,11 +168,15 @@ class GPUVE(Camera):
         a suffix is appended. Ignored if ``save_images`` is :obj:`False`. If
         not provided and ``save_images`` is :obj:`True`, the images are saved
         to the folder ``Crappy_images``, created next to the running script.
+
+        .. versionadded:: 1.5.10
       save_period: Must be given as an :obj:`int`. Only one out of that number
         images at most will be saved. Allows to have a known periodicity in
         case the framerate is too high to record all the images. Or simply to
         reduce the number of recorded images if saving them all is not needed.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       save_backend: If ``save_images`` is :obj:`True`, the backend to use for
         recording the images. It should be one of:
         ::
@@ -168,6 +191,8 @@ class GPUVE(Camera):
         Python must of course be installed. If not provided and ``save_images``
         is :obj:`True`, the backends are tried in the same order as given above
         and the first available one is used. ``'npy'`` is always available.
+
+        .. versionadded:: 1.5.10
       image_generator: A callable taking two :obj:`float` as arguments and
         returning an image as a :obj:`numpy.array`. **This argument is intended
         for use in the examples of Crappy, to apply an artificial strain on a
@@ -175,6 +200,8 @@ class GPUVE(Camera):
         argument is ignored and the images are acquired from the generator. To
         apply a strain on the image, strain values (in `%`) should be sent to
         the Camera Block over the labels ``'Exx(%)'`` and ``'Eyy(%)'``.
+
+        .. versionadded:: 1.5.10
       labels: The labels to use for sending data to downstream Blocks. If not
         given, the default labels are ``'t(s)', 'meta'`` followed for each
         given patch by ``'p<i>x', 'p<i>y'`` with ``'<i>'`` the number of the
@@ -187,12 +214,18 @@ class GPUVE(Camera):
         the test can start from the first acquired frame. If not given, the
         first acquired image will be set as the reference, which will slow down
         the beginning of the test.
+
+        .. versionadded:: 1.5.10
       kernel_file: The path to the file containing the kernels to use for the
         correlation. Can be a :obj:`pathlib.Path` object or a :obj:`str`. If
         not provided, the default :ref:`GPU Kernels` are used.
+
+        .. versionadded:: 1.5.10
       iterations: The maximum number of iterations to run before returning the
         results. The results may be returned before if the residuals start
         increasing.
+
+        .. versionadded:: 1.5.10
       mul: The scalar by which the direction will be multiplied before being
         added to the solution. If it's too high, the convergence will be fast
         but there's a risk to go past the solution and to diverge. If it's too
@@ -200,19 +233,14 @@ class GPUVE(Camera):
         was found to be an acceptable value in most cases, but it is
         recommended to tune this value for each application so that the
         convergence is neither too slow nor too fast.
+
+        .. versionadded:: 1.5.10
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
 
-    .. versionadded:: 1.5.10
-       *freq*, *save_images*, *image_generator*, *img_ref*, *kernel_file*,
-       *iterations* and *mul* arguments
     .. versionremoved:: 1.5.10
        *fps_label*, *ext*, *input_label*, *config* and *cam_kwargs* arguments
-    .. versionadded:: 2.0.0
-       *display_images*, *displayer_framerate*, *displayer_backend*, *debug*,
-       *software_trig_label*, *img_extension*, *img_shape* and *img_dtype*
-       arguments
     .. versionremoved:: 2.0.0 *img_name* argument
     """
 

--- a/src/crappy/blocks/grapher.py
+++ b/src/crappy/blocks/grapher.py
@@ -57,6 +57,8 @@ class Grapher(Block):
       max_pt: The maximum number of points displayed on the graph. When
         reaching this limit, the Block deletes one point out of two to avoid
         using too much memory and CPU.
+
+        .. versionchanged:: 2.0.0 renamed from *maxpt* to *max_pt*
       window_size: The size of the graph, in inches.
       window_pos: The position of the graph in pixels. The first value is for
         the `x` direction, the second for the `y` direction. The origin is the
@@ -68,10 +70,15 @@ class Grapher(Block):
         available depending on your machine.
       display_freq: if :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionadded:: 1.5.6
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+        
+        .. versionadded:: 2.0.0
 
     Example:
       ::
@@ -90,11 +97,6 @@ class Grapher(Block):
         graph = Grapher(('t(s)', 'F(N)'), length=30)
 
       will plot a dynamic graph displaying the last 30 chunks of data.
-
-    .. versionadded:: 1.5.6 *verbose* argument
-    .. versionadded 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
-    .. versionchanged:: 2.0.0 renamed *maxpt* argument to *max_pt*
     """
 
     super().__init__()

--- a/src/crappy/blocks/hdf_recorder.py
+++ b/src/crappy/blocks/hdf_recorder.py
@@ -32,7 +32,7 @@ class HDFRecorder(Block):
     that the recorded data will be readable.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Hdf_recorder to HDFRecorder
+  .. versionchanged:: 2.0.0 renamed from *Hdf_recorder* to *HDFRecorder*
   """
 
   def __init__(self,
@@ -63,16 +63,19 @@ class HDFRecorder(Block):
         `HDF5` file.
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
+        
+        .. versionadded:: 1.5.10
       display_freq: if :obj:`True`, displays the looping frequency of the 
         Block.
+        
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded:: 1.5.10 *freq* and *verbose* arguments
-    .. versionadded 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+        
+        .. versionadded:: 2.0.0
     """
 
     self._hfile = None

--- a/src/crappy/blocks/ioblock.py
+++ b/src/crappy/blocks/ioblock.py
@@ -68,6 +68,8 @@ class IOBlock(Block):
       trigger_label: If given, the Block will only read data whenever a value
         is received on this label (can be any value). Ignored if the Block has
         no output Link. A trigger label can also be a cmd label.
+
+        .. versionchanged:: 1.5.10 renamed from *trigger* to *trigger_label*
       streamer: If :obj:`False`, the :meth:`~crappy.inout.InOut.get_data`
         method of the InOut is called for acquiring data, else it is the
         :meth:`~crappy.inout.InOut.get_stream` method. Refer to the
@@ -79,11 +81,15 @@ class IOBlock(Block):
       exit_cmd: A final command for the InOut, set during :meth:`finish`. If
         given, there must be as many values as in ``cmd_labels``. Must be given
         as an iterable (e.g. a :obj:`list` or a :obj:`tuple`).
+
+        .. versionchanged:: 1.5.10 renamed from *exit_values* to *exit_cmd*
       make_zero_delay: If set, will acquire data before the beginning of the
         test and use it to offset all the labels to zero. The data will be
         acquired during the given number of seconds. Ignored if the Block has
         no output Links. Does not work for InOuts that acquire values other
         than numbers (:obj:`str` for example).
+        
+        .. versionadded:: 1.5.10
       spam: If :obj:`False`, the Block will call
         :meth:`~crappy.inout.InOut.set_cmd` on the InOut object only if the
         current command is different from the previous. Otherwise, it will call
@@ -92,17 +98,15 @@ class IOBlock(Block):
         as fast as possible.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block while running.
+        
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+        
+        .. versionadded:: 2.0.0
       **kwargs: The arguments to be passed to the :class:`~crappy.inout.InOut`.
-
-    .. versionchanged:: 1.5.10 renamed *trigger* argument to *trigger_label*
-    .. versionchanged:: 1.5.10 renamed *exit_values* argument to *exit_cmd*
-    .. versionadded:: 1.5.10 *make_zero_delay* argument
-    .. versionadded 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._device: Optional[InOut] = None

--- a/src/crappy/blocks/link_reader.py
+++ b/src/crappy/blocks/link_reader.py
@@ -19,7 +19,7 @@ class LinkReader(Block):
   a persistent way.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Reader to LinkReader
+  .. versionchanged:: 2.0.0 renamed from *Reader* to *LinkReader*
   """
 
   _index = 0
@@ -35,20 +35,24 @@ class LinkReader(Block):
       name: If set, will be displayed to identify the LinkReader. Otherwise, 
         the block is automatically named based on the number of its instances 
         already running.
+        
+        .. versionchanged:: 1.5.5 renamed from *name* to *reader_name*
+        .. versionchanged:: 1.5.5 renamed from *reader_name* to *name*
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
+        
+        .. versionadded:: 1.5.10
       display_freq: if :obj:`True`, displays the looping frequency of the 
         Block.
+        
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-
-    .. versionchanged:: 1.5.5 renamed *name* argument to *reader_name*
-    .. versionadded:: 1.5.10 *freq* and *verbose* arguments
-    .. versionchanged:: 1.5.5 renamed *reader_name* argument to *name*
-    .. versionadded 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+        
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/blocks/machine.py
+++ b/src/crappy/blocks/machine.py
@@ -73,16 +73,25 @@ class Machine(Block):
         one will prevail.
       time_label: If reading speed or position from one or more Actuators, the
         time information will be carried by this label.
+      ft232h_ser_num: Serial number of the FT232H device to use for driving
+        the controlled Actuator.
+        
+        .. versionadded:: 2.0.0
       spam: If :obj:`True`, a command is sent to the Actuators at each loop of
         the Block, else it is sent every time a new command is received.
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+        
+        .. versionadded:: 2.0.0
 
     Note:
       - ``actuators`` keys:
@@ -112,10 +121,6 @@ class Machine(Block):
         - ``speed_cmd_label``: The label carrying the speed to set when driving
           in `'position'` mode. Each time a value is received, the stored speed
           value is updated. It will also overwrite the ``speed`` key if given.
-
-    .. versionadded:: 1.5.10 *verbose* argument
-    .. versionadded 2.0.0 *debug* and *ft232h_ser_num* arguments
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     self._actuators: List[ActuatorInstance] = list()

--- a/src/crappy/blocks/mean.py
+++ b/src/crappy/blocks/mean.py
@@ -31,7 +31,7 @@ class MeanBlock(Block):
     number of labels.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Mean_block to MeanBlock
+  .. versionchanged:: 2.0.0 renamed from *Mean_block* to *MeanBlock*
   """
 
   def __init__(self,
@@ -47,6 +47,8 @@ class MeanBlock(Block):
       delay: The averaged data will be sent each ``delay`` seconds.
       time_label: The label containing the time information. It must be common
         to all the incoming Links.
+        
+        .. versionchanged:: 1.5.10 renamed from *t_label* to *time_label*
       out_labels: An iterable (like a :obj:`list` or a :obj:`tuple`) containing
         all the labels to average, as :obj:`str`. If not given, all the
         received labels are averaged and returned. The time label should not
@@ -55,17 +57,17 @@ class MeanBlock(Block):
         not in an iterable.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded:: 1.5.10 *verbose* argument
-    .. versionchanged:: 1.5.10 renamed *t_label* argument to *time_label*
-    .. versionadded 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+        
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -147,6 +147,8 @@ class Block(Process, metaclass=MetaBlock):
       allow_root: If set to :obj:`True`, tries to renice the Processes with
         sudo privilege in Linux. It requires the Python script to be run
         with sudo privilege, otherwise it has no effect.
+
+        .. versionchanged:: 2.0.0 renamed from *high_prio* to *allow_root*
       log_level: The maximum logging level that will be handled by Crappy. By
         default, it is set to the lowest level (:obj:`~logging.DEBUG`) so that
         all messages are handled. If set to a higher level, the levels
@@ -154,16 +156,18 @@ class Block(Process, metaclass=MetaBlock):
         set to :obj:`None`, logging is totally disabled. Refer to the
         documentation of the :mod:`logging` module for information on the
         possible levels.
+
+        .. versionadded:: 2.0.0
       no_raise: When set to :obj:`False`, the Exceptions encountered during
         Crappy's execution, as well as the :exc:`KeyboardInterrupt`, will raise
         an Exception right before Crappy returns. This is meant to prevent the
         execution of code that would come after Crappy, in case Crappy does not
         terminate as expected. This behavior can be disabled by setting this
         argument to :obj:`True`.
-    
-    .. versionchanged:: 2.0.0 renamed *high_prio* argument to *allow_root*
+
+        .. versionadded:: 2.0.0
+
     .. versionremoved:: 2.0.0 *t0*, *verbose*, *bg* arguments
-    .. versionadded:: 2.0.0 *log_level*, *no_raise* arguments
     """
 
     cls.prepare_all(log_level)
@@ -191,9 +195,10 @@ class Block(Process, metaclass=MetaBlock):
         set to :obj:`None`, logging is totally disabled. Refer to the 
         documentation of the :mod:`logging` module for information on the 
         possible levels.
+
+        .. versionadded:: 2.0.0
     
     .. versionremoved:: 2.0.0 *verbose* argument
-    .. versionadded:: 2.0.0 *log_level* argument
     """
 
     # Flag indicating whether to perform the cleanup action or not
@@ -329,8 +334,8 @@ class Block(Process, metaclass=MetaBlock):
       allow_root: If set to :obj:`True`, tries to renice the Processes with 
         sudo privilege in Linux. It requires the Python script to be run with 
         sudo privilege, otherwise it has no effect.
-    
-    .. versionchanged:: 2.0.0 renamed *high_prio* argument to *allow_root*
+
+        .. versionchanged:: 2.0.0 renamed from *high_prio* to *allow_root*
     """
 
     # Flag indicating whether to perform the cleanup action or not
@@ -1190,7 +1195,7 @@ class Block(Process, metaclass=MetaBlock):
     """Returns :obj:`True` if there's data available for reading in at least
     one of the input :class:`~crappy.links.Link`.
     
-    .. versionchanged:: 2.0.0 renamed from poll to data_available
+    .. versionchanged:: 2.0.0 renamed from *poll* to *data_available*
     """
 
     self.log(logging.DEBUG, "Data availability requested")
@@ -1214,7 +1219,7 @@ class Block(Process, metaclass=MetaBlock):
       A :obj:`dict` whose keys are the received labels and with a single value
       for each key (usually a :obj:`float` or a :obj:`str`).
     
-    .. versionchanged:: 2.0.0 renamed from recv_all to recv_data
+    .. versionchanged:: 2.0.0 renamed from *recv_all* to *recv_data*
     """
 
     ret = dict()
@@ -1248,7 +1253,8 @@ class Block(Process, metaclass=MetaBlock):
 
     .. versionremoved:: 1.5.10 *num* argument
     .. versionadded:: 1.5.10 *blocking* argument
-    .. versionchanged:: 2.0.0 renamed from get_last to recv_last_data
+    .. versionremoved:: 2.0.0 *blocking* argument
+    .. versionchanged:: 2.0.0 renamed from *get_last* to *recv_last_data*
     """
 
     # Initializing the buffer storing the last received values
@@ -1305,7 +1311,8 @@ class Block(Process, metaclass=MetaBlock):
 
     .. versionremoved:: 1.5.10 *num* argument
     .. versionadded:: 1.5.10 *blocking* argument
-    .. versionchanged:: 2.0.0 renamed from get_all_last to recv_all_data
+    .. versionremoved:: 2.0.0 *blocking* argument
+    .. versionchanged:: 2.0.0 renamed from *get_all_last* to *recv_all_data*
     """
 
     ret = defaultdict(list)

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -32,7 +32,7 @@ class Multiplexer(Block):
     rates.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Multiplex to Multiplexer
+  .. versionchanged:: 2.0.0 renamed from *Multiplex* to *Multiplexer*
   """
 
   def __init__(self,
@@ -46,6 +46,8 @@ class Multiplexer(Block):
 
     Args:
       time_label: The label carrying the time information.
+      
+        .. versionchanged:: 1.5.10 renamed from *key* to *time_label*
       out_labels: An iterable (like a :obj:`list` or a :obj:`tuple`) containing
         the labels to multiplex, except for the time label that is given
         separately in the ``time_label`` argument. The Block also doesn't
@@ -54,19 +56,28 @@ class Multiplexer(Block):
         recommended to always set this argument !** It is also possible to
         give this argument as a single :obj:`str` (i.e. not in an iterable),
         although multiplexing a single label is of limited interest.
+        
+        .. versionadded:: 2.0.0
+      interp_freq: The target frequency for performing the interpolation. In 
+        the output data, there will be one interpolated data point each 
+        :math:`1 / interp_freq` seconds. Independent of the ``freq`` argument, 
+        but it is no use setting ``freq`` higher than ``interp_freq`` otherwise 
+        there will be void loops.
+        
+        .. versionadded:: 2.0.0
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionadded:: 1.5.9
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-
-    .. versionadded:: 1.5.9 *verbose* argument
-    .. versionchanged:: 1.5.10 renamed *key* argument to *time_label*
-    .. versionadded 2.0.0 *debug*, *out_labels* and *interp_freq* arguments
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+        
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -62,6 +62,9 @@ class PID(Block):
       out_max: Ensures the output is always inferior to this value.
       out_min: Ensures the output is always superior to this value.
       setpoint_label: The label carrying the setpoint value.
+
+        .. versionchanged:: 2.0.0
+           renamed from *target_label* to *setpoint_label*
       input_label: The label carrying the reading of the actual value, to be
         compared with the setpoint.
       time_label: The label carrying the time information in the incoming
@@ -69,12 +72,18 @@ class PID(Block):
       kp_label: The label to use for changing the `P` gain on the fly. If a
         value is received over this label, it will overwrite the one given in
         the ``kp`` argument.
+
+        .. versionadded:: 2.0.0
       ki_label: The label to use for changing the `I` gain on the fly. If a
         value is received over this label, it will overwrite the one given in
         the ``ki`` argument.
+
+        .. versionadded:: 2.0.0
       kd_label: The label to use for changing the `D` gain on the fly. If a
         value is received over this label, it will overwrite the one given in
         the ``kd`` argument.
+
+        .. versionadded:: 2.0.0
       labels: The two labels that will be sent to downstream Blocks. The first
         one is the time label, the second one is the output of the PID. If this
         argument is not given, they default to ``'t(s)'`` and ``'pid'``.
@@ -88,17 +97,15 @@ class PID(Block):
         as fast as possible.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded:: 1.5.10 *verbose* argument
-    .. versionadded 2.0.0 
-       *debug*, *kp_label*, *kd_label* and *ki_label* arguments
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
-    .. versionchanged:: 2.0.0
-       renamed *target_label* argument to *setpoint_label*
+        
+        .. versionadded:: 2.0.0
     """
 
     # Attributes of the parent class

--- a/src/crappy/blocks/recorder.py
+++ b/src/crappy/blocks/recorder.py
@@ -40,22 +40,26 @@ class Recorder(Block):
         parent folders of the file do not exist, they will be created. If the
         file already exists, the actual file where data will be written will be
         renamed with a trailing index to avoid overriding it.
+
+        .. versionchanged:: 2.0.0 renamed from *filename* to *file_name*
       delay: Delay between each write in seconds.
       labels: If provided, only the data carried by these labels will be saved.
         Otherwise, all the received data is saved.
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
+        
+        .. versionadded:: 1.5.10
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the 
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded 1.5.10 *freq* and *verbose* arguments
-    .. versionadded 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
-    .. versionchanged:: 2.0.0 renamed *filename* argument to *file_name*
+        
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/blocks/sink.py
+++ b/src/crappy/blocks/sink.py
@@ -24,16 +24,19 @@ class Sink(Block):
     Args:
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionadded:: 1.5.10
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
+        
+        .. versionadded:: 1.5.10
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded 1.5.6 *verbose* and *freq* arguments
-    .. versionadded 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+        
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/blocks/stop_block.py
+++ b/src/crappy/blocks/stop_block.py
@@ -15,7 +15,7 @@ class StopBlock(Block):
   Along with the :class:`~crappy.blocks.StopButton` Block, it allows to stop a
   test in a clean way without resorting to CTRL+C.
 
-  .. versionadded 2.0.0
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/stop_button.py
+++ b/src/crappy/blocks/stop_button.py
@@ -19,7 +19,7 @@ class StopButton(Block):
   Along with the :class:`~crappy.blocks.StopBlock`, it allows to stop a test in
   a clean way without resorting to CTRL+C.
 
-  .. versionadded 2.0.0
+  .. versionadded:: 2.0.0
   """
 
   def __init__(self,

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -75,15 +75,16 @@ class UController(Block):
         capabilities of the device.
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+        
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       freq: The target looping frequency for the Block. If :obj:`None`, loops 
         as fast as possible.
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
-    
-    .. versionadded:: 2.0.0 *debug* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
+        
+        .. versionadded:: 2.0.0
     """
 
     self._bus = None

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -85,6 +85,8 @@ class VideoExtenso(Camera):
         transformed image is displayed and/or saved and/or further processed.
         The transform operation is not parallelized, so it might negatively
         affect the acquisition framerate if it is too heavy.
+
+        .. versionadded:: 1.5.10
       config: If :obj:`True`, a
         :class:`~crappy.tool.camera_config.VideoExtensoConfig` window is
         displayed before the test starts. There, the user can interactively
@@ -95,6 +97,8 @@ class VideoExtenso(Camera):
         starts when closing the configuration window. **It is currently not
         possible to set this argument to** :obj:`False` **!** This might change
         in the future.
+
+        .. versionadded:: 1.5.10
       display_images: If :obj:`True`, displays the acquired images in a
         dedicated window, using the backend given in ``displayer_backend`` and
         at the frequency specified in ``displayer_framerate``. This option
@@ -104,16 +108,23 @@ class VideoExtenso(Camera):
         might be downscaled to fit in this format. In addition to the acquired
         frames, the tracked spots are also displayed on the image as an
         overlay.
+
+        .. versionchanged:: 1.5.10
+           renamed from *show_image* to *display_images*
       displayer_backend: The backend to use for displaying the images. Can be
         either ``'cv2'`` or ``'mpl'``, to use respectively :mod:`cv2` (OpenCV)
         or :mod:`matplotlib`. ``'cv2'`` usually allows achieving a higher
         display frequency. Ignored if ``display_images`` is :obj:`False`. If
         not given and ``display_images`` is :obj:`True`, ``'cv2'`` is tried
         first and ``'mpl'`` second, and the first available one is used.
+
+        .. versionadded:: 1.5.10
       displayer_framerate: The maximum update frequency of the image displayer,
         as an :obj:`int`. This value usually lies between 5 and 30Hz, the
         default is 5. The achieved update frequency might be lower than
         requested. Ignored if ``display_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       software_trig_label: The name of a label used as a software trigger for
         the :class:`~crappy.camera.Camera`. If given, images will only be
         acquired when receiving data over this label. The received value does
@@ -121,14 +132,22 @@ class VideoExtenso(Camera):
         is recommended not to rely on it for a trigger frequency greater than
         10Hz, in which case a hardware trigger should be preferred if available
         on the camera.
+
+        .. versionadded:: 2.0.0
       display_freq: If :obj:`True`, displays the looping frequency of the
         Block.
+
+        .. versionchanged:: 2.0.0 renamed from *verbose* to *display_freq*
       debug: If :obj:`True`, displays all the log messages including the
         :obj:`~logging.DEBUG` ones. If :obj:`False`, only displays the log
         messages with :obj:`~logging.INFO` level or higher. If :obj:`None`,
         disables logging for this Block.
+
+        .. versionadded:: 2.0.0
       freq: The target looping frequency for the Block. If :obj:`None`, loops
         as fast as possible.
+
+        .. versionadded:: 1.5.10
       save_images: If :obj:`True`, the acquired images are saved to the folder
         specified in ``save_folder``, in the format specified in
         ``img_extension``, using the backend specified in ``save_backend``, and
@@ -142,12 +161,16 @@ class VideoExtenso(Camera):
         :class:`~crappy.blocks.Camera` Block. Depending on the framerate of the
         camera and the performance of the computer, it is not guaranteed that
         all the acquired images will be recorded.
+
+        .. versionadded:: 1.5.10
       img_extension: The file extension for the recorded images, as a
         :obj:`str` and without the dot. Common file extensions include `tiff`,
         `png`, `jpg`, etc. Depending on the used ``save_backend``, some
         extensions might not be available. It is currently not possible to
         customize the save parameters further than choosing the file extension.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 2.0.0
       save_folder: Path to the folder where to save the images, either as a
         :obj:`str` or as a :obj:`pathlib.Path`. Can be an absolute or a
         relative path, pointing to a folder. If the folder does not exist, it
@@ -157,11 +180,15 @@ class VideoExtenso(Camera):
         a suffix is appended. Ignored if ``save_images`` is :obj:`False`. If
         not provided and ``save_images`` is :obj:`True`, the images are saved
         to the folder ``Crappy_images``, created next to the running script.
+
+        .. versionadded:: 1.5.10
       save_period: Must be given as an :obj:`int`. Only one out of that number
         images at most will be saved. Allows to have a known periodicity in
         case the framerate is too high to record all the images. Or simply to
         reduce the number of recorded images if saving them all is not needed.
         Ignored if ``save_images`` is :obj:`False`.
+
+        .. versionadded:: 1.5.10
       save_backend: If ``save_images`` is :obj:`True`, the backend to use for
         recording the images. It should be one of:
         ::
@@ -176,6 +203,8 @@ class VideoExtenso(Camera):
         Python must of course be installed. If not provided and ``save_images``
         is :obj:`True`, the backends are tried in the same order as given above
         and the first available one is used. ``'npy'`` is always available.
+
+        .. versionadded:: 1.5.10
       image_generator: A callable taking two :obj:`float` as arguments and
         returning an image as a :obj:`numpy.array`. **This argument is intended
         for use in the examples of Crappy, to apply an artificial strain on a
@@ -183,16 +212,22 @@ class VideoExtenso(Camera):
         argument is ignored and the images are acquired from the generator. To
         apply a strain on the image, strain values (in `%`) should be sent to
         the Camera Block over the labels ``'Exx(%)'`` and ``'Eyy(%)'``.
+
+        .. versionadded:: 1.5.10
       img_shape: The shape of the images returned by the
         :class:`~crappy.camera.Camera` object as a :obj:`tuple` of :obj:`int`.
         It should correspond to the value returned by :obj:`numpy.shape`.
         **This argument is always ignored as** ``config`` **cannot be set to**
         :obj:`False`. This might change in the future.
+
+        .. versionadded:: 2.0.0
       img_dtype: The `dtype` of the images returned by the
         :class:`~crappy.camera.Camera` object, as a :obj:`str`. It should
         correspond to a valid data type in :mod:`numpy`, e.g. ``'uint8'``.
         **This argument is always ignored as** ``config`` **cannot be set to**
         :obj:`False`. This might change in the future.
+
+        .. versionadded:: 2.0.0
       labels: The labels to use for sending data to downstream Blocks. If not
         given, the default labels are
         ``'t(s)', 'meta', 'Coord(px)', 'Eyy(%)', 'Exx(%)'``. They carry for
@@ -206,6 +241,8 @@ class VideoExtenso(Camera):
       raise_on_lost_spot: If :obj:`True`, raises an exception when losing the
         spots to track, which stops the test. Otherwise, stops the tracking but
         lets the test go on and silently sleeps.
+
+        .. versionchanged:: 1.5.10 renamed from *end* to *raise_on_lost_spot*
       white_spots: If :obj:`True`, detects white objects over a black
         background, else black objects over a white background.
       update_thresh: If :obj:`True`, the grey level threshold for detecting the
@@ -241,20 +278,10 @@ class VideoExtenso(Camera):
       **kwargs: Any additional argument will be passed to the
         :class:`~crappy.camera.Camera` object, and used as a kwarg to its
         :meth:`~crappy.camera.Camera.open` method.
-    
-    .. versionadded:: 1.5.10 
-       *display_images*, *displayer_backend*, *displayer_framerate*, *freq*,
-       *save_images* and *image_generator* arguments
+
     .. versionremoved:: 1.5.10 
        *ext*, *fps_label*, *wait_l0* and *input_label* arguments
-    .. versionchanged:: 1.5.10
-       renamed *show_image* argument to *display_images*
-    .. versionchanged:: 1.5.10 renamed *end* argument to *raise_on_lost_spot*
-    .. versionadded:: 2.0.0
-       *debug*, *software_trig_label*, *img_extension*, *img_shape* and
-       *img_dtype* arguments
     .. versionremoved:: 2.0.0 *img_name* argument
-    .. versionchanged:: 2.0.0 renamed *verbose* argument to *display_freq*
     """
 
     super().__init__(camera=camera,

--- a/src/crappy/camera/cameralink/basler_ironman_cameralink.py
+++ b/src/crappy/camera/cameralink/basler_ironman_cameralink.py
@@ -32,7 +32,8 @@ class BaslerIronmanCameraLink(Camera):
     proprietary drivers to be installed.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Cl_camera to BaslerIronmanCameraLink
+  .. versionchanged:: 2.0.0
+     renamed from *Cl_camera* to *BaslerIronmanCameraLink*
   .. versionremoved:: 2.1.0
   """
 
@@ -61,6 +62,8 @@ class BaslerIronmanCameraLink(Camera):
     Args:
       num_device: The index of the camera to open if multiple cameras are
         connected, as an :obj:`int`.
+
+        .. versionchanged:: 2.0.0 renamed from *numdevice* to *num_device*
       config_file: Path to the configuration file for the camera, as a
         :obj:`str`. Allows setting various parameters at once, and to store
         them in a persistent way.
@@ -70,7 +73,6 @@ class BaslerIronmanCameraLink(Camera):
     .. versionadded:: 1.5.10
        explicitly listing the *num_device*, *config_file* and *camera_type*
        arguments
-    .. versionchanged:: 2.0.0 renamed *numdevice* argument to *num_device*
     """
 
     # Reading the camera type from the config file, if applicable

--- a/src/crappy/camera/cameralink/jai_go_5000c_pmcl.py
+++ b/src/crappy/camera/cameralink/jai_go_5000c_pmcl.py
@@ -36,7 +36,7 @@ class JaiGO5000CPMCL8Bits(BaslerIronmanCameraLink):
     proprietary drivers to be installed.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Jai8 to JaiGO5000CPMCL8Bits
+  .. versionchanged:: 2.0.0 renamed from *Jai8* to *JaiGO5000CPMCL8Bits*
   .. versionremoved:: 2.1.0
   """
 
@@ -130,7 +130,7 @@ class JaiGO5000CPMCL(JaiGO5000CPMCL8Bits):
     proprietary drivers to be installed.
 
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Jai to JaiGO5000CPMCL
+  .. versionchanged:: 2.0.0 renamed from *Jai* to *JaiGO5000CPMCL*
   .. versionremoved:: 2.1.0
   """
 

--- a/src/crappy/camera/fake_camera.py
+++ b/src/crappy/camera/fake_camera.py
@@ -17,7 +17,7 @@ class FakeCamera(Camera):
   frame rate and the speed of the moving line.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Fake_camera to FakeCamera
+  .. versionchanged:: 2.0.0 renamed from *Fake_camera* to *FakeCamera*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/file_reader.py
+++ b/src/crappy/camera/file_reader.py
@@ -37,8 +37,8 @@ class FileReader(Camera):
   delay keeps growing.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 1.5.10 renamed from Streamer to File_reader
-  .. versionchanged:: 2.0.0 renamed from File_reader to FileReader
+  .. versionchanged:: 1.5.10 renamed from *Streamer* to *File_reader*
+  .. versionchanged:: 2.0.0 renamed from *File_reader* to *FileReader*
   """
 
   def __init__(self) -> None:
@@ -62,6 +62,8 @@ class FileReader(Camera):
 
     Args:
       reader_folder: The path to the folder containing the images to read.
+      
+        .. versionchanged:: 1.5.10 renamed from *path* to *reader_folder*
       reader_backend: The backend to use for reding the images. Should be one
         of :
         ::
@@ -69,13 +71,16 @@ class FileReader(Camera):
           'sitk' or 'cv2'
 
         If not given, SimpleITK is preferred over OpenCV if available.
+
+        .. versionadded:: 1.5.10
       stop_at_end: If :obj:`True` (the default), stops the Crappy script once
         the available images are all exhausted. Otherwise, simply remains idle
         while waiting for the test to finish.
-    
-    .. versionchanged:: 1.5.10 renamed *path* argument to *reader_folder*
-    .. versionadded:: 1.5.10 *reader_backend* and *stop_at_end* arguments
-    .. deprecated:: 1.5.10 *pattern*, *start_delay* and *modifier* arguments
+
+        .. versionadded:: 1.5.10
+
+    .. versionremoved::
+       1.5.10 *pattern*, *start_delay* and *modifier* arguments
     """
 
     # Selecting an  available backend between first sitk and then cv2

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -53,7 +53,8 @@ class CameraGstreamer(Camera):
     as GStreamer.
   
   .. versionadded:: 1.5.9
-  .. versionchanged:: 2.0.0 renamed from Camera_gstreamer to CameraGstreamer
+  .. versionchanged:: 2.0.0
+     renamed from *Camera_gstreamer* to *CameraGstreamer*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -53,7 +53,8 @@ class CameraGstreamer(Camera, V4L2Helper):
     as GStreamer.
   
   .. versionadded:: 1.5.9
-  .. versionchanged:: 2.0.0 renamed from Camera_gstreamer to CameraGstreamer
+  .. versionchanged:: 2.0.0
+     renamed from *Camera_gstreamer* to *CameraGstreamer*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -233,8 +233,9 @@ class Camera(metaclass=MetaCamera):
         be the average of ``lowest`` and ``highest``.
       step: The step value for the variation of the setting values.
 
+        .. versionadded:: 2.0.0
+
     .. versionadded:: 1.5.10
-    .. versionchanged:: 2.0.0 add the *step* argument
     """
 
     # Checking if the given name is valid

--- a/src/crappy/camera/meta_camera/camera_setting/camera_bool_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_bool_setting.py
@@ -13,7 +13,7 @@ class CameraBoolSetting(CameraSetting):
   
   .. versionadded:: 1.5.10
   .. versionchanged:: 2.0.0
-     renamed from Camera_bool_setting to CameraBoolSetting
+     renamed from *Camera_bool_setting* to *CameraBoolSetting*
   """
 
   def __init__(self,

--- a/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
@@ -16,7 +16,7 @@ class CameraChoiceSetting(CameraSetting):
   
   .. versionadded:: 1.5.10
   .. versionchanged:: 2.0.0
-     renamed from Camera_choice_setting to CameraChoiceSetting
+     renamed from *Camera_choice_setting* to *CameraChoiceSetting*
   """
 
   def __init__(self,

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -22,7 +22,7 @@ class CameraScaleSetting(CameraSetting):
   
   .. versionadded:: 1.5.10
   .. versionchanged:: 2.0.0
-     renamed from Camera_scale_setting to CameraScaleSetting
+     renamed from *Camera_scale_setting* to *CameraScaleSetting*
   """
 
   def __init__(self,

--- a/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
@@ -20,7 +20,7 @@ class CameraSetting:
   and :class:`~crappy.camera.meta_camera.camera_setting.CameraScaleSetting`.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Camera_setting to CameraSetting
+  .. versionchanged:: 2.0.0 renamed from *Camera_setting* to *CameraSetting*
   """
 
   def __init__(self,

--- a/src/crappy/camera/opencv_camera_basic.py
+++ b/src/crappy/camera/opencv_camera_basic.py
@@ -31,7 +31,7 @@ class CameraOpencv(Camera):
     more parameters than the basic version.
 
   .. versionadded:: 1.5.9
-  .. versionchanged:: 2.0.0 renamed from Camera_opencv to CameraOpencv
+  .. versionchanged:: 2.0.0 renamed from *Camera_opencv* to *CameraOpencv*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/opencv_camera_v4l2.py
+++ b/src/crappy/camera/opencv_camera_v4l2.py
@@ -35,7 +35,7 @@ class CameraOpencv(Camera, V4L2Helper):
     more parameters than the basic version.
 
   .. versionadded:: 1.5.9
-  .. versionchanged:: 2.0.0 renamed from Camera_opencv to CameraOpencv
+  .. versionchanged:: 2.0.0 renamed from *Camera_opencv* to *CameraOpencv*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/opencv_camera_webcam.py
+++ b/src/crappy/camera/opencv_camera_webcam.py
@@ -44,7 +44,7 @@ class Webcam(Camera):
       **kwargs: Any additional setting to set before opening the configuration
         window.
 
-    .. versionchanged:: 1.5.9 renamed *numdevice* argument to *device_num*
+        .. versionchanged:: 1.5.9 renamed from *numdevice* to *device_num*
     """
 
     # Opening the videocapture device

--- a/src/crappy/camera/raspberry_pi_camera.py
+++ b/src/crappy/camera/raspberry_pi_camera.py
@@ -40,7 +40,7 @@ class RaspberryPiCamera(Camera):
     "Bullseye", it has to be specifically activated in the configuration menu.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Picamera to RaspberryPiCamera
+  .. versionchanged:: 2.0.0 renamed from *Picamera* to *RaspberryPiCamera*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/seek_thermal_pro.py
+++ b/src/crappy/camera/seek_thermal_pro.py
@@ -66,7 +66,7 @@ MODE=\\"0777\\\"" | sudo tee seek_thermal.rules > /dev/null 2>&1
     in a shell opened in ``/etc/udev/rules.d``.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Seek_thermal_pro to SeekThermalPro
+  .. versionchanged:: 2.0.0 renamed from *Seek_thermal_pro* to *SeekThermalPro*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/camera/ximea_xiapi.py
+++ b/src/crappy/camera/ximea_xiapi.py
@@ -60,7 +60,7 @@ class XiAPI(Camera):
     Ximea's website in order for this class to run.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Xiapi to XiAPI
+  .. versionchanged:: 2.0.0 renamed from *Xiapi* to *XiAPI*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/inout/ads1115.py
+++ b/src/crappy/inout/ads1115.py
@@ -89,7 +89,7 @@ class ADS1115(InOut):
   voltage range.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Ads1115 to ADS1115
+  .. versionchanged:: 2.0.0 renamed from *Ads1115* to *ADS1115*
   """
 
   def __init__(self,
@@ -150,6 +150,8 @@ class ADS1115(InOut):
         the traffic on the I2C bus, but requires one extra wire. With the
         backend `'Pi4'`, give the index of the GPIO in BCM convention. This
         feature is not available with the `'blinka'` backend.
+
+        .. versionadded:: 1.5.8
       gain: Allows to tune the output value according to the formula :
         :math:`output = gain * tension + offset`.
       offset: Allows to tune the output value according to the formula :
@@ -160,7 +162,6 @@ class ADS1115(InOut):
       `GND-0.3V`. Setting high ``v_range`` values does not allow measuring
       voltages higher than `VDD` !!
 
-    .. versionadded:: 1.5.8 *dry_pin* argument
     .. versionremoved:: 2.0.0 *ft232h_ser_num* argument
     """
 

--- a/src/crappy/inout/comedi.py
+++ b/src/crappy/inout/comedi.py
@@ -62,6 +62,8 @@ class Comedi(InOut):
       device: The address of the device, as a :obj:`str`.
       sub_device: The id of the subdevice to use for input channels, as an
         :obj:`int`.
+
+        .. versionchanged:: 2.0.0 renamed from *subdevice* to *sub_device*
       channels: An iterable (like a :obj:`list` or a :obj:`tuple`) containing
         the indexes of the channels to use as inputs, given as :obj:`int`.
       range_num: An iterable (like a :obj:`list` or a :obj:`tuple`) containing
@@ -89,6 +91,9 @@ class Comedi(InOut):
         not given, the channels are by default not zeroed.
       out_sub_device: The id of the subdevice to use for output channels, as an
         :obj:`int`.
+
+        .. versionchanged:: 2.0.0
+           renamed from *out_subdevice* to *out_sub_device*
       out_channels: An iterable (like a :obj:`list` or a :obj:`tuple`)
         containing the indexes of the channels to use as outputs, given as
         :obj:`int`.
@@ -124,9 +129,6 @@ class Comedi(InOut):
        now explicitly listing the *device*, *subdevice*, *channels*,
        *range_num*, *gain*, *offset*, *make_zero*, *out_subdevice*,
        *out_channels*, *out_range_num*, *out_gain* and *out_offset* arguments
-    .. versionchanged:: 2.0.0 renamed *subdevice* argument to *sub_device*
-    .. versionchanged:: 2.0.0
-       renamed *out_subdevice* argument to *out_sub_device*
     """
 
     warn(f"Starting from version 2.1.0, {type(self).__name__} will be moved "

--- a/src/crappy/inout/daqmx.py
+++ b/src/crappy/inout/daqmx.py
@@ -38,7 +38,7 @@ class DAQmx(InOut):
     :mod:`PyDAQmx` module.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Daqmx to DAQmx
+  .. versionchanged:: 2.0.0 renamed from *Daqmx* to *DAQmx*
   """
 
   def __init__(self,
@@ -78,6 +78,8 @@ class DAQmx(InOut):
           0.5, 1., 2.5, 5.
 
         If not given, all input channels will be set to the range `5`.
+
+        .. versionchanged:: 1.5.10 renamed from *range* to *ranges*
       make_zero: An iterable (like a :obj:`list` or a :obj:`tuple`) containing
         for each input channel a :obj:`bool` indicating whether the channel
         should be zeroed or not. If so, data will be acquired on this channel
@@ -112,14 +114,14 @@ class DAQmx(InOut):
 
         If not given, all output channels will be set to the range `5`.
 
+        .. versionchanged:: 1.5.10 renamed from *out_range* to *out_ranges*
+
     Note:
       All the iterables given as arguments for the input channels should have
       the same length, and same for the output channels. If that's not the
       case, all the given iterables are treated as if they had the same length
       as the shortest given one.
 
-    .. versionchanged:: 1.5.10 renamed *range* argument to *ranges*
-    .. versionchanged:: 1.5.10 renamed *out_range* argument to *out_ranges*
     .. versionremoved:: 1.5.10 *nperscan* argument
     """
 

--- a/src/crappy/inout/fake_inout.py
+++ b/src/crappy/inout/fake_inout.py
@@ -21,7 +21,7 @@ class FakeInOut(InOut):
   computer.
   
   .. versionadded:: 1.5.5
-  .. versionchanged:: 2.0.0 renamed from Fake_inout to FakeInOut
+  .. versionchanged:: 2.0.0 renamed from *Fake_inout* to *FakeInOut*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/inout/gpio_pwm.py
+++ b/src/crappy/inout/gpio_pwm.py
@@ -23,7 +23,7 @@ class GPIOPWM(InOut):
     Only works on Raspberry Pi !
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Gpio_pwm to GPIOPWM
+  .. versionchanged:: 2.0.0 renamed from *Gpio_pwm* to *GPIOPWM*
   """
 
   def __init__(self,

--- a/src/crappy/inout/gpio_switch.py
+++ b/src/crappy/inout/gpio_switch.py
@@ -32,7 +32,7 @@ class GPIOSwitch(InOut):
   `0` it is turned low. Any value other than `0` and `1` raises an error.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Gpio_switch to GPIOSwitch
+  .. versionchanged:: 2.0.0 renamed from *Gpio_switch* to *GPIOSwitch*
   """
 
   def __init__(self,
@@ -54,8 +54,10 @@ class GPIOSwitch(InOut):
         The `'Pi4'` backend only works on the Raspberry Pis. The `'blinka'`
         backend requires installing :mod:`Adafruit-Blinka`, but this module is
         compatible with and maintained on a wide variety of boards.
+
+        .. versionadded:: 1.5.10
     
-    .. versionadded:: 1.5.10 *backend* and *ft232h_ser_num* arguments
+    .. versionadded:: 1.5.10 *ft232h_ser_num* argument
     .. versionremoved:: 2.0.0 *ft232h_ser_num* argument
     """
 

--- a/src/crappy/inout/kollmorgen_akd_pdmm.py
+++ b/src/crappy/inout/kollmorgen_akd_pdmm.py
@@ -42,7 +42,7 @@ class KollmorgenAKDPDMM(InOut):
    The values of the current speeds or positions can also be retrieved.
    
    .. versionadded:: 1.4.0
-   .. versionchanged:: 2.0.0 renamed from Koll to KollmorgenAKDPDMM
+   .. versionchanged:: 2.0.0 renamed from *Koll* to *KollmorgenAKDPDMM*
    """
 
   def __init__(self,
@@ -55,14 +55,16 @@ class KollmorgenAKDPDMM(InOut):
     Args:
       axes: An iterable (like a :obj:`list` or a :obj:`tuple`) containing the
         motors/axes to drive, given as :obj:`int`.
+
+        .. versionchanged:: 1.5.10 renamed from *axis* to *axes*
       mode: The driving mode, should be either `'speed'` or `'position'`.
+
+        .. versionchanged:: 1.5.10 renamed from *data* to *mode*
       host: The IP address of the variator, given as a :obj:`str`.
       port: The network port over which to communicate with the variator, as
         an :obj:`int`.
     
     .. versionremoved:: 1.5.10 *speed*, *acc*, *decc* and *labels* arguments
-    .. versionchanged:: 1.5.10 renamed *axis* argument to *axes*
-    .. versionchanged:: 1.5.10 renamed *data* argument to *mode*
     """
 
     warn(f"Starting from version 2.1.0, {type(self).__name__} will be moved "

--- a/src/crappy/inout/labjack_t7.py
+++ b/src/crappy/inout/labjack_t7.py
@@ -70,7 +70,7 @@ class LabjackT7(InOut):
   :class:`~crappy.inout.T7Streamer` class.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Labjack_t7 to LabjackT7
+  .. versionchanged:: 2.0.0 renamed from *Labjack_t7* to *LabjackT7*
   """
 
   def __init__(self,

--- a/src/crappy/inout/labjack_t7_streamer.py
+++ b/src/crappy/inout/labjack_t7_streamer.py
@@ -67,7 +67,7 @@ class T7Streamer(InOut):
     point acquisition can be performed.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from T7_streamer to T7Streamer
+  .. versionchanged:: 2.0.0 renamed from *T7_streamer* to *T7Streamer*
   """
 
   def __init__(self,

--- a/src/crappy/inout/labjack_ue9.py
+++ b/src/crappy/inout/labjack_ue9.py
@@ -36,7 +36,7 @@ class LabjackUE9(InOut):
   further improved in the future.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Labjack_ue9 to LabjackUE9
+  .. versionchanged:: 2.0.0 renamed from *Labjack_ue9* to *LabjackUE9*
   """
 
   def __init__(self,

--- a/src/crappy/inout/mcp9600.py
+++ b/src/crappy/inout/mcp9600.py
@@ -100,7 +100,7 @@ class MCP9600(InOut):
   that the MCP9600 can only achieve a data rate of a few Hz.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Mcp9600 to MCP9600
+  .. versionchanged:: 2.0.0 renamed from *Mcp9600* to *MCP9600*
   """
 
   def __init__(self,

--- a/src/crappy/inout/mprls.py
+++ b/src/crappy/inout/mprls.py
@@ -45,7 +45,7 @@ class MPRLS(InOut):
   It communicates over I2C with the sensor.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Mprls to MPRLS
+  .. versionchanged:: 2.0.0 renamed from *Mprls* to *MPRLS*
   """
 
   def __init__(self,
@@ -67,6 +67,8 @@ class MPRLS(InOut):
         :mod:`Adafruit-Blinka` and :mod:`adafruit-circuitpython-mprls`, but
         these modules are compatible with and maintained on a wide
         variety of boards.
+
+        .. versionadded:: 1.5.8
       eoc_pin: Optionally, reads the end of conversion signal from the polarity
         of a GPIO rather than from an I2C register. Speeds up the reading and
         decreases the traffic on the bus, but requires one extra wire. With the
@@ -74,15 +76,19 @@ class MPRLS(InOut):
         backend `'blinka'`, it should be a string but the syntax varies
         according to the board. Refer to blinka's documentation for more
         information.
+
+        .. versionadded:: 1.5.8
       device_address: The I2C address of the MPRLS. The address of the devices
         sold by Adafruit is `0x18`, but other suppliers may sell it with
         another address.
+
+        .. versionadded:: 1.5.8
       i2c_port: The I2C port over which the MPRLS should communicate. On most
         Raspberry Pi models the default I2C port is `1`.
+
+        .. versionadded:: 1.5.8
     
-    .. versionadded:: 1.5.8
-       *backend*, *eoc_pin*, *device_address*, *i2c_port* and *ft232h_ser_num*
-       arguments
+    .. versionadded:: 1.5.8 *ft232h_ser_num* argument
     .. versionremoved:: 2.0.0 *ft232h_ser_num* argument
     """
 

--- a/src/crappy/inout/nau7802.py
+++ b/src/crappy/inout/nau7802.py
@@ -113,7 +113,7 @@ class NAU7802(InOut):
   converted to Newtons using the ``gain`` and ``offset`` arguments.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Nau7802 to NAU7802
+  .. versionchanged:: 2.0.0 renamed from *Nau7802* to *NAU7802*
   """
 
   def __init__(self,
@@ -150,12 +150,13 @@ class NAU7802(InOut):
         of a GPIO rather than from an I2C register. Speeds up the reading and
         decreases the traffic on the bus, but requires one extra wire. Give the
         index of the GPIO in BCM convention, as an :obj:`int`.
+
+        .. versionadded:: 1.5.8
       gain: Allows to tune the output value according to the formula :
         :math:`output = gain * tension + offset`.
       offset: Allows to tune the output value according to the formula :
         :math:`output = gain * tension + offset`.
-      
-    .. versionadded:: 1.5.8 *int_pin* argument
+
     .. versionremoved:: 2.0.0 *backend* and *ft232h_ser_num* arguments
     """
 

--- a/src/crappy/inout/ni_daqmx.py
+++ b/src/crappy/inout/ni_daqmx.py
@@ -71,7 +71,7 @@ class NIDAQmx(InOut):
   be performed, like voltage, resistance, current, etc.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Nidaqmx to NIDAQmx
+  .. versionchanged:: 2.0.0 renamed from *Nidaqmx* to *NIDAQmx*
   """
 
   def __init__(self,
@@ -90,8 +90,12 @@ class NIDAQmx(InOut):
         channels of this type.
       sample_rate: The target sample rate for data acquisition in streamer
         mode, given as a :obj:`float`. Default is `100` SPS.
+
+        .. versionchanged:: 1.5.10 renamed from *samplerate* to *sample_rate*
       n_samples: The number of samples to acquire per chunk of data in streamer
         mode. Default is 20% of ``sample_rate``.
+
+        .. versionchanged:: 1.5.10 renamed from *nsamples* to *n_samples*
 
 
     Note:
@@ -128,9 +132,6 @@ class NIDAQmx(InOut):
           internally. Also note that for the analog output channels and the
           analog input channels of type `'voltage'`, the `'min_val'` and
           `'max_val'` arguments are internally set by default to `0` and `5`.
-    
-    .. versionchanged:: 1.5.10 renamed *samplerate* argument to *sample_rate*
-    .. versionchanged:: 1.5.10 renamed *nsamples* argument to *n_samples*
     """
 
     super().__init__()

--- a/src/crappy/inout/opsens_handysens.py
+++ b/src/crappy/inout/opsens_handysens.py
@@ -22,7 +22,7 @@ class HandySens(InOut):
   pressure, position or strain.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Opsens to HandySens
+  .. versionchanged:: 2.0.0 renamed from *Opsens* to *HandySens*
   """
 
   def __init__(self,

--- a/src/crappy/inout/phidgets_wheatstone_bridge.py
+++ b/src/crappy/inout/phidgets_wheatstone_bridge.py
@@ -25,6 +25,8 @@ class PhidgetWheatstoneBridge(InOut):
   It relies on the :mod:`Phidget22` module to communicate with the load cell
   conditioner. It can acquire values up to `50Hz` with possible gain values
   from `1` to `128`.
+
+  .. versionadded:: 2.0.4
   """
 
   def __init__(self,

--- a/src/crappy/inout/pijuice_hat.py
+++ b/src/crappy/inout/pijuice_hat.py
@@ -52,7 +52,7 @@ class PiJuice(InOut):
     Only available on Raspberry Pi !
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Pijuice to PiJuice
+  .. versionchanged:: 2.0.0 renamed from *Pijuice* to *PiJuice*
   """
 
   def __init__(self,
@@ -69,10 +69,10 @@ class PiJuice(InOut):
 
         The `'Pi4'` backend is based on the :mod:`smbus2` module, while the
         `'pijuice'` backend is based on the :mod:`pijuice` module.
+        
+        .. versionadded:: 1.5.10
       i2c_port: The I2C port over which the PiJuice should communicate.
       address: The I2C address of the piJuice. The default address is `0x14`.
-    
-    .. versionadded:: 1.5.10 *backend* argument
     """
 
     warn(f"Starting from version 2.1.0, {type(self).__name__} will be moved "

--- a/src/crappy/inout/sim868.py
+++ b/src/crappy/inout/sim868.py
@@ -26,7 +26,7 @@ class Sim868(InOut):
     to manage the messages to send.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Gsm to Sim868
+  .. versionchanged:: 2.0.0 renamed from *Gsm* to *Sim868*
   """
 
   def __init__(self,
@@ -47,10 +47,12 @@ class Sim868(InOut):
       port: Serial port the Sim868 is connected to.
       baudrate: Serial baudrate, between `1200` and `115200`.
       pin_code: Optionally, a pin code to use for activating the SIM card.
+      
+        .. versionadded:: 2.0.0
       registration_timeout: The maximum number of seconds to allow for the
         Sim868 to register to a network once the SIM card has the ready status.
-    
-    .. versionadded:: 2.0.0 *pin_code* and *registration_timeout* arguments
+
+        .. versionadded:: 2.0.0
     """
 
     warn(f"Starting from version 2.1.0, {type(self).__name__} will be moved "

--- a/src/crappy/inout/spectrum_m2i4711.py
+++ b/src/crappy/inout/spectrum_m2i4711.py
@@ -22,7 +22,7 @@ class SpectrumM2I4711(InOut):
   points.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Spectrum to SpectrumM2I4711
+  .. versionchanged:: 2.0.0 renamed from *Spectrum* to *SpectrumM2I4711*
   """
 
   def __init__(self,
@@ -46,12 +46,13 @@ class SpectrumM2I4711(InOut):
         If not given, all ranges default to `10000` mV.
       sample_rate: The sample rate of the acquisition for all channels, in Hz.
         The default is 100KHz.
+
+        .. versionchanged:: 1.5.10 renamed from *samplerate* to *sample_rate*
       buff_size: The size of the memory allocated as a rolling buffer to copy
         the data from the card, in bytes. The default is 67MB.
       notify_size: The size of each chunk of data to copy from the card, in
         bytes. The default is 65kB.
-    
-    .. versionchanged:: 1.5.10 renamed *samplerate* argument to *sample_rate*
+
     .. versionremoved:: 1.5.10 *split_chan* argument
     """
 

--- a/src/crappy/inout/waveshare_ad_da.py
+++ b/src/crappy/inout/waveshare_ad_da.py
@@ -99,7 +99,7 @@ class WaveshareADDA(InOut):
     This class is specifically meant to be used on a Raspberry Pi.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Waveshare_ad_da to WaveshareADDA
+  .. versionchanged:: 2.0.0 renamed from *Waveshare_ad_da* to *WaveshareADDA*
   """
 
   def __init__(self,

--- a/src/crappy/inout/waveshare_high_precision.py
+++ b/src/crappy/inout/waveshare_high_precision.py
@@ -117,7 +117,7 @@ class WaveshareHighPrecision(InOut):
   
   .. versionadded:: 1.5.10
   .. versionchanged:: 2.0.0
-     renamed from Waveshare_high_precision to WaveshareHighPrecision
+     renamed from *Waveshare_high_precision* to *WaveshareHighPrecision*
   """
 
   def __init__(self,

--- a/src/crappy/lamcube/bispectral.py
+++ b/src/crappy/lamcube/bispectral.py
@@ -85,7 +85,7 @@ class BiSpectral(BaslerIronmanCameraLink):
     proprietary drivers to be installed.
     
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Bispectral to BiSpectral
+  .. versionchanged:: 2.0.0 renamed from *Bispectral* to *BiSpectral*
   """
 
   def __init__(self) -> None:

--- a/src/crappy/modifier/demux.py
+++ b/src/crappy/modifier/demux.py
@@ -46,13 +46,13 @@ class Demux(Modifier):
         rows or columns in the stream, only the data from the first rows or
         columns will be retrieved.
       stream_label: The label carrying the stream.
+
+        .. versionchanged:: 1.5.10 renamed from *stream* to *stream_label*
       mean: If :obj:`True`, the returned value will be the average of the
         row or column. Otherwise, it will be the first value.
       time_label: The label carrying the time information.
       transpose: If :obj:`True`, each label corresponds to a row in the stream.
         Otherwise, a label corresponds to a column in the stream.
-    
-    .. versionchanged:: 1.5.10 renamed *stream* argument to *stream_label*
     """
 
     super().__init__()
@@ -71,8 +71,8 @@ class Demux(Modifier):
     corresponding timestamp, and returns them.
     
     .. versionchanged:: 1.5.10 
-       merge evaluate_mean and evaluate_nomean methods into evaluate
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+       merge *evaluate_mean* and *evaluate_nomean* methods into *evaluate*
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/differentiate.py
+++ b/src/crappy/modifier/differentiate.py
@@ -22,10 +22,10 @@ class Diff(Modifier):
     Args:
       label: The label whose time derivative to compute.
       time_label: The label carrying the time information.
+
+        .. versionchanged:: 1.5.10 renamed from *time* to *time_label*
       out_label: The label carrying the calculated derivative. If not given,
         defaults to ``'d_<label>'``.
-
-    .. versionchanged:: 1.5.10 renamed *time* argument to *time_label*
     """
 
     super().__init__()
@@ -40,7 +40,7 @@ class Diff(Modifier):
     """Gets the data from the upstream Block, updates the derivative value,
     appends it to the data and returns the data.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/integrate.py
+++ b/src/crappy/modifier/integrate.py
@@ -22,10 +22,10 @@ class Integrate(Modifier):
     Args:
       label: The label whose data to integrate over time.
       time_label: The label carrying the time information.
+
+        .. versionchanged:: 1.5.10 renamed from *time* to *time_label*
       out_label: The label carrying the integration value. If not given,
         defaults to ``'i_<label>'``.
-
-    .. versionchanged:: 1.5.10 renamed *time* argument to *time_label*
     """
 
     super().__init__()
@@ -41,7 +41,7 @@ class Integrate(Modifier):
     """Gets the data from the upstream Block, updates the integration value,
     adds it to the data and returns the data.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/mean.py
+++ b/src/crappy/modifier/mean.py
@@ -23,7 +23,7 @@ class Mean(Modifier):
     Args:
       n_points: The number of points on which to compute the average.
     
-    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
+        .. versionchanged:: 1.5.10 renamed from *npoints* to *n_points*
     """
 
     super().__init__()
@@ -37,7 +37,7 @@ class Mean(Modifier):
 
     If there are not enough points, doesn't return anything.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/median.py
+++ b/src/crappy/modifier/median.py
@@ -23,7 +23,7 @@ class Median(Modifier):
     Args:
       n_points: The number of points on which to compute the median.
 
-    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
+        .. versionchanged:: 1.5.10 renamed from *npoints* to *n_points*
     """
 
     super().__init__()

--- a/src/crappy/modifier/moving_avg.py
+++ b/src/crappy/modifier/moving_avg.py
@@ -15,7 +15,7 @@ class MovingAvg(Modifier):
   received from the upstream Block.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Moving_avg to MovingAvg
+  .. versionchanged:: 2.0.0 renamed from *Moving_avg* to *MovingAvg*
   """
 
   def __init__(self, n_points: int = 100) -> None:
@@ -24,7 +24,7 @@ class MovingAvg(Modifier):
     Args:
       n_points: The maximum number of points on which to compute the average.
     
-    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
+        .. versionchanged:: 1.5.10 renamed from *npoints* to *n_points*
     """
 
     super().__init__()
@@ -35,7 +35,7 @@ class MovingAvg(Modifier):
     """Receives data from the upstream Block, computes the average of every
     label and replaces the original data with it.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/moving_med.py
+++ b/src/crappy/modifier/moving_med.py
@@ -15,7 +15,7 @@ class MovingMed(Modifier):
   received from the upstream Block.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Moving_med to MovingMed
+  .. versionchanged:: 2.0.0 renamed from *Moving_med* to *MovingMed*
   """
 
   def __init__(self, n_points: int = 100) -> None:
@@ -24,7 +24,7 @@ class MovingMed(Modifier):
     Args:
       n_points: The maximum number of points on which to compute the median.
     
-    .. versionchanged:: 1.5.10 renamed *npoints* argument to *n_points*
+        .. versionchanged:: 1.5.10 renamed from *npoints* to *n_points*
     """
 
     super().__init__()
@@ -35,7 +35,7 @@ class MovingMed(Modifier):
     """Receives data from the upstream Block, computes the median of every
     label and replaces the original data with it.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/offset.py
+++ b/src/crappy/modifier/offset.py
@@ -64,7 +64,7 @@ class Offset(Modifier):
     """If the compensations are not set, sets them, and then offsets the
     required labels.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/trig_on_change.py
+++ b/src/crappy/modifier/trig_on_change.py
@@ -14,7 +14,7 @@ class TrigOnChange(Modifier):
   upon change of a label value.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Trig_on_change to TrigOnChange
+  .. versionchanged:: 2.0.0 renamed from *Trig_on_change* to *TrigOnChange*
   """
 
   def __init__(self, label: str) -> None:
@@ -23,7 +23,7 @@ class TrigOnChange(Modifier):
     Args:
       label: The name of the label to monitor.
     
-    .. versionchanged:: 1.5.10 renamed *name* argument to *label*
+        .. versionchanged:: 1.5.10 renamed from *name* to *label*
     """
 
     super().__init__()
@@ -34,7 +34,7 @@ class TrigOnChange(Modifier):
     """Compares the received value with the last sent one, and if they're
     different sends the received data and stores the latest value.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/modifier/trig_on_value.py
+++ b/src/crappy/modifier/trig_on_value.py
@@ -13,7 +13,7 @@ class TrigOnValue(Modifier):
   Mostly useful to trigger Blocks in predefined situations.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Trig_on_value to TrigOnValue
+  .. versionchanged:: 2.0.0 renamed from *Trig_on_value* to *TrigOnValue*
   """
 
   def __init__(self,
@@ -23,11 +23,11 @@ class TrigOnValue(Modifier):
 
     Args:
       label: The name of the label to monitor.
+
+        .. versionchanged:: 1.5.10 renamed from *name* to *label*
       values: The values of ``label`` for which the data will be transmitted.
         Can be a single value, or an iterable of values (like a :obj:`list` or
         a :obj:`tuple`).
-
-    .. versionchanged:: 1.5.10 renamed *name* argument to *label*
     """
 
     super().__init__()
@@ -48,7 +48,7 @@ class TrigOnValue(Modifier):
     """Checks if the value of ``label`` is in the predefined set of accepted
     values, and if so transmits the data.
     
-    .. versionchanged:: 2.0.0 renamed from evaluate to __call__
+    .. versionchanged:: 2.0.0 renamed from *evaluate* to *__call__*
     """
 
     self.log(logging.DEBUG, f"Received {data}")

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -53,7 +53,7 @@ class CameraConfig(tk.Tk):
   :class:`~crappy.camera.meta_camera.camera_setting.CameraSetting` class.
 
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from Camera_config to CameraConfig
+  .. versionchanged:: 2.0.0 renamed from *Camera_config* to *CameraConfig*
   """
 
   def __init__(self,
@@ -68,13 +68,17 @@ class CameraConfig(tk.Tk):
         the images.
       log_queue: A :obj:`multiprocessing.Queue` for sending the log messages to 
         the main :obj:`~logging.Logger`, only used in Windows.
+
+        .. versionadded:: 2.0.0
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
+
+        .. versionadded:: 2.0.0
       max_freq: The maximum frequency this window is allowed to loop at. It is
         simply the ``freq`` attribute of the :class:`~crappy.blocks.Camera`
         Block.
-    
-    .. versionadded:: 2.0.0 *log_queue*, *log_level* and *max_freq* arguments
+
+        .. versionadded:: 2.0.0
     """
 
     super().__init__()

--- a/src/crappy/tool/camera_config/camera_config_boxes.py
+++ b/src/crappy/tool/camera_config/camera_config_boxes.py
@@ -24,7 +24,7 @@ class CameraConfigBoxes(CameraConfig):
   
   .. versionadded:: 1.4.0
   .. versionchanged:: 2.0.0
-     renamed from Camera_config_with_boxes to CameraConfigBoxes
+     renamed from *Camera_config_with_boxes* to *CameraConfigBoxes*
   """
 
   def __init__(self,
@@ -39,13 +39,17 @@ class CameraConfigBoxes(CameraConfig):
         the images.
       log_queue: A :obj:`multiprocessing.Queue` for sending the log messages to 
         the main :obj:`~logging.Logger`, only used in Windows.
+
+        .. versionadded:: 2.0.0
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
+
+        .. versionadded:: 2.0.0
       max_freq: The maximum frequency this window is allowed to loop at. It is
         simply the ``freq`` attribute of the :class:`~crappy.blocks.Camera`
         Block.
 
-    .. versionadded:: 2.0.0 *log_queue*, *log_level* and *max_freq* arguments
+        .. versionadded:: 2.0.0
     """
 
     self._spots = SpotsBoxes()

--- a/src/crappy/tool/camera_config/dic_ve_config.py
+++ b/src/crappy/tool/camera_config/dic_ve_config.py
@@ -31,7 +31,7 @@ class DICVEConfig(CameraConfigBoxes):
   meant to be used for configuring the :class:`~crappy.blocks.DICVE` Block.
   
   .. versionadded:: 1.5.10
-  .. versionchanged:: 2.0.0 renamed from DISVE_config to DICVEConfig
+  .. versionchanged:: 2.0.0 renamed from *DISVE_config* to *DICVEConfig*
   """
 
   def __init__(self,
@@ -47,16 +47,20 @@ class DICVEConfig(CameraConfigBoxes):
         the images.
       log_queue: A :obj:`multiprocessing.Queue` for sending the log messages to 
         the main :obj:`~logging.Logger`, only used in Windows.
+
+        .. versionadded:: 2.0.0
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
+
+        .. versionadded:: 2.0.0
       max_freq: The maximum frequency this window is allowed to loop at. It is
         simply the ``freq`` attribute of the :class:`~crappy.blocks.Camera`
         Block.
+
+        .. versionadded:: 2.0.0
       patches: An instance of
         :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` containing
         the patches to follow for image correlation.
-    
-    .. versionadded:: 2.0.0 *log_queue*, *log_level* and *max_freq* arguments
     """
 
     self._patch_size: Optional[CameraScaleSetting] = None

--- a/src/crappy/tool/camera_config/dis_correl_config.py
+++ b/src/crappy/tool/camera_config/dis_correl_config.py
@@ -30,7 +30,7 @@ class DISCorrelConfig(CameraConfigBoxes):
   Block.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from DISConfig to DISCorrelConfig
+  .. versionchanged:: 2.0.0 renamed from *DISConfig* to *DISCorrelConfig*
   """
 
   def __init__(self,
@@ -46,17 +46,22 @@ class DISCorrelConfig(CameraConfigBoxes):
         the images.
       log_queue: A :obj:`multiprocessing.Queue` for sending the log messages to 
         the main :obj:`~logging.Logger`, only used in Windows.
+
+        .. versionadded:: 2.0.0
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
+
+        .. versionadded:: 2.0.0
       max_freq: The maximum frequency this window is allowed to loop at. It is
         simply the ``freq`` attribute of the :class:`~crappy.blocks.Camera`
         Block.
+
+        .. versionadded:: 2.0.0
       patch: The :class:`~crappy.tool.camera_config.config_tools.Box` container
         that will save the information on the patch where to perform image
         correlation.
-        
-    .. versionadded:: 2.0.0
-       *patch*, *log_queue*, *log_level* and *max_freq* arguments
+
+        .. versionadded:: 2.0.0
     """
 
     self._correl_box = patch

--- a/src/crappy/tool/camera_config/video_extenso_config.py
+++ b/src/crappy/tool/camera_config/video_extenso_config.py
@@ -33,7 +33,7 @@ class VideoExtensoConfig(CameraConfigBoxes):
   Block.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from VE_config to VideoExtensoConfig
+  .. versionchanged:: 2.0.0 renamed from *VE_config* to *VideoExtensoConfig*
   """
 
   def __init__(self,
@@ -49,19 +49,25 @@ class VideoExtensoConfig(CameraConfigBoxes):
       the images.
       log_queue: A :obj:`multiprocessing.Queue` for sending the log messages to
         the main :obj:`~logging.Logger`, only used in Windows.
+
+        .. versionadded:: 2.0.0
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
+
+        .. versionadded:: 2.0.0
       max_freq: The maximum frequency this window is allowed to loop at. It is
         simply the ``freq`` attribute of the :class:`~crappy.blocks.Camera`
         Block.
+
+        .. versionadded:: 2.0.0
       detector: An instance of
         :class:`~crappy.tool.camera_config.config_tools.SpotsDetector` used for
         detecting spots on the images received from the
         :class:`~crappy.camera.Camera`.
+        
+        .. versionadded:: 2.0.0
 
     .. versionchanged:: 1.5.10 renamed *ve* argument to *video_extenso*
-    .. versionadded:: 2.0.0
-       *detector*, *log_queue*, *log_level* and *max_freq* arguments
     .. versionremoved:: 2.0.0 *video_extenso* argument
     """
 

--- a/src/crappy/tool/ft232h/ft232h.py
+++ b/src/crappy/tool/ft232h/ft232h.py
@@ -118,7 +118,7 @@ class FindSerialNumber:
   
   .. versionadded:: 1.5.10
   .. versionchanged:: 2.0.0
-     renamed from Find_serial_number to FindSerialNumber
+     renamed from *Find_serial_number* to *FindSerialNumber*
   """
 
   def __init__(self, serial_number: str) -> None:
@@ -165,7 +165,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     ``set_ft232h_serial_nr.py``.
   
   .. versionadded:: 1.5.10
-  .. versionchanged:: 2.0.0 renamed from ft232h to FT232H
+  .. versionchanged:: 2.0.0 renamed from *ft232h* to *FT232H*
   """
 
   class BitMode(IntEnum):

--- a/src/crappy/tool/ft232h/ft232h_server.py
+++ b/src/crappy/tool/ft232h/ft232h_server.py
@@ -172,7 +172,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     ``set_ft232h_serial_nr.py``.
   
   .. versionadded:: 1.5.10
-  .. versionchanged:: 2.0.0 renamed from ft232h_server to FT232HServer
+  .. versionchanged:: 2.0.0 renamed from *ft232h_server* to *FT232HServer*
   """
 
   def __init__(self,
@@ -199,9 +199,14 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
       block_index: The index the :class:`~crappy.blocks.Block` driving this 
         FT232HServer instance has been assigned by the 
         :class:`~crappy.tool.ft232h.USBServer`, as an :obj:`int`.
+
+        .. versionchanged:: 2.0.0 renamed from *block_number* to *block_index*
       current_block: The handle to a shared :obj:`multiprocessing.Value` 
         indicating which :class:`~crappy.blocks.Block` can currently
         communicate with the :class:`~crappy.tool.ft232h.USBServer`.
+
+        .. versionchanged:: 2.0.0
+           renamed from *current_file* to *current_block*
       command_file: A file in which the current command to be executed by the
         USB server is written.
       answer_file: A file in which the answer to the current command is
@@ -213,6 +218,8 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
       shared_lock: A :obj:`multiprocessing.Lock` common to all the 
         :class:`~crappy.blocks.Block` that allows the one Block holding it to 
         communicate with the :class:`~crappy.tool.ft232h.USBServer`.
+
+        .. versionchanged:: 2.0.0 renamed from *current_lock* to *shared_lock*
       serial_nr: The serial number of the FT232H to drive, as a :obj:`str`. In
         `Write_serial_nr` mode, the serial number to be written.
       i2c_speed: In I2C mode, the I2C bus clock frequency in Hz. Available
@@ -238,11 +245,6 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
         It is not possible to simultaneously control slaves over SPI and I2C,
         due to different hardware requirements for the two protocols. Trying to
         do so will most likely raise an error or lead to inconsistent behavior.
-
-    .. versionchanged:: 2.0.0 renamed *block_number* argument to *block_index*
-    .. versionchanged:: 2.0.0
-       renamed *current_file* argument to *current_block*
-    .. versionchanged:: 2.0.0 renamed *current_lock* argument to *shared_lock*
     """
 
     self._block_index = block_index

--- a/src/crappy/tool/ft232h/i2c_message.py
+++ b/src/crappy/tool/ft232h/i2c_message.py
@@ -12,7 +12,7 @@ class I2CMessage:
   :class:`~crappy.inout.MPRLS` InOut.
   
   .. versionadded:: 1.5.10
-  .. versionchanged:: 2.0.0 renamed from i2c_msg_ft232h to I2CMessage
+  .. versionchanged:: 2.0.0 renamed from *i2c_msg_ft232h* to *I2CMessage*
   """
 
   def __init__(self,

--- a/src/crappy/tool/ft232h/usb_server.py
+++ b/src/crappy/tool/ft232h/usb_server.py
@@ -59,7 +59,7 @@ class USBServer(Process):
   The server is a child of :obj:`multiprocessing.Process`.
   
   .. versionadded:: 1.5.2
-  .. versionchanged:: 2.0.0 renamed from Usb_server to USBServer
+  .. versionchanged:: 2.0.0 renamed from *Usb_server* to *USBServer*
   """
 
   initialized = False
@@ -182,10 +182,12 @@ class USBServer(Process):
       log_queue: The :obj:`multiprocessing.Queue` carrying the log messages 
         from the server Process to Crappy's centralized log handler. Only used 
         in Windows.
+
+        .. versionadded:: 2.0.0
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
 
-    .. versionadded:: 2.0.0 *log_queue* and *log_level* arguments
+        .. versionadded:: 2.0.0
     """
 
     cls.process = cls(current_block=cls.current_block,

--- a/src/crappy/tool/image_processing/dic_ve.py
+++ b/src/crappy/tool/image_processing/dic_ve.py
@@ -23,7 +23,7 @@ class DICVETool:
   could as well be of use for other applications.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from DISVE to DICVETool
+  .. versionchanged:: 2.0.0 renamed from *DISVE* to *DICVETool*
   """
 
   def __init__(self,
@@ -56,6 +56,8 @@ class DICVETool:
         meant for debugging. `Parabola` refines the result of
         `Pixel precision` by interpolating the neighborhood of the maximum, and
         has thus a sub-pixel resolution.
+
+        .. versionadded:: 1.5.9
       alpha: Weight of the smoothness term in DISFlow, as a :obj:`float`.
       delta: Weight of the color constancy term in DISFlow, as a :obj:`float`.
       gamma: Weight of the gradient constancy term in DISFlow , as a
@@ -66,6 +68,9 @@ class DICVETool:
         patch inverse search stage in DISFlow, as an :obj:`int`.
       gradient_iterations: Maximum number of gradient descent iterations
         in the patch inverse search stage in DISFlow, as an :obj:`int`.
+
+        .. versionchanged:: 1.5.9
+           renamed from *gditerations* to *gradient_iterations*
       patch_size: Size of an image patch for matching in DISFlow
         (in pixels).
       patch_stride: Stride between neighbor patches in DISFlow. Must be
@@ -77,10 +82,7 @@ class DICVETool:
         image, and raises an error if that's the case.
       follow: It :obj:`True`, the patches will move to follow the displacement
         of the image.
-    
-    .. versionchanged:: 1.5.9
-       renamed *gditerations* argument to *gradient_iterations*
-    .. versionadded:: 1.5.9 *method* argument
+
     .. versionremoved:: 1.5.10 *img0* and *show_image* arguments
     """
 

--- a/src/crappy/tool/image_processing/dis_correl.py
+++ b/src/crappy/tool/image_processing/dis_correl.py
@@ -22,7 +22,7 @@ class DISCorrelTool:
   image on the chosen fields, and calculates the residuals.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from DISCorrel to DISCorrelTool
+  .. versionchanged:: 2.0.0 renamed from *DISCorrel* to *DISCorrelTool*
   """
 
   def __init__(self,
@@ -43,6 +43,8 @@ class DISCorrelTool:
       box: An instance of the
         :class:`~crappy.tool.camera_config.config_tools.Box` object containing
         the coordinates of the patch on which to perform image correlation.
+
+        .. versionadded:: 2.0.0
       fields: The base of fields to use for the projection, given as a
         :obj:`list` of :obj:`str`. The available fields are :
         ::
@@ -61,14 +63,13 @@ class DISCorrelTool:
         patch inverse search stage in DISFlow, as an :obj:`int`.
       gradient_iterations: Maximum number of gradient descent iterations
         in the patch inverse search stage in DISFlow, as an :obj:`int`.
+
+        .. versionchanged:: 1.5.10
+           renamed from *gditerations* to *gradient_iterations*
       patch_size: Size of an image patch for matching in DISFlow
         (in pixels).
       patch_stride: Stride between neighbor patches in DISFlow. Must be
         less than patch size.
-    
-    .. versionchanged:: 1.5.10
-       renamed *gditerations* argument to *gradient_iterations*
-    .. versionadded:: 2.0.0 *box* argument
     """
 
     if fields is not None and not all((field in allowed_fields

--- a/src/crappy/tool/image_processing/fields.py
+++ b/src/crappy/tool/image_processing/fields.py
@@ -26,11 +26,12 @@ def get_field(field_string: str,
   Args:
     field_string: The :obj:`str` describing the field on which to project the
       image for correlation.
+
+      .. versionchanged:: 1.5.10 renamed from *s* to *field_string*
     h: The height of the image, as an :obj:`int`.
     w: The width of the image, as an :obj:`int`.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 1.5.10 renamed *s* argument to *field_string*
   """
 
   if field_string == 'x':
@@ -90,13 +91,16 @@ def get_res(ref: np.ndarray, img: np.ndarray, flow: np.ndarray) -> np.ndarray:
 
   Args:
     ref: The reference image for calculating the optical flow.
+
+      .. versionchanged:: 1.5.10 renamed from *r* to *ref*
     img: The current image for calculating the optical flow.
+
+      .. versionchanged:: 1.5.10 renamed from *a* to *img*
     flow: The calculated optical flow
+
+      .. versionchanged:: 1.5.10 renamed from *b* to *flow*
     
   .. versionadded:: 1.4.0
-  .. versionchanged:: 1.5.10 renamed *a* argument to *img*
-  .. versionchanged:: 1.5.10 renamed *b* argument to *flow*
-  .. versionchanged:: 1.5.10 renamed *r* argument to *ref*
   """
 
   x, y = np.meshgrid(np.arange(img.shape[1]), np.arange(img.shape[0]))

--- a/src/crappy/tool/image_processing/gpu_correl.py
+++ b/src/crappy/tool/image_processing/gpu_correl.py
@@ -62,14 +62,8 @@ class CorrelStage:
 
   This class actually performs the GPU computation, while the calling classes
   only manage the data.
-  
+
   .. versionadded:: 1.4.0
-  .. versionchanged:: 1.5.10
-     now explicitly listing the *verbose*, *iterations*, *mul* and
-     *kernel_file* arguments
-  .. versionchanged:: 1.5.10 renamed *Nfields* argument to *n_fields*
-  .. versionremoved:: 1.5.10 *show_diff*, *img*, *mask* and *fields* arguments
-  .. versionadded:: 2.0.0 *logger_name* argument
   """
 
   def __init__(self,
@@ -86,6 +80,8 @@ class CorrelStage:
       img_size: The shape of the images to process. It is given beforehand so
         that the memory can be allocated before the test starts.
       logger_name: The name of the parent logger, as a :obj:`str`.
+
+        .. versionadded:: 2.0.0
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
         is displayed that is slows the code down.
@@ -100,8 +96,15 @@ class CorrelStage:
         recommended to tune this value for each application so that the
         convergence is neither too slow nor too fast.
       n_fields: The number of fields to project the displacement on.
+
+        .. versionchanged:: 1.5.10 renamed from *Nfields* to *n_fields*
       kernel_file: The path to the file containing the kernels to use for the
         correlation. Can be a :obj:`pathlib.Path` object or a :obj:`str`.
+
+    .. versionchanged:: 1.5.10
+       now explicitly listing the *verbose*, *iterations*, *mul* and
+       *kernel_file* arguments
+    .. versionremoved:: 1.5.10 *show_diff*, *img*, *mask* and *fields* arguments
     """
 
     self._logger: Optional[logging.Logger] = None
@@ -508,7 +511,7 @@ class GPUCorrelTool:
   an optimal solution.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 2.0.0 renamed from GPUCorrel to GPUCorrelTool
+  .. versionchanged:: 2.0.0 renamed from *GPUCorrel* to *GPUCorrelTool*
   """
 
   context = None
@@ -530,11 +533,15 @@ class GPUCorrelTool:
     Args:
       logger_name: The name of the parent :obj:`~logging.Logger`, to be used
         for setting the Logger of the class.
+
+        .. versionadded:: 2.0.0
       context: Optionally, the :mod:`pycuda` context to use. If not specified,
         a new context is instantiated.
+
+        .. versionadded:: 1.5.10
       verbose: The verbose level as an integer, between `0` and `3`. At level
         `0` no information is displayed, and at level `3` so much information
-        is displayed that is slows the code down.
+        is displayed that it slows the code down.
       levels: Number of levels of the pyramid. More levels may help converging
         on images with large strain, but may fail on images that don't contain
         low spatial frequency. Fewer levels mean that the program runs faster.
@@ -559,6 +566,8 @@ class GPUCorrelTool:
       ref_img: The reference image, as a 2D :obj:`numpy.array` with `dtype`
         `float32`. It can either be given at :meth:`__init__`, or set later
         with :meth:`set_orig`.
+
+        .. versionchanged:: 1.5.10 renamed from *img* to *ref_img*
       mask: The mask used for weighting the region of interest on the image. It
         is generally used to prevent unexpected behavior on the border of the
         image.
@@ -573,10 +582,7 @@ class GPUCorrelTool:
     .. versionchanged:: 1.5.10 
        now explicitly listing the *verbose*, *levels*, *resampling_factor*,
        *kernel_file*, *iterations*, *fields*, *mask* and *mul* arguments
-    .. versionchanged:: 1.5.10 renamed *img* argument to *ref_img*
-    .. versionadded:: 1.5.10 *context* argument
     .. versionremoved:: 1.5.10 *show_diff* and *img_size* arguments
-    .. versionadded:: 2.0.0 *logger_name* argument
     """
 
     self._context = context

--- a/src/crappy/tool/image_processing/video_extenso/video_extenso.py
+++ b/src/crappy/tool/image_processing/video_extenso/video_extenso.py
@@ -29,8 +29,8 @@ class VideoExtensoTool:
   center is returned and the strain values are left to `0`.
   
   .. versionadded:: 1.4.0
-  .. versionchanged:: 1.5.10 renamed from Video_extenso to VideoExtenso
-  .. versionchanged:: 2.0.0 renamed from VideoExtenso to VideoExtensoTool
+  .. versionchanged:: 1.5.10 renamed from *Video_extenso* to *VideoExtenso*
+  .. versionchanged:: 2.0.0 renamed from *VideoExtenso* to *VideoExtensoTool*
   """
 
   def __init__(self,
@@ -49,14 +49,22 @@ class VideoExtensoTool:
       spots: An instance of the 
         :class:`~crappy.tool.camera_config.config_tools.SpotsBoxes` tool 
         containing the coordinates of the spots to track.
+
+        .. versionadded:: 2.0.0
       thresh: The grey level value of the threshold to use for discriminating
         spots from the background, as an :obj:int`. Passed to the
         :class:`~crappy.tool.image_processing.video_extenso.tracker.Tracker`
         and not used in this class.
+
+        .. versionadded:: 2.0.0
       log_level: The minimum logging level of the entire Crappy script, as an
         :obj:`int`.
+
+        .. versionadded:: 2.0.0
       log_queue: A :obj:`multiprocessing.Queue` for sending the log messages to 
         the main :obj:`~logging.Logger`, only used in Windows.
+
+        .. versionadded:: 2.0.0
       white_spots: If :obj:`True`, detects white objects over a black
         background, else black objects over a white background. Passed to the
         :class:`~crappy.tool.image_processing.video_extenso.tracker.Tracker`
@@ -91,8 +99,6 @@ class VideoExtensoTool:
         and not used in this class.
 
     .. versionremoved:: 2.0.0 *num_spots* and *min_area* arguments
-    .. versionadded:: 2.0.0
-       *spots*, *thresh*, *log_level* and *log_queue* arguments
     """
 
     # These attributes will be used later
@@ -184,7 +190,7 @@ class VideoExtensoTool:
       A :obj:`list` containing :obj:`tuple` with the coordinates of the centers 
       of the detected spots, and the calculated x and y strain values.
     
-    .. versionchanged:: 1.5.10 renamed from get_def to get_data
+    .. versionchanged:: 1.5.10 renamed from *get_def* to *get_data*
     """
 
     # Sending the latest sub-image containing the spot to track


### PR DESCRIPTION
Since release `2.0.2` (specifically commit 6ec2eb28), change-set information was added to the documentation in order to make it clear at which point in the project's history the changes in the API occurred. However, the change-set information was included in the documentation after the description of the arguments. 

In this PR, the change-set information is moved inside the argument description, effectively tying it up with the described arguments. Users are less likely to miss this information, and developers are more likely to remember to update it when needed.
Only the information about deleted arguments was kept after the argument description. 