### PR TITLE
Send image index on save

### DIFF
--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -28,9 +28,10 @@ class Camera(Block):
   can accept input Links is when an ``image_generator`` is defined, or when
   defining a ``software_trig_label``. If ``save_images`` is set to :obj:`True`,
   and if an output Link is present, a message is sent to downstream Blocks at
-  each saved image, containing the timestamp and the metadata of the image.
-  They are respectively carried by the `'t(s)'` and `'meta'` labels. This is
-  useful for performing an action conditionally at each new saved image.
+  each saved image, containing the timestamp, the index, and the metadata of
+  the image. They are respectively carried by the `'t(s)'`, `'img_index'` and
+  `'meta'` labels. This is useful for performing an action conditionally at
+  each new saved image.
 
   Most of the time, this Block is used for recording to the desired location
   the images it acquires. Optionally, the images can also be displayed in a

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -71,8 +71,8 @@ class ImageSaver(CameraProcess):
         backend ``'npy'``, that saves the images as raw numpy arrays.
       send_msg: In case no processing is performed, and if output Links are
         present, this argument is set to :obj:`True`. In that case, a message
-        containing the timestamp and the metadata of the image is sent to
-        downstream Blocks each time an image is saved.
+        containing the timestamp, the index, and the metadata of the image is
+        sent to downstream Blocks each time an image is saved.
 
         .. versionadded:: 2.0.5
     """
@@ -241,4 +241,6 @@ class ImageSaver(CameraProcess):
 
     # Sending the results to the downstream Blocks
     if self._send_msg:
-      self.send({'t(s)': self.metadata['t(s)'], 'meta': self.metadata})
+      self.send({'t(s)': self.metadata['t(s)'],
+                 'img_index': self.metadata['ImageUniqueID'],
+                 'meta': self.metadata})


### PR DESCRIPTION
Since #107, the [`Camera` Block](https://github.com/LaboratoireMecaniqueLille/crappy/blob/595df27ec58fcb138124062c5050c7e42178e7ba/src/crappy/blocks/camera.py#L21) sends a signal to downstream Blocks when recording images in case no image processing is performed and output Links are present. Originally, the sent message was containing only the timestamp of the saved image and its metadata. However, these two labels did not allow integration with the [`Synchronizer` Block](https://github.com/LaboratoireMecaniqueLille/crappy/blob/595df27ec58fcb138124062c5050c7e42178e7ba/src/crappy/blocks/synchronizer.py#L11) added in #108, as the time label is a special one and the metadata label cannot be interpolated.

To solve this issue, this PR adds a new label `'index'`, carrying the image index, to the values sent when saving an image. By taking the `'index'` label as the reference one for the `Synchronizer` Block, is is now possible to synchronize signals with the timestamps of recorded images.