### PR TITLE
Not interpolating reference label in Synchronizer Block

### DIFF
--- a/src/crappy/blocks/synchronizer.py
+++ b/src/crappy/blocks/synchronizer.py
@@ -159,7 +159,14 @@ class Synchronizer(Block):
 
     # Building the dict of values to send
     for label, values in self._data.items():
-      to_send[label] = list(np.interp(interp_times, values[0], values[1]))
+
+      # Keeping the values of the reference label as they are
+      if label == self._ref_label:
+        to_send[label] = values[1, :]
+      # For all the other labels, performing interpolation
+      else:
+        to_send[label] = list(np.interp(interp_times, values[0], values[1]))
+
       # Keeping the last data point before max_t to pass this information on
       last = values[:, values[0] <= max_t][:, -1]
       # Removing the used values from the buffer, except the last data point


### PR DESCRIPTION
In the [`Synchronizer` Block](https://github.com/LaboratoireMecaniqueLille/crappy/blob/595df27ec58fcb138124062c5050c7e42178e7ba/src/crappy/blocks/synchronizer.py#L11) added in https://github.com/LaboratoireMecaniqueLille/crappy/pull/108, the reference label was originally interpolated along with the other ones. However, this was problematic in case the reference label carries values that cannot be interpolated (e.g. strings).

This PR introduces a differentiated treatment for the reference label in the `Synchronizer` Block, so that its values are passed on as is without any interpolation.