### PR TITLE
Fix camera configuration bug and remove duplicate code

### DIFF
--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -112,6 +112,7 @@ class CameraConfig(tk.Tk):
     self._run = True
     self._n_loops = 0
     self._max_freq = max_freq
+    self._got_first_img: bool = False
 
     # Settings for adjusting the behavior of the zoom
     self._zoom_ratio = 0.9
@@ -1025,13 +1026,12 @@ class CameraConfig(tk.Tk):
     ret = self._camera.get_image()
 
     # Flag raised if no image could be grabbed
-    no_img = False
+    no_img = ret is None
 
     # If no frame could be grabbed from the camera
-    if ret is None:
-      no_img = True
+    if no_img:
       # If it's the first call, generate error image to initialize the window
-      if not self._n_loops:
+      if not self._got_first_img:
         self.log(logging.WARNING, "Could not get an image from the camera, "
                                   "displaying an error image instead")
         ret = None, np.array(Image.open(BytesIO(resource_string(
@@ -1043,6 +1043,8 @@ class CameraConfig(tk.Tk):
         sleep(0.001)
         return
 
+    # Always set, so that the error image is only ever loaded once
+    self._got_first_img = True
     self._n_loops += 1
     _, img = ret
 

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -1050,6 +1050,7 @@ class CameraConfig(tk.Tk):
       self.shape = img.shape
 
     self._cast_img(img)
+    self._draw_overlay()
     self._resize_img()
 
     self._calc_hist()
@@ -1061,3 +1062,9 @@ class CameraConfig(tk.Tk):
     self._update_pixel_value()
 
     self.update()
+
+  def _draw_overlay(self) -> None:
+    """Method meant to be used by subclasses for drawing an overlay on top of
+    the image to display."""
+
+    ...

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -940,6 +940,8 @@ class CameraConfig(tk.Tk):
 
     self.log(logging.DEBUG, "The image canvas was resized")
 
+    self._draw_overlay()
+
     self._resize_img()
     self._display_img()
     self.update()

--- a/src/crappy/tool/camera_config/camera_config_boxes.py
+++ b/src/crappy/tool/camera_config/camera_config_boxes.py
@@ -88,7 +88,7 @@ class CameraConfigBoxes(CameraConfig):
     """This method is meant to simplify the customization of the action to
     perform when a patch is outside the image in subclasses."""
 
-    pass
+    ...
 
   def _draw_spots(self) -> None:
     """Simply draws every spot on top of the image."""

--- a/src/crappy/tool/camera_config/dic_ve_config.py
+++ b/src/crappy/tool/camera_config/dic_ve_config.py
@@ -150,17 +150,6 @@ class DICVEConfig(CameraConfigBoxes):
     # This box is not needed anymore
     self._select_box.reset()
 
-  def _on_img_resize(self, _: Optional[tk.Event] = None) -> None:
-    """Same as in the parent class except it also draws the patches on top of
-    the displayed image."""
-
-    self.log(logging.DEBUG, "The image canvas was resized")
-
-    self._draw_spots()
-    self._resize_img()
-    self._display_img()
-    self.update()
-
   def _draw_overlay(self) -> None:
     """Draws the detected spots to track on top of the last acquired image."""
 

--- a/src/crappy/tool/camera_config/dic_ve_config.py
+++ b/src/crappy/tool/camera_config/dic_ve_config.py
@@ -3,10 +3,6 @@
 from typing import Optional
 from tkinter.messagebox import showerror
 import tkinter as tk
-import numpy as np
-from io import BytesIO
-from pkg_resources import resource_string
-from time import sleep
 import logging
 from multiprocessing.queues import Queue
 
@@ -165,50 +161,10 @@ class DICVEConfig(CameraConfigBoxes):
     self._display_img()
     self.update()
 
-  def _update_img(self) -> None:
-    """Same as in the parent class except it also draws the patches on top of
-    the displayed image."""
+  def _draw_overlay(self) -> None:
+    """Draws the detected spots to track on top of the last acquired image."""
 
-    self.log(logging.DEBUG, "Updating the image")
-
-    ret = self._camera.get_image()
-
-    # If no frame could be grabbed from the camera
-    if ret is None:
-      # If it's the first call, generate error image to initialize the window
-      if not self._n_loops:
-        self.log(logging.WARNING, "Could not get an image from the camera, "
-                                  "displaying an error image instead")
-        ret = None, np.array(Image.open(BytesIO(resource_string(
-          'crappy', 'tool/data/no_image.png'))))
-      # Otherwise, just pass
-      else:
-        self.log(logging.DEBUG, "No image returned by the camera")
-        self.update()
-        sleep(0.001)
-        return
-
-    self._n_loops += 1
-    _, img = ret
-
-    if img.dtype != self.dtype:
-      self.dtype = img.dtype
-    if self.shape != img.shape:
-      self.shape = img.shape
-
-    self._cast_img(img)
     self._draw_spots()
-    self._resize_img()
-
-    self._calc_hist()
-    self._resize_hist()
-
-    self._display_img()
-    self._display_hist()
-
-    self._update_pixel_value()
-
-    self.update()
 
   def _handle_box_outside_img(self, box: Box) -> None:
     """If a patch is outside the image, warning the user and resetting the

--- a/src/crappy/tool/camera_config/dis_correl_config.py
+++ b/src/crappy/tool/camera_config/dis_correl_config.py
@@ -146,20 +146,6 @@ class DISCorrelConfig(CameraConfigBoxes):
 
     self._draw_correl_box = True
 
-  def _on_img_resize(self, _: Optional[tk.Event] = None) -> None:
-    """Same as in the parent class except it also draws the select box on top
-    of the displayed image."""
-
-    self.log(logging.DEBUG, "The image canvas was resized")
-
-    # Do not draw the correl box if the user is creating the select box
-    if self._draw_correl_box:
-      self._draw_box(self._correl_box)
-    self._draw_box(self._select_box)
-
-    self._resize_img()
-    self._display_img()
-    self.update()
   def _draw_overlay(self) -> None:
     """Draws the box to use for performing correlation on top of the last
     acquired image.

--- a/src/crappy/tool/camera_config/dis_correl_config.py
+++ b/src/crappy/tool/camera_config/dis_correl_config.py
@@ -108,14 +108,7 @@ class DISCorrelConfig(CameraConfigBoxes):
     """Simply saves the position of the user click, and disables the display of
     the current correl box."""
 
-    self.log(logging.DEBUG, "Starting the selection box")
-
-    # If the mouse is on the canvas but not on the image, do nothing
-    if not self._check_event_pos(event):
-      return
-
-    self._select_box.x_start, \
-        self._select_box.y_start = self._coord_to_pix(event.x, event.y)
+    super()._start_box(event)
 
     self._draw_correl_box = False
 

--- a/src/crappy/tool/camera_config/dis_correl_config.py
+++ b/src/crappy/tool/camera_config/dis_correl_config.py
@@ -3,10 +3,6 @@
 import tkinter as tk
 from tkinter.messagebox import showerror
 from typing import Optional
-import numpy as np
-from io import BytesIO
-from pkg_resources import resource_string
-from time import sleep
 import logging
 from multiprocessing.queues import Queue
 
@@ -164,54 +160,16 @@ class DISCorrelConfig(CameraConfigBoxes):
     self._resize_img()
     self._display_img()
     self.update()
+  def _draw_overlay(self) -> None:
+    """Draws the box to use for performing correlation on top of the last
+    acquired image.
 
-  def _update_img(self) -> None:
-    """Same as in the parent class except it also draws the select box on top
-    of the displayed image."""
+    Does not draw the correl box is the user is using the selection box.
+    """
 
-    self.log(logging.DEBUG, "Updating the image")
-
-    ret = self._camera.get_image()
-
-    # If no frame could be grabbed from the camera
-    if ret is None:
-      # If it's the first call, generate error image to initialize the window
-      if not self._n_loops:
-        self.log(logging.WARNING, "Could not get an image from the camera, "
-                                  "displaying an error image instead")
-        ret = None, np.array(Image.open(BytesIO(resource_string(
-          'crappy', 'tool/data/no_image.png'))))
-      # Otherwise, just pass
-      else:
-        self.log(logging.DEBUG, "No image returned by the camera")
-        self.update()
-        sleep(0.001)
-        return
-
-    self._n_loops += 1
-    _, img = ret
-
-    if img.dtype != self.dtype:
-      self.dtype = img.dtype
-    if self.shape != img.shape:
-      self.shape = img.shape
-
-    self._cast_img(img)
-    # Do not draw the correl box if the user is creating the select box
     if self._draw_correl_box:
       self._draw_box(self._correl_box)
     self._draw_box(self._select_box)
-    self._resize_img()
-
-    self._calc_hist()
-    self._resize_hist()
-
-    self._display_img()
-    self._display_hist()
-
-    self._update_pixel_value()
-
-    self.update()
 
   def _handle_box_outside_img(self, _: Box) -> None:
     """If the correl box is outside the image, it means that the image size has

--- a/src/crappy/tool/camera_config/video_extenso_config.py
+++ b/src/crappy/tool/camera_config/video_extenso_config.py
@@ -162,17 +162,6 @@ class VideoExtensoConfig(CameraConfigBoxes):
                f"Successfully saved L0 ! L0 x : {self._detector.spots.x_l0}, "
                f"L0 y : {self._detector.spots.y_l0}")
 
-  def _on_img_resize(self, _: Optional[tk.Event] = None) -> None:
-    """Same as in the parent class except it also draws the patches and the
-    select box on top of the displayed image."""
-
-    self.log(logging.DEBUG, "The image canvas was resized")
-
-    self._draw_box(self._select_box)
-    self._draw_spots()
-    self._resize_img()
-    self._display_img()
-    self.update()
   def _draw_overlay(self) -> None:
     """Draws the detected spots to track on top of the last acquired image.
 

--- a/src/crappy/tool/camera_config/video_extenso_config.py
+++ b/src/crappy/tool/camera_config/video_extenso_config.py
@@ -111,10 +111,7 @@ class VideoExtensoConfig(CameraConfigBoxes):
     """Compared with the parent class, creates an extra button for saving the
     original position of the spots."""
 
-    self._update_button = tk.Button(self._sets_frame, text="Apply Settings",
-                                    command=self._update_settings)
-    self._update_button.pack(expand=False, fill='none', ipadx=5, ipady=5,
-                             padx=5, pady=5, anchor='n', side='top')
+    super()._create_buttons()
 
     self._update_button = tk.Button(self._sets_frame, text="Save L0",
                                     command=self._save_l0)

--- a/src/crappy/tool/camera_config/video_extenso_config.py
+++ b/src/crappy/tool/camera_config/video_extenso_config.py
@@ -3,10 +3,6 @@
 import tkinter as tk
 from tkinter.messagebox import showerror
 from typing import Optional
-import numpy as np
-from io import BytesIO
-from pkg_resources import resource_string
-from time import sleep
 import logging
 from multiprocessing.queues import Queue
 
@@ -177,52 +173,14 @@ class VideoExtensoConfig(CameraConfigBoxes):
     self._resize_img()
     self._display_img()
     self.update()
+  def _draw_overlay(self) -> None:
+    """Draws the detected spots to track on top of the last acquired image.
 
-  def _update_img(self) -> None:
-    """Same as in the parent class except it also draws the patches and the
-    select box on top of the displayed image."""
+    Also draws the selection box if the user is currently drawing one.
+    """
 
-    self.log(logging.DEBUG, "Updating the image")
-
-    ret = self._camera.get_image()
-
-    # If no frame could be grabbed from the camera
-    if ret is None:
-      # If it's the first call, generate error image to initialize the window
-      if not self._n_loops:
-        self.log(logging.WARNING, "Could not get an image from the camera, "
-                                  "displaying an error image instead")
-        ret = None, np.array(Image.open(BytesIO(resource_string(
-          'crappy', 'tool/data/no_image.png'))))
-      # Otherwise, just pass
-      else:
-        self.log(logging.DEBUG, "No image returned by the camera")
-        self.update()
-        sleep(0.001)
-        return
-
-    self._n_loops += 1
-    _, img = ret
-
-    if img.dtype != self.dtype:
-      self.dtype = img.dtype
-    if self.shape != img.shape:
-      self.shape = img.shape
-
-    self._cast_img(img)
     self._draw_box(self._select_box)
     self._draw_spots()
-    self._resize_img()
-
-    self._calc_hist()
-    self._resize_hist()
-
-    self._display_img()
-    self._display_hist()
-
-    self._update_pixel_value()
-
-    self.update()
 
   def _handle_box_outside_img(self, _: Box) -> None:
     """If a patch is outside the image, it means that the image size has been


### PR DESCRIPTION
As detailed in #113, the camera configuration window currently displays repeatedly an error image in case the Camera object returning the images alternatively returns images or `None`. This behavior is not the intended one, as the error image should only be displayed once as the very first frame. In case `None` values are received later, the last acquired image should remain in the interface. 

This PR fixes #113. It also removes duplicate code in children of the camera configuration window class, by using ad-hoc helper functions re-defined by the children classes. As a side-effect, this refactoring propagates the fix of d6247ef0 to the children classes. Its propagation had been omitted, due to duplicates in code !