### PR TITLE
fix: cast numpy types to Python types wherever needed

### DIFF
--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -172,8 +172,8 @@ class Displayer(CameraProcess):
     if self.img.dtype != np.uint8:
       self.log(logging.DEBUG, f"Casting displayed image from "
                               f"{self.img.dtype} to uint8")
-      if np.max(self.img) > 255:
-        factor = max(ceil(log2(np.max(self.img) + 1) - 8), 0)
+      if int(np.max(self.img)) > 255:
+        factor = max(ceil(log2(int(np.max(self.img)) + 1) - 8), 0)
         img = (self.img / 2 ** factor).astype(np.uint8)
       else:
         img = self.img.astype(np.uint8)

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -213,7 +213,8 @@ class GPUCorrelProcess(CameraProcess):
         self._res_history.append(res)
         self._res_history = self._res_history[-self._discard_ref - 1:]
 
-        if res > self._discard_limit * np.average(self._res_history[:-1]):
+        if (res > self._discard_limit *
+            float(np.average(self._res_history[:-1]))):
           self.log(logging.WARNING, "Residual too high, not sending "
                                     "values")
           return

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -138,10 +138,11 @@ class FakeMachine(Block):
 
     # Calculating the speed based on the command and the mode
     if self._mode == 'speed':
-      speed = np.sign(cmd) * np.min((self._max_speed, np.abs(cmd)))
+      speed = float(np.sign(cmd)) * float(np.min((self._max_speed,
+                                                  np.abs(cmd))))
     elif self._mode == 'position':
-      speed = np.sign(cmd - self._current_pos) * np.min(
-          (self._max_speed, np.abs(cmd - self._current_pos) / delta_t))
+      speed = float(np.sign(cmd - self._current_pos)) * float(np.min(
+          (self._max_speed, np.abs(cmd - self._current_pos) / delta_t)))
     else:
       raise ValueError(f'Invalid mode : {self._mode} !')
 

--- a/src/crappy/blocks/mean.py
+++ b/src/crappy/blocks/mean.py
@@ -112,7 +112,7 @@ class MeanBlock(Block):
     for label, values in data.items():
       if self._out_labels is None or label in self._out_labels:
         try:
-          to_send[label] = np.mean(values)
+          to_send[label] = float(np.mean(values))
         except (ValueError, TypeError):
           self.log(logging.WARNING, f"Cannot perform averaging on label "
                                     f"{label} with values: {values}")

--- a/src/crappy/camera/seek_thermal_pro.py
+++ b/src/crappy/camera/seek_thermal_pro.py
@@ -265,7 +265,8 @@ MODE=\\"0777\\\"" | sudo tee seek_thermal.rules > /dev/null 2>&1
     """
 
     for i, j in self._dead_pixels:
-      img[i, j] = np.median(img[max(0, i - 1): i + 2, max(0, j - 1): j + 2])
+      img[i, j] = float(np.median(img[max(0, i - 1): i + 2,
+                                      max(0, j - 1): j + 2]))
     return img
 
   def _write_data(self, request: int, data: bytes) -> int:

--- a/src/crappy/modifier/demux.py
+++ b/src/crappy/modifier/demux.py
@@ -86,24 +86,24 @@ class Demux(Modifier):
       # The data of a given label is on a same row
       if self._transpose:
         if self._mean:
-          data[label] = np.mean(data[self._stream_label][i, :])
+          data[label] = float(np.mean(data[self._stream_label][i, :]))
         else:
-          data[label] = data[self._stream_label][i, 0]
+          data[label] = float(data[self._stream_label][i, 0])
       # The data of a given label is on a same column
       else:
         if self._mean:
-          data[label] = np.mean(data[self._stream_label][:, i])
+          data[label] = float(np.mean(data[self._stream_label][:, i]))
         else:
-          data[label] = data[self._stream_label][0, i]
+          data[label] = float(data[self._stream_label][0, i])
 
     # Discarding the raw data
     del data[self._stream_label]
 
     # Keeping either the average or the first time value
     if self._mean:
-      data[self._time_label] = np.mean(data[self._time_label])
+      data[self._time_label] = float(np.mean(data[self._time_label]))
     else:
-      data[self._time_label] = np.squeeze(data[self._time_label])[0]
+      data[self._time_label] = float(np.squeeze(data[self._time_label])[0])
 
     self.log(logging.DEBUG, f"Sending {data}")
 

--- a/src/crappy/modifier/mean.py
+++ b/src/crappy/modifier/mean.py
@@ -54,7 +54,7 @@ class Mean(Modifier):
       # Once there's enough data in the buffer, calculating the average value
       if len(self._buf[label]) == self._n_points:
         try:
-          ret[label] = np.mean(self._buf[label])
+          ret[label] = float(np.mean(self._buf[label]))
         except TypeError:
           ret[label] = self._buf[label][-1]
 

--- a/src/crappy/modifier/median.py
+++ b/src/crappy/modifier/median.py
@@ -54,7 +54,7 @@ class Median(Modifier):
       # Once there's enough data in the buffer, calculating the median value
       if len(self._buf[label]) == self._n_points:
         try:
-          ret[label] = np.median(self._buf[label])
+          ret[label] = float(np.median(self._buf[label]))
         except TypeError:
           ret[label] = self._buf[label][-1]
 

--- a/src/crappy/modifier/moving_avg.py
+++ b/src/crappy/modifier/moving_avg.py
@@ -55,7 +55,7 @@ class MovingAvg(Modifier):
 
       # Calculating the average for each label
       try:
-        ret[label] = np.mean(self._buf[label])
+        ret[label] = float(np.mean(self._buf[label]))
       except TypeError:
         ret[label] = self._buf[label][-1]
 

--- a/src/crappy/modifier/moving_med.py
+++ b/src/crappy/modifier/moving_med.py
@@ -55,7 +55,7 @@ class MovingMed(Modifier):
 
       # Calculating the median for each label
       try:
-        ret[label] = np.median(self._buf[label])
+        ret[label] = float(np.median(self._buf[label]))
       except TypeError:
         ret[label] = self._buf[label][-1]
 

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -522,13 +522,13 @@ class CameraConfig(tk.Tk):
     self.log(logging.DEBUG, "Updating the value of the current pixel")
 
     try:
-      self._reticle_val.set(np.average(self._original_img[self._y_pos.get(),
-                                                          self._x_pos.get()]))
+      self._reticle_val.set(int(np.average(
+          self._original_img[self._y_pos.get(), self._x_pos.get()])))
     except IndexError:
       self._x_pos.set(0)
       self._y_pos.set(0)
-      self._reticle_val.set(np.average(self._original_img[self._y_pos.get(),
-                                                          self._x_pos.get()]))
+      self._reticle_val.set(int(np.average(
+          self._original_img[self._y_pos.get(), self._x_pos.get()])))
 
   def _coord_to_pix(self, x: int, y: int) -> Tuple[int, int]:
     """Converts the coordinates of the mouse in the GUI referential to
@@ -859,19 +859,20 @@ class CameraConfig(tk.Tk):
     # If the auto_range is set, adjusting the values to the range
     if self._auto_range.get():
       self.log(logging.DEBUG, "Applying auto range to the image")
-      self._low_thresh, self._high_thresh = np.percentile(img, (3, 97))
+      self._low_thresh, self._high_thresh = map(float,
+                                                np.percentile(img, (3, 97)))
       self._img = ((np.clip(img, self._low_thresh, self._high_thresh) -
                     self._low_thresh) * 255 /
                    (self._high_thresh - self._low_thresh)).astype('uint8')
 
       # The original image still needs to be saved as 8-bits
-      bit_depth = np.ceil(np.log2(np.max(img) + 1))
+      bit_depth = int(np.ceil(np.log2(int(np.max(img)) + 1)))
       self._original_img = (img / 2 ** (bit_depth - 8)).astype('uint8')
 
     # Or if the image is not already 8 bits, casting to 8 bits
     elif img.dtype != np.uint8:
       self.log(logging.DEBUG, "Casting the image to 8 bits")
-      bit_depth = np.ceil(np.log2(np.max(img) + 1))
+      bit_depth = int(np.ceil(np.log2(int(np.max(img)) + 1)))
       self._img = (img / 2 ** (bit_depth - 8)).astype('uint8')
       self._original_img = np.copy(self._img)
 
@@ -881,7 +882,7 @@ class CameraConfig(tk.Tk):
       self._original_img = np.copy(img)
 
     # Updating the information
-    self._nb_bits.set(int(np.ceil(np.log2(np.max(img) + 1))))
+    self._nb_bits.set(int(np.ceil(np.log2(int(np.max(img)) + 1))))
     self._max_pixel.set(int(np.max(img)))
     self._min_pixel.set(int(np.min(img)))
 

--- a/src/crappy/tool/image_processing/dic_ve.py
+++ b/src/crappy/tool/image_processing/dic_ve.py
@@ -307,7 +307,7 @@ class DICVETool:
       arr: This array contains the y values for the 3 points.
     """
 
-    return (arr[0] - arr[2]) / (2 * (arr[0] - 2 * arr[1] + arr[2]))
+    return float((arr[0] - arr[2]) / (2 * (arr[0] - 2 * arr[1] + arr[2])))
 
   @staticmethod
   def _cross_correlation(img0: np.ndarray,

--- a/src/crappy/tool/image_processing/dis_correl.py
+++ b/src/crappy/tool/image_processing/dis_correl.py
@@ -157,7 +157,7 @@ class DISCorrelTool:
 
     # These attributes will be used later
     self._base = [fields[:, :, :, i] for i in range(fields.shape[3])]
-    self._norm2 = [np.sum(base_field ** 2) for base_field in self._base]
+    self._norm2 = [float(np.sum(base_field ** 2)) for base_field in self._base]
 
   def get_data(self,
                img: np.ndarray,
@@ -192,12 +192,13 @@ class DISCorrelTool:
       self._dis_flow = self._dis.calc(self._img0, img, None)
 
     # Getting the values to calculate as floats
-    ret = [np.sum(vec * self._crop(self._dis_flow)) / n2 for vec, n2 in
+    ret = [float(np.sum(vec * self._crop(self._dis_flow))) / n2 for vec, n2 in
            zip(self._base, self._norm2)]
 
     # Adding the average residual value if requested
     if residuals:
-      ret.append(np.average(np.abs(get_res(self._img0, img, self._dis_flow))))
+      ret.append(float(np.average(np.abs(get_res(self._img0, img,
+                                                 self._dis_flow)))))
 
     return ret
 

--- a/src/crappy/tool/image_processing/video_extenso/video_extenso.py
+++ b/src/crappy/tool/image_processing/video_extenso/video_extenso.py
@@ -243,15 +243,15 @@ class VideoExtensoTool:
         x_top_1, x_bottom_1, y_left_1, y_right_1 = box_1.sorted()
         x_top_2, x_bottom_2, y_left_2, y_right_2 = box_2.sorted()
 
-        box_1.x_start = min(x_top_1 + 1, box_1.x_centroid - 2)
-        box_1.y_start = min(y_left_1 + 1, box_1.y_centroid - 2)
-        box_1.x_end = max(x_bottom_1 - 1, box_1.x_centroid + 2)
-        box_1.y_end = max(y_right_1 - 1, box_1.y_centroid + 2)
+        box_1.x_start = min(x_top_1 + 1, int(box_1.x_centroid - 2))
+        box_1.y_start = min(y_left_1 + 1, int(box_1.y_centroid - 2))
+        box_1.x_end = max(x_bottom_1 - 1, int(box_1.x_centroid + 2))
+        box_1.y_end = max(y_right_1 - 1, int(box_1.y_centroid + 2))
 
-        box_2.x_start = min(x_top_2 + 1, box_2.x_centroid - 2)
-        box_2.y_start = min(y_left_2 + 1, box_2.y_centroid - 2)
-        box_2.x_end = max(x_bottom_2 - 1, box_2.x_centroid + 2)
-        box_2.y_end = max(y_right_2 - 1, box_2.y_centroid + 2)
+        box_2.x_start = min(x_top_2 + 1, int(box_2.x_centroid - 2))
+        box_2.y_start = min(y_left_2 + 1, int(box_2.y_centroid - 2))
+        box_2.x_end = max(x_bottom_2 - 1, int(box_2.x_centroid + 2))
+        box_2.y_end = max(y_right_2 - 1, int(box_2.y_centroid + 2))
 
     if overlap:
       self._consecutive_overlaps += 1


### PR DESCRIPTION
As detailed in #125, starting from version 2.0.0, some numpy operations no longer return Python types and return numpy types instead. This is particularly bothersome when using `isinstance()` for example, or operations like `np.max(img) + 1` that would previously return up to 256 on uint8 images and would now return 0 instead of 256.

A quick and easy fix was simply to cast numpy operations that now return numpy types into `float` or `int`, so that the behavior is preserved compared to numpy<2.0.0. 

closes #125 