### PR TITLE
Fix color image recording

### DIFF
--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -226,13 +226,21 @@ class ImageSaver(CameraProcess):
     # Saving the image at the destination path using the chosen backend
     self.log(logging.DEBUG, "Saving image")
     if self._save_backend == 'sitk':
-      Sitk.WriteImage(Sitk.GetImageFromArray(self.img[:, :, ::-1],
-                                             isVector=True), path)
+      if len(self.img.shape) == 3:
+        Sitk.WriteImage(Sitk.GetImageFromArray(self.img[:, :, ::-1],
+                                               isVector=True), path)
+      else:
+        Sitk.WriteImage(Sitk.GetImageFromArray(self.img), path)
 
     elif self._save_backend == 'pil':
-      PIL.Image.fromarray(self.img[:, :, ::-1]).save(
-        path, exif={TAGS_INV[key]: val for key, val in self.metadata.items()
-                    if key in TAGS_INV})
+      if len(self.img.shape) == 3:
+        PIL.Image.fromarray(self.img[:, :, ::-1]).save(
+          path, exif={TAGS_INV[key]: val for key, val in self.metadata.items()
+                      if key in TAGS_INV})
+      else:
+        PIL.Image.fromarray(self.img).save(
+          path, exif={TAGS_INV[key]: val for key, val in self.metadata.items()
+                      if key in TAGS_INV})
 
     elif self._save_backend == 'cv2':
       cv2.imwrite(path, self.img)

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -229,13 +229,13 @@ class ImageSaver(CameraProcess):
       Sitk.WriteImage(Sitk.GetImageFromArray(self.img[:, :, ::-1],
                                              isVector=True), path)
 
-    elif self._save_backend == 'cv2':
-      cv2.imwrite(path, self.img)
-
     elif self._save_backend == 'pil':
       PIL.Image.fromarray(self.img[:, :, ::-1]).save(
         path, exif={TAGS_INV[key]: val for key, val in self.metadata.items()
                     if key in TAGS_INV})
+
+    elif self._save_backend == 'cv2':
+      cv2.imwrite(path, self.img)
 
     elif self._save_backend == 'npy':
       np.save(path, self.img)

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -226,7 +226,8 @@ class ImageSaver(CameraProcess):
     # Saving the image at the destination path using the chosen backend
     self.log(logging.DEBUG, "Saving image")
     if self._save_backend == 'sitk':
-      Sitk.WriteImage(Sitk.GetImageFromArray(self.img), path)
+      Sitk.WriteImage(Sitk.GetImageFromArray(self.img[:, :, ::-1],
+                                             isVector=True), path)
 
     elif self._save_backend == 'cv2':
       cv2.imwrite(path, self.img)

--- a/src/crappy/blocks/camera_processes/record.py
+++ b/src/crappy/blocks/camera_processes/record.py
@@ -232,7 +232,7 @@ class ImageSaver(CameraProcess):
       cv2.imwrite(path, self.img)
 
     elif self._save_backend == 'pil':
-      PIL.Image.fromarray(self.img).save(
+      PIL.Image.fromarray(self.img[:, :, ::-1]).save(
         path, exif={TAGS_INV[key]: val for key, val in self.metadata.items()
                     if key in TAGS_INV})
 


### PR DESCRIPTION
As detailed in #124, two out of the four backends were buggy when recording color images, namely Pillow and SimpleITK.

This PR addresses these two bugs using simple image operations and overlooked function call arguments.

Fixes #124 