### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -21,13 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         # Run on all the supported Python versions
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # Run on all the supported platforms
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # Cannot run for Python 3.7 on macOS as it is no longer supported
-        exclude:
-          - os: macos-latest
-            python-version: 3.7
 
     steps:
     # Checkout the repository

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ for materials testing.
 Requirements
 ------------
 
-CRAPPY can run with Python 3.7 to 3.10, and has been tested on Windows, Linux, 
+CRAPPY can run with Python 3.9 to 3.13, and has been tested on Windows, Linux, 
 Raspberry Pi and macOS. It can probably run on other operating systems 
 supporting the required Python versions. 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,7 +21,7 @@ was not tested.
   We develop Crappy on recent OS versions, and no particular effort is made to
   ensure compatibility with older OS versions.
 
-Crappy requires **Python 3.6 or later**, as well as the following module :
+Crappy requires **Python 3.9 or later**, as well as the following module :
 
 - `numpy <https://numpy.org/>`_ (1.21.0 or higher)
 
@@ -59,7 +59,7 @@ e.g. :shell:`Python 3.9.7`.
   all ! In this case, the given command will display an error message.
 
 If the current version of Python is not compatible with Crappy (requires Python
->=3.6), or if Python is not installed, you will first need to **install a**
+>=3.9), or if Python is not installed, you will first need to **install a**
 **compatible version of Python**. The precise installation steps for each OS
 are beyond the scope of this documentation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Command and Real-time Acquisition in Parallelized Python"
 license = {file = "LICENSE"}
 keywords = ["control", "command", "acquisition", "multiprocessing"]
 dependencies = ["numpy"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [{name = "LaMcube", email = "antoine.weisrock1@centralelille.fr"}]
 maintainers = [{name = "Antoine Weisrock", email = "antoine.weisrock@gmail.com"}]
 classifiers = [
@@ -19,12 +19,11 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Embedded Systems"


### PR DESCRIPTION
The supported versions of Crappy haven't been updated for a while. In a separate branch, features of Python 3.8 and 3.9 are being added to the code base. This PR simply updates the lower and higher supported Python versions wherever needed. Related to #63.