### PR TITLE
Release/2.0.5

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@
 from time import gmtime, strftime
 from re import match
 
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -158,6 +158,11 @@ Real-time image correlation
      that it still works as expected ! On the long-term, it should be replaced
      by another Block.
 
+  .. Warning::
+     This Block cannot run with CUDA versions greater than 11.3 ! This is due
+     to a deprecation in pycuda, and is unlikely to be fixed anytime soon in
+     Crappy or pycuda.
+
 Video-extensometry
 ++++++++++++++++++
 
@@ -200,6 +205,11 @@ Video-extensometry
      This Block hasn't been maintained nor tested for a while, it is not sure
      that it still works as expected ! On the long-term, it should be replaced
      by another Block.
+
+  .. Warning::
+     This Block cannot run with CUDA versions greater than 11.3 ! This is due
+     to a deprecation in pycuda, and is unlikely to be fixed anytime soon in
+     Crappy or pycuda.
 
 - :ref:`Video Extenso`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "crappy"
 dynamic = ["readme"]
-version = "2.0.4"
+version = "2.0.5"
 description = "Command and Real-time Acquisition in Parallelized Python"
 license = {file = "LICENSE"}
 keywords = ["control", "command", "acquisition", "multiprocessing"]

--- a/src/crappy/__version__.py
+++ b/src/crappy/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-__version__ = '2.0.4'
+__version__ = '2.0.5'

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -34,6 +34,11 @@ class GPUCorrel(Camera):
   correlation is performed on the entire image. It is however possible to set
   a mask, so that only part of the image is considered when running the
   correlation.
+
+  Warning:
+    This Block cannot run with CUDA versions greater than 11.3 ! This is due to
+    a deprecation in pycuda, and is unlikely to be fixed anytime soon in Crappy
+    or pycuda.
   
   .. versionadded:: 1.4.0
   """

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -29,6 +29,11 @@ class GPUVE(Camera):
   also performs video-extensometry, but it does so by tracking spots instead
   of textured patches, and it is not GPU-accelerated.
 
+  Warning:
+    This Block cannot run with CUDA versions greater than 11.3 ! This is due to
+    a deprecation in pycuda, and is unlikely to be fixed anytime soon in Crappy
+    or pycuda.
+
   .. versionadded:: 1.4.0
   """
 


### PR DESCRIPTION
Update the version from `2.0.4` to `2.0.5`, and add warnings in the documentation.