### PR TITLE
Include new features from Python 3.8 and 3.9

### DIFF
--- a/examples/blocks/synchronizer.py
+++ b/examples/blocks/synchronizer.py
@@ -28,7 +28,7 @@ stop it earlier, but it is not a clean way to stop Crappy.
 """
 
 import crappy
-from typing import Tuple, Dict, Optional
+from typing import Optional
 from time import sleep
 import random
 
@@ -43,8 +43,8 @@ class RandomPath(crappy.blocks.generator_path.meta_path.Path):
   """
 
   def __init__(self,
-               time_range: Tuple[float, float],
-               value_range: Tuple[float, float]) -> None:
+               time_range: tuple[float, float],
+               value_range: tuple[float, float]) -> None:
     """Sets the arguments and initializes the parent class.
 
     Args:
@@ -55,10 +55,10 @@ class RandomPath(crappy.blocks.generator_path.meta_path.Path):
 
     super().__init__()
 
-    self._time_range: Tuple[float, float] = time_range
-    self._value_range: Tuple[float, float] = value_range
+    self._time_range: tuple[float, float] = time_range
+    self._value_range: tuple[float, float] = value_range
 
-  def get_cmd(self, data: Dict[str, list]) -> Optional[float]:
+  def get_cmd(self, data: dict[str, list]) -> Optional[float]:
     """Returns a randomly generated value after sleeping a random number of
     seconds."""
 

--- a/examples/custom_objects/custom_block.py
+++ b/examples/custom_objects/custom_block.py
@@ -27,7 +27,8 @@ clean way to stop Crappy.
 """
 
 import crappy
-from typing import Optional, Iterable
+from typing import Optional
+from collections.abc import Iterable
 import logging
 from time import sleep, time
 

--- a/examples/custom_objects/custom_camera/custom_camera_basic.py
+++ b/examples/custom_objects/custom_camera/custom_camera_basic.py
@@ -29,7 +29,6 @@ but it is not a clean way to stop Crappy.
 import crappy
 import numpy as np
 import numpy.random as rd
-from typing import Tuple
 from time import time
 
 
@@ -76,7 +75,7 @@ class CustomCam(crappy.camera.Camera):
     # Here the Camera does not include settings though
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """This method must return the current timestamp as well as an acquired
     image.
 

--- a/examples/custom_objects/custom_camera/custom_camera_hardware_trigger.py
+++ b/examples/custom_objects/custom_camera/custom_camera_hardware_trigger.py
@@ -42,7 +42,6 @@ CTRL+C, but it is not a clean way to stop Crappy.
 import crappy
 import numpy as np
 import numpy.random as rd
-from typing import Tuple
 from time import time, sleep
 
 
@@ -100,7 +99,7 @@ class CustomCam(crappy.camera.Camera):
     # This line is mandatory here for first applying the trigger setting
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Compared to the one in custom_camera_basic.py, this method returns the
     same images but with a delay if in Hardware trigger mode.
 

--- a/examples/custom_objects/custom_camera/custom_camera_metadata.py
+++ b/examples/custom_objects/custom_camera/custom_camera_metadata.py
@@ -34,7 +34,7 @@ the metadata returned in the get_image method was correctly saved.
 import crappy
 import numpy as np
 import numpy.random as rd
-from typing import Tuple, Dict, Any
+from typing import Any
 from time import time, strftime, gmtime
 
 
@@ -69,7 +69,7 @@ class CustomCam(crappy.camera.Camera):
     # Here the Camera does not include settings though
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[Dict[str, Any], np.ndarray]:
+  def get_image(self) -> tuple[dict[str, Any], np.ndarray]:
     """Compared to the custom_camera_basic.py example, this method returns a
     complete dictionary of metadata instead of just a timestamp.
 

--- a/examples/custom_objects/custom_camera/custom_camera_settings.py
+++ b/examples/custom_objects/custom_camera/custom_camera_settings.py
@@ -34,7 +34,6 @@ Crappy.
 import crappy
 import numpy as np
 import numpy.random as rd
-from typing import Tuple
 from time import time
 
 
@@ -109,7 +108,7 @@ class CustomCam(crappy.camera.Camera):
     # This line is mandatory here for first applying the instantiated settings
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """This method is an extension of the custom_camera_basic.py one.
 
     Instead of just generating the random image always in a same way, it is

--- a/examples/custom_objects/custom_camera/custom_camera_software_roi.py
+++ b/examples/custom_objects/custom_camera/custom_camera_software_roi.py
@@ -33,7 +33,6 @@ Crappy.
 
 import crappy
 import numpy as np
-from typing import Tuple
 from time import time
 
 
@@ -83,7 +82,7 @@ class CustomCam(crappy.camera.Camera):
     # This line is mandatory here for first applying the parameters of the ROI
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Compared to the one in custom_camera_basic.py, this method returns the
     static image cropped by the selected software ROI.
 

--- a/examples/custom_objects/custom_camera_block.py
+++ b/examples/custom_objects/custom_camera_block.py
@@ -34,7 +34,7 @@ CTRL+C to stop Crappy, but it is not a clean way to do it.
 import crappy
 import cv2
 import numpy as np
-from typing import Optional, Callable, Tuple, Union
+from typing import Optional, Callable, Union
 from pathlib import Path
 
 
@@ -226,7 +226,7 @@ class CustomCameraBlock(crappy.blocks.Camera):
                save_backend: Optional[str] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
-               img_shape: Optional[Tuple[int, int]] = None,
+               img_shape: Optional[tuple[int, int]] = None,
                img_dtype: Optional[str] = None,
                scale_factor: float = 1.2,
                min_neighbors: int = 3,

--- a/examples/custom_objects/custom_camera_block.py
+++ b/examples/custom_objects/custom_camera_block.py
@@ -34,7 +34,8 @@ CTRL+C to stop Crappy, but it is not a clean way to do it.
 import crappy
 import cv2
 import numpy as np
-from typing import Optional, Callable, Union
+from typing import Optional, Union
+from collections.abc import Callable
 from pathlib import Path
 
 

--- a/examples/custom_objects/custom_camera_block.py
+++ b/examples/custom_objects/custom_camera_block.py
@@ -92,7 +92,7 @@ class Ellipse(crappy.tool.camera_config.Overlay):
     cv2.ellipse(img,
                 (self._center_x, self._center_y),
                 (self._x_axis, self._y_axis),
-                0, 0, 360, 0, thickness)
+                0., 0., 360., (0.,), thickness)
 
 
 class CustomCameraProcess(crappy.blocks.camera_processes.CameraProcess):

--- a/examples/custom_objects/custom_generator_path.py
+++ b/examples/custom_objects/custom_generator_path.py
@@ -26,7 +26,7 @@ clean way to stop Crappy.
 
 import crappy
 from crappy.blocks.generator_path.meta_path import Path, ConditionType
-from typing import Optional, Union, Dict
+from typing import Optional, Union
 from math import pi, sin, copysign
 from time import time
 
@@ -74,7 +74,7 @@ class CustomPath(Path):
     self._amplitude = amplitude / 2
     self._offset = offset
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """This method is the one that generates and returns the value to output
     for the Generator Block.
 

--- a/examples/custom_objects/custom_inout/custom_inout_basic_in.py
+++ b/examples/custom_objects/custom_inout/custom_inout_basic_in.py
@@ -29,7 +29,7 @@ Crappy.
 """
 
 import crappy
-from typing import Tuple, Optional
+from typing import Optional
 from time import time
 
 
@@ -66,7 +66,7 @@ class CustomInOut(crappy.inout.InOut):
 
     ...
 
-  def get_data(self) -> Tuple[float, int]:
+  def get_data(self) -> tuple[float, int]:
     """This method is used for acquiring data from the hardware.
 
     Here, it simply updates the loop counter and returns its value along with a

--- a/examples/custom_objects/custom_inout/custom_inout_basic_inout.py
+++ b/examples/custom_objects/custom_inout/custom_inout_basic_inout.py
@@ -28,7 +28,7 @@ CTRL+C to stop it earlier, but it is not a clean way to stop Crappy.
 """
 
 import crappy
-from typing import Dict, Optional
+from typing import Optional
 from time import time
 
 
@@ -64,7 +64,7 @@ class CustomInOut(crappy.inout.InOut):
 
     ...
 
-  def get_data(self) -> Dict[str, float]:
+  def get_data(self) -> dict[str, float]:
     """This method is used for acquiring data from the hardware.
 
     Here, it returns the current timestamp as well as the value of the _buffer

--- a/examples/custom_objects/custom_inout/custom_inout_make_zero.py
+++ b/examples/custom_objects/custom_inout/custom_inout_make_zero.py
@@ -31,7 +31,7 @@ way to stop Crappy.
 
 import crappy
 from random import random
-from typing import Tuple, Optional
+from typing import Optional
 from time import time
 
 
@@ -67,7 +67,7 @@ class CustomInOut(crappy.inout.InOut):
 
     ...
 
-  def get_data(self) -> Tuple[float, float]:
+  def get_data(self) -> tuple[float, float]:
     """This method is used for acquiring data from the hardware.
 
     Here, it returns the current timestamp and a random value in the interval

--- a/examples/custom_objects/custom_inout/custom_inout_streamer.py
+++ b/examples/custom_objects/custom_inout/custom_inout_streamer.py
@@ -28,7 +28,6 @@ hit CTRL+C, but it is not a clean way to stop Crappy.
 import crappy
 import numpy as np
 import numpy.random as rd
-from typing import Tuple
 from time import time
 
 
@@ -70,7 +69,7 @@ class CustomInOut(crappy.inout.InOut):
 
     ...
 
-  def get_stream(self) -> Tuple[np.ndarray, np.ndarray]:
+  def get_stream(self) -> tuple[np.ndarray, np.ndarray]:
     """This method acquires the stream data and returns it in one array
     containing the time information and another array containing the data.
 

--- a/examples/custom_objects/custom_modifier.py
+++ b/examples/custom_objects/custom_modifier.py
@@ -26,8 +26,11 @@ a clean way to stop Crappy.
 """
 
 import crappy
-from typing import Any, Iterable, Optional
+from typing import Optional, TypeVar
+from collections.abc import Iterable
 from math import sqrt
+
+T = TypeVar('T')
 
 
 class CustomModifier(crappy.modifier.Modifier):
@@ -73,7 +76,7 @@ class CustomModifier(crappy.modifier.Modifier):
     self._square_sum = 0
     self._nb_samples = 0
 
-  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+  def __call__(self, data: dict[str, T]) -> dict[str, T]:
     """This method is the one that transforms the received data and returns the
     modified version.
 

--- a/examples/custom_objects/custom_modifier.py
+++ b/examples/custom_objects/custom_modifier.py
@@ -26,7 +26,7 @@ a clean way to stop Crappy.
 """
 
 import crappy
-from typing import Dict, Any, Iterable, Optional
+from typing import Any, Iterable, Optional
 from math import sqrt
 
 
@@ -73,7 +73,7 @@ class CustomModifier(crappy.modifier.Modifier):
     self._square_sum = 0
     self._nb_samples = 0
 
-  def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
     """This method is the one that transforms the received data and returns the
     modified version.
 

--- a/src/crappy/actuator/__init__.py
+++ b/src/crappy/actuator/__init__.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from typing import Dict, Type
-
 from .adafruit_dc_motor_hat import DCMotorHat
 from .fake_dc_motor import FakeDCMotor
 from .fake_stepper_motor import FakeStepperMotor
@@ -18,4 +16,4 @@ from .ft232h import DCMotorHatFT232H
 from .meta_actuator import MetaActuator, Actuator
 
 from ._deprecated import deprecated_actuators
-actuator_dict: Dict[str, Type[Actuator]] = MetaActuator.classes
+actuator_dict: dict[str, type[Actuator]] = MetaActuator.classes

--- a/src/crappy/actuator/adafruit_dc_motor_hat.py
+++ b/src/crappy/actuator/adafruit_dc_motor_hat.py
@@ -2,7 +2,7 @@
 
 from struct import pack_into
 from time import sleep
-from typing import Union, Tuple
+from typing import Union, Tuple, Literal
 import logging
 from  warnings import warn
 
@@ -68,7 +68,7 @@ class DCMotorHat(Actuator):
   """
 
   def __init__(self,
-               backend: str,
+               backend: Literal['Pi4', 'blinka'],
                device_address: int = 0x60,
                i2c_port: int = 1) -> None:
     """Checks the validity of the arguments.

--- a/src/crappy/actuator/adafruit_dc_motor_hat.py
+++ b/src/crappy/actuator/adafruit_dc_motor_hat.py
@@ -2,7 +2,7 @@
 
 from struct import pack_into
 from time import sleep
-from typing import Union, Tuple, Literal
+from typing import Union, Literal
 import logging
 from  warnings import warn
 
@@ -142,7 +142,7 @@ class DCMotorHat(Actuator):
       for i in range(1, 5):
         self._write_i2c(motor_hat_ctrl[i], motor_hat_0xFF)
 
-  def set_speed(self, cmd: Tuple[int, float]) -> None:
+  def set_speed(self, cmd: tuple[int, float]) -> None:
     """Sets the desired voltage on the selected motor.
 
     The provided voltage should be between `-12` and `12V` which are the limits

--- a/src/crappy/actuator/ft232h/adafruit_dc_motor_hat.py
+++ b/src/crappy/actuator/ft232h/adafruit_dc_motor_hat.py
@@ -2,7 +2,7 @@
 
 from struct import pack_into
 from time import sleep
-from typing import Union, Optional, Tuple
+from typing import Union, Optional
 import logging
 from warnings import warn
 
@@ -114,7 +114,7 @@ class DCMotorHatFT232H(Actuator):
     for i in range(1, 5):
       self._write_i2c(motor_hat_ctrl[i], motor_hat_0xFF)
 
-  def set_speed(self, cmd: Tuple[int, float]) -> None:
+  def set_speed(self, cmd: tuple[int, float]) -> None:
     """Sets the desired voltage on the selected motor.
 
     The provided voltage should be between `-12` and `12V` which are the limits

--- a/src/crappy/actuator/jvl_mac_140.py
+++ b/src/crappy/actuator/jvl_mac_140.py
@@ -1,7 +1,7 @@
 ﻿# coding: utf-8
 
 from struct import pack, unpack
-from typing import Optional, Tuple
+from typing import Optional
 from time import sleep
 import logging
 
@@ -201,8 +201,8 @@ class JVLMac140(Actuator):
       pass
 
   def _make_cmd(self,
-                values: Tuple[int, int, int, int],
-                encodings: Tuple[str, str, str, str],
+                values: tuple[int, int, int, int],
+                encodings: tuple[str, str, str, str],
                 last_cmd: bool) -> bytes:
     """Builds a command to send to the servomotor, from the given arguments.
 

--- a/src/crappy/actuator/kollmorgen_servostar_300.py
+++ b/src/crappy/actuator/kollmorgen_servostar_300.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Union, Optional
+from typing import Union, Optional, Literal
 import logging
 
 from .meta_actuator import Actuator
@@ -27,7 +27,7 @@ class ServoStar300(Actuator):
   def __init__(self,
                port: str,
                baudrate: int = 38400,
-               mode: str = "serial") -> None:
+               mode: Literal['serial', 'analog'] = "serial") -> None:
     """Sets the instance attributes and initializes the parent class.
 
     Args:

--- a/src/crappy/actuator/oriental_ard_k.py
+++ b/src/crappy/actuator/oriental_ard_k.py
@@ -111,8 +111,7 @@ class OrientalARDK(Actuator):
       return
 
     # Stopping the motor if the direction changed
-    dir_chg = self._prev_set_speed * sign < 0
-    if dir_chg:
+    if self._prev_set_speed * sign < 0:
       self.stop()
 
     # Writing the target speed value

--- a/src/crappy/actuator/phidgets_stepper4a.py
+++ b/src/crappy/actuator/phidgets_stepper4a.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 from pathlib import Path
 from platform import system
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from .meta_actuator import Actuator
 from .._global import OptionalModule
@@ -44,7 +44,7 @@ class Phidget4AStepper(Actuator):
                remote: bool = False,
                absolute_mode: bool = False,
                reference_pos: float = 0,
-               switch_ports: Tuple[int, ...] = tuple(),
+               switch_ports: tuple[int, ...] = tuple(),
                save_last_pos: bool = False,
                save_pos_folder: Optional[Union[str, Path]] = None) -> None:
     """Sets the args and initializes the parent class.

--- a/src/crappy/actuator/pololu_tic.py
+++ b/src/crappy/actuator/pololu_tic.py
@@ -3,7 +3,7 @@
 from subprocess import check_output
 from threading import Thread, RLock
 from time import sleep
-from typing import Union, Dict, Optional
+from typing import Union, Dict, Optional, Literal
 import logging
 
 from .meta_actuator import Actuator
@@ -238,6 +238,11 @@ Tic_pin_modes = {'Default': 0,
 Tic_pin_polarity = {'Active low': 0,
                     'Active high': 1}
 
+pin_type = Literal['SCL', 'SDA', 'TX', 'RX', 'RC']
+pin_mode_type = Literal['Default', 'Kill switch', 'Limit switch forward', 
+                        'Limit switch reverse']
+pin_polarity_type = Literal['Active high', 'Active low']
+
 
 class FindSerialNumber:
   """A class used for finding USB devices matching a given serial number, using
@@ -277,17 +282,20 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
   def __init__(self,
                steps_per_mm: float,
                current_limit: float,
-               step_mode: Union[int, str] = 8,
+               step_mode: Literal[1, 2, 4, 8, 16, 32,
+                                  64, 128, 256, '2_100p'] = 8,
                max_accel: float = 20,
                t_shutoff: float = 0,
                config_file: Optional[str] = None,
                serial_number: Optional[str] = None,
-               model: Optional[str] = None,
+               model: Optional[Literal['T825', 'T824', 'T500', 
+                               'N825', 'T249', '36v4']] = None,
                reset_command_timeout: bool = True,
-               backend: str = 'USB',
+               backend: Literal['USB', 'ticcmd'] = 'USB',
                unrestricted_current_limit: bool = False,
-               pin_function: Optional[Dict[str, str]] = None,
-               pin_polarity: Optional[Dict[str, str]] = None) -> None:
+               pin_function: Optional[Dict[pin_type, pin_mode_type]] = None,
+               pin_polarity: Optional[Dict[pin_type, 
+                                           pin_polarity_type]] = None) -> None:
     """Checks args validity, finds the right device, reads the current limit
     tables.
 
@@ -496,6 +504,7 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
       devices.pop()  # Removing the '' element at the end of devices
       devices = [string.split(',') for string in devices]
       if model is not None:
+        model: str
         if serial_number is not None:
           devices = [dev for dev in devices if dev[0] == serial_number and
                      model in dev[1]]
@@ -1010,7 +1019,7 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
           byteorder='little',
           signed=False) / 10000)
 
-  def _set_pin_function(self, pin_func: Dict[str, str]) -> None:
+  def _set_pin_function(self, pin_func: Dict[pin_type, pin_mode_type]) -> None:
     """Sets the pin function bitfields.
 
     Sends a command for setting each pin separately, and three commands for
@@ -1079,7 +1088,8 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
                         value=limit_reverse_map,
                         index=Tic_settings['Limit_switch_reverse_map'])
 
-  def _set_pin_polarity(self, pin_pol: Dict[str, str]) -> None:
+  def _set_pin_polarity(self, pin_pol: Dict[pin_type,
+                                            pin_polarity_type]) -> None:
     """Sets the switch polarity bitfield."""
 
     self.log(logging.INFO, "Setting the pin polarities")

--- a/src/crappy/actuator/pololu_tic.py
+++ b/src/crappy/actuator/pololu_tic.py
@@ -3,7 +3,7 @@
 from subprocess import check_output
 from threading import Thread, RLock
 from time import sleep
-from typing import Union, Dict, Optional, Literal
+from typing import Union, Optional, Literal
 import logging
 
 from .meta_actuator import Actuator
@@ -293,8 +293,8 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
                reset_command_timeout: bool = True,
                backend: Literal['USB', 'ticcmd'] = 'USB',
                unrestricted_current_limit: bool = False,
-               pin_function: Optional[Dict[pin_type, pin_mode_type]] = None,
-               pin_polarity: Optional[Dict[pin_type, 
+               pin_function: Optional[dict[pin_type, pin_mode_type]] = None,
+               pin_polarity: Optional[dict[pin_type,
                                            pin_polarity_type]] = None) -> None:
     """Checks args validity, finds the right device, reads the current limit
     tables.
@@ -1019,7 +1019,7 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
           byteorder='little',
           signed=False) / 10000)
 
-  def _set_pin_function(self, pin_func: Dict[pin_type, pin_mode_type]) -> None:
+  def _set_pin_function(self, pin_func: dict[pin_type, pin_mode_type]) -> None:
     """Sets the pin function bitfields.
 
     Sends a command for setting each pin separately, and three commands for
@@ -1088,7 +1088,7 @@ MODE=\\"0666\\\"" | sudo tee pololu.rules > /dev/null 2>&1
                         value=limit_reverse_map,
                         index=Tic_settings['Limit_switch_reverse_map'])
 
-  def _set_pin_polarity(self, pin_pol: Dict[pin_type,
+  def _set_pin_polarity(self, pin_pol: dict[pin_type,
                                             pin_polarity_type]) -> None:
     """Sets the switch polarity bitfield."""
 

--- a/src/crappy/blocks/auto_drive_video_extenso.py
+++ b/src/crappy/blocks/auto_drive_video_extenso.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Literal
 import logging
 
 from .meta_block import Block
@@ -30,7 +30,7 @@ class AutoDriveVideoExtenso(Block):
   def __init__(self,
                actuator: Dict[str, Any],
                gain: float = 2000,
-               direction: str = 'Y-',
+               direction: Literal['X-', 'X+', 'Y-', 'Y+'] = 'Y-',
                pixel_range: int = 2048,
                max_speed: float = 200000,
                ft232h_ser_num: Optional[str] = None,

--- a/src/crappy/blocks/auto_drive_video_extenso.py
+++ b/src/crappy/blocks/auto_drive_video_extenso.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Dict, Any, Optional, Literal
+from typing import Any, Optional, Literal
 import logging
 
 from .meta_block import Block
@@ -28,7 +28,7 @@ class AutoDriveVideoExtenso(Block):
   """
 
   def __init__(self,
-               actuator: Dict[str, Any],
+               actuator: dict[str, Any],
                gain: float = 2000,
                direction: Literal['X-', 'X+', 'Y-', 'Y+'] = 'Y-',
                pixel_range: int = 2048,

--- a/src/crappy/blocks/auto_drive_video_extenso.py
+++ b/src/crappy/blocks/auto_drive_video_extenso.py
@@ -128,8 +128,7 @@ class AutoDriveVideoExtenso(Block):
     the :class:`~crappy.actuator.Actuator` speed accordingly."""
 
     # Receiving the latest data
-    data = self.recv_last_data(fill_missing=False)
-    if not data:
+    if not (data := self.recv_last_data(fill_missing=False)):
       return
 
     # Extracting the coordinates of the spots

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -586,7 +586,7 @@ class Camera(Block):
     # This is done with all the Locks acquired to avoid any conflict
     with self._save_lock, self._disp_lock, self._proc_lock:
       self.log(logging.DEBUG, f"Writing metadata to shared dict: {metadata}")
-      self._metadata |= metadata
+      self._metadata.update(metadata)
       self.log(logging.DEBUG, "Writing image to shared array")
       np.copyto(self._img, img)
 

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Callable, Union, Optional, Tuple
+from typing import Callable, Union, Optional, Tuple, Literal
 from pathlib import Path
 import numpy as np
 from time import time, sleep, strftime, gmtime
@@ -63,7 +63,7 @@ class Camera(Block):
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                config: bool = True,
                display_images: bool = False,
-               displayer_backend: Optional[str] = None,
+               displayer_backend: Optional[Literal['cv2', 'mpl']] = None,
                displayer_framerate: float = 5,
                software_trig_label: Optional[str] = None,
                display_freq: bool = False,
@@ -73,7 +73,8 @@ class Camera(Block):
                img_extension: str = "tiff",
                save_folder: Optional[Union[str, Path]] = None,
                save_period: int = 1,
-               save_backend: Optional[str] = None,
+               save_backend: Optional[Literal['sitk', 'pil',
+                                              'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
                img_shape: Optional[Union[Tuple[int, int],

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -586,7 +586,7 @@ class Camera(Block):
     # This is done with all the Locks acquired to avoid any conflict
     with self._save_lock, self._disp_lock, self._proc_lock:
       self.log(logging.DEBUG, f"Writing metadata to shared dict: {metadata}")
-      self._metadata.update(metadata)
+      self._metadata |= metadata
       self.log(logging.DEBUG, "Writing image to shared array")
       np.copyto(self._img, img)
 

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Callable, Union, Optional, Literal
+from typing import Union, Optional, Literal
+from collections.abc import Callable
 from pathlib import Path
 import numpy as np
 from time import time, sleep, strftime, gmtime

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Callable, Union, Optional, Tuple, Literal
+from typing import Callable, Union, Optional, Literal
 from pathlib import Path
 import numpy as np
 from time import time, sleep, strftime, gmtime
@@ -77,8 +77,8 @@ class Camera(Block):
                                               'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
-               img_shape: Optional[Union[Tuple[int, int],
-                                         Tuple[int, int, int]]] = None,
+               img_shape: Optional[Union[tuple[int, int],
+                                         tuple[int, int, int]]] = None,
                img_dtype: Optional[str] = None,
                **kwargs) -> None:
     """Sets the arguments and initializes the parent class.

--- a/src/crappy/blocks/camera.py
+++ b/src/crappy/blocks/camera.py
@@ -562,8 +562,7 @@ class Camera(Block):
         self._camera.Eyy = data['Eyy(%)']
 
     # Grabbing the frame from the Camera object
-    ret = self._camera.get_image()
-    if ret is None:
+    if (ret := self._camera.get_image()) is None:
       return
     metadata, img = ret
  

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -8,7 +8,7 @@ from multiprocessing.connection import Connection
 from multiprocessing.queues import Queue
 from threading import BrokenBarrierError
 import numpy as np
-from typing import Optional, Tuple, List, Union, Dict, Any, Iterable
+from typing import Optional, Union, Any, Iterable
 import logging
 import logging.handlers
 from select import select
@@ -66,10 +66,10 @@ class CameraProcess(Process):
     self._lock: Optional[RLock] = None
     self._cam_barrier: Optional[Barrier] = None
     self._stop_event: Optional[Event] = None
-    self._shape: Optional[Tuple[int, int]] = None
+    self._shape: Optional[tuple[int, int]] = None
     self._to_draw_conn: Optional[Connection] = None
-    self._outputs: List[Link] = list()
-    self._labels: List[str] = list()
+    self._outputs: list[Link] = list()
+    self._labels: list[str] = list()
     self.img: Optional[np.ndarray] = None
     self._dtype = None
     self.metadata = {'ImageUniqueID': None}
@@ -87,11 +87,11 @@ class CameraProcess(Process):
                  lock: RLock,
                  barrier: Barrier,
                  event: Event,
-                 shape: Union[Tuple[int, int], Tuple[int, int, int]],
+                 shape: Union[tuple[int, int], tuple[int, int, int]],
                  dtype,
                  to_draw_conn: Optional[Connection],
-                 outputs: List[Link],
-                 labels: Optional[List[str]],
+                 outputs: list[Link],
+                 labels: Optional[list[str]],
                  log_queue: Queue,
                  log_level: Optional[int] = 20,
                  display_freq: bool = False) -> None:
@@ -268,7 +268,7 @@ class CameraProcess(Process):
 
     ...
 
-  def send(self, data: Optional[Union[Dict[str, Any],
+  def send(self, data: Optional[Union[dict[str, Any],
                                       Iterable[Any]]]) -> None:
     """This method allows sending data to downstream Blocks.
 

--- a/src/crappy/blocks/camera_processes/camera_process.py
+++ b/src/crappy/blocks/camera_processes/camera_process.py
@@ -8,7 +8,8 @@ from multiprocessing.connection import Connection
 from multiprocessing.queues import Queue
 from threading import BrokenBarrierError
 import numpy as np
-from typing import Optional, Union, Any, Iterable
+from typing import Optional, Union, Any
+from collections.abc import Iterable
 import logging
 import logging.handlers
 from select import select

--- a/src/crappy/blocks/camera_processes/dic_ve.py
+++ b/src/crappy/blocks/camera_processes/dic_ve.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional
+from typing import Optional, Literal
 import numpy as np
 import logging
 import logging.handlers
@@ -29,7 +29,8 @@ class DICVEProcess(CameraProcess):
 
   def __init__(self,
                patches: SpotsBoxes,
-               method: str = 'Disflow',
+               method: Literal['Disflow', 'Lucas Kanade',
+                               'Pixel precision', 'Parabola'] = 'Disflow',
                alpha: float = 3,
                delta: float = 1,
                gamma: float = 0,

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, List, Union
+from typing import Optional, Union
 import logging
 import logging.handlers
 
@@ -28,7 +28,7 @@ class DISCorrelProcess(CameraProcess):
 
   def __init__(self,
                patch: Box,
-               fields: Optional[List[Union[str, np.ndarray]]] = None,
+               fields: Optional[list[Union[str, np.ndarray]]] = None,
                alpha: float = 3,
                delta: float = 1,
                gamma: float = 0,

--- a/src/crappy/blocks/camera_processes/dis_correl.py
+++ b/src/crappy/blocks/camera_processes/dis_correl.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, Union
+from typing import Optional, Union, Literal
 import logging
 import logging.handlers
 
@@ -28,7 +28,9 @@ class DISCorrelProcess(CameraProcess):
 
   def __init__(self,
                patch: Box,
-               fields: Optional[list[Union[str, np.ndarray]]] = None,
+               fields: Optional[list[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+                                                   'exy', 'eyx', 'exy2', 'z'],
+                                           np.ndarray]]] = None,
                alpha: float = 3,
                delta: float = 1,
                gamma: float = 0,

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -172,8 +172,8 @@ class Displayer(CameraProcess):
     if self.img.dtype != np.uint8:
       self.log(logging.DEBUG, f"Casting displayed image from "
                               f"{self.img.dtype} to uint8")
-      if int(np.max(self.img)) > 255:
-        factor = max(ceil(log2(int(np.max(self.img)) + 1) - 8), 0)
+      if max_pix := int(np.max(self.img)) > 255:
+        factor = max(ceil(log2(max_pix + 1) - 8), 0)
         img = (self.img / 2 ** factor).astype(np.uint8)
       else:
         img = self.img.astype(np.uint8)

--- a/src/crappy/blocks/camera_processes/display.py
+++ b/src/crappy/blocks/camera_processes/display.py
@@ -3,7 +3,8 @@
 from threading import Thread
 from math import log2, ceil
 import numpy as np
-from typing import Optional, Iterable
+from typing import Optional
+from collections.abc import Iterable
 from time import time, sleep
 import logging
 import logging.handlers

--- a/src/crappy/blocks/camera_processes/gpu_correl.py
+++ b/src/crappy/blocks/camera_processes/gpu_correl.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, List, Union
+from typing import Optional, Union
 from pathlib import Path
 import logging
 import logging.handlers
@@ -37,7 +37,7 @@ class GPUCorrelProcess(CameraProcess):
                resampling_factor: float = 2,
                kernel_file: Optional[Union[str, Path]] = None,
                iterations: int = 4,
-               fields: Optional[List[Union[str, np.ndarray]]] = None,
+               fields: Optional[list[Union[str, np.ndarray]]] = None,
                mask: Optional[np.ndarray] = None,
                mul: float = 3) -> None:
     """Sets the arguments and initializes the parent class.

--- a/src/crappy/blocks/camera_processes/gpu_ve.py
+++ b/src/crappy/blocks/camera_processes/gpu_ve.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, Tuple, List, Union
+from typing import Optional, Union
 from pathlib import Path
 import logging
 import logging.handlers
@@ -35,7 +35,7 @@ class GPUVEProcess(CameraProcess):
   """
 
   def __init__(self,
-               patches: List[Tuple[int, int, int, int]],
+               patches: list[tuple[int, int, int, int]],
                verbose: int = 0,
                kernel_file: Optional[Union[str, Path]] = None,
                iterations: int = 4,
@@ -94,7 +94,7 @@ class GPUVEProcess(CameraProcess):
     self._mul = mul
 
     # Other attributes
-    self._correls: Optional[List[GPUCorrelTool]] = None
+    self._correls: Optional[list[GPUCorrelTool]] = None
     self._patches = patches
     self._img_ref = img_ref
 

--- a/src/crappy/blocks/camera_processes/video_extenso.py
+++ b/src/crappy/blocks/camera_processes/video_extenso.py
@@ -88,10 +88,9 @@ class VideoExtensoProcess(CameraProcess):
       # Processing the received frame
       try:
         self.log(logging.DEBUG, "Processing the received image")
-        data = self._ve.get_data(self.img)
         
         # Sending the results to the downstream Blocks
-        if data is not None:
+        if (data := self._ve.get_data(self.img)) is not None:
           self.send([self.metadata['t(s)'], self.metadata, *data])
 
         # Sending the detected spots to the Displayer for display

--- a/src/crappy/blocks/canvas.py
+++ b/src/crappy/blocks/canvas.py
@@ -265,8 +265,7 @@ class Canvas(Block):
     """Receives the latest data from upstream Blocks and updates the drawing
     accordingly."""
 
-    data = self.recv_last_data(fill_missing=False)
-    if not data:
+    if not (data := self.recv_last_data(fill_missing=False)):
       return
 
     for elt in self._drawing_elements:

--- a/src/crappy/blocks/canvas.py
+++ b/src/crappy/blocks/canvas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from datetime import timedelta
 from time import time
-from typing import Tuple, Dict, Any, Optional, Iterable
+from typing import Any, Optional, Iterable
 import logging
 
 from .meta_block import Block
@@ -21,7 +21,7 @@ class Text:
 
   def __init__(self,
                _: Canvas,
-               coord: Tuple[int, int],
+               coord: tuple[int, int],
                text: str,
                label: str,
                **__: str) -> None:
@@ -44,7 +44,7 @@ class Text:
 
     self._txt = plt.text(x, y, text)
 
-  def update(self, data: Dict[str, float]) -> None:
+  def update(self, data: dict[str, float]) -> None:
     """Updates the text according to the received values."""
 
     if self._label in data:
@@ -60,7 +60,7 @@ class DotText:
 
   def __init__(self,
                drawing: Canvas,
-               coord: Tuple[int, int],
+               coord: tuple[int, int],
                text: str,
                label: str,
                **__: str) -> None:
@@ -97,7 +97,7 @@ class DotText:
     self._amp = high - low
     self._low = low
 
-  def update(self, data: Dict[str, float]) -> None:
+  def update(self, data: dict[str, float]) -> None:
     """Updates the text and the color dot according to the received values."""
 
     if self._label in data:
@@ -113,7 +113,7 @@ class Time:
   .. versionadded:: 1.4.0
   """
 
-  def __init__(self, drawing: Canvas, coord: Tuple[int, int], **__) -> None:
+  def __init__(self, drawing: Canvas, coord: tuple[int, int], **__) -> None:
     """Sets the arguments.
 
     Args:
@@ -130,7 +130,7 @@ class Time:
 
     self._txt = plt.text(x, y, "00:00", size=38)
 
-  def update(self, _: Dict[str, float]) -> None:
+  def update(self, _: dict[str, float]) -> None:
     """Updates the time counter, independently of the received values."""
 
     self._txt.set_text(str(timedelta(seconds=int(time() - self._block.t0))))
@@ -158,10 +158,10 @@ class Canvas(Block):
 
   def __init__(self,
                image_path: str,
-               draw: Optional[Iterable[Dict[str, Any]]] = None,
-               color_range: Tuple[float, float] = (20, 300),
+               draw: Optional[Iterable[dict[str, Any]]] = None,
+               color_range: tuple[float, float] = (20, 300),
                title: str = "Canvas",
-               window_size: Tuple[int, int] = (7, 5),
+               window_size: tuple[int, int] = (7, 5),
                backend: str = "TkAgg",
                freq: Optional[float] = 2,
                display_freq: bool = False,

--- a/src/crappy/blocks/canvas.py
+++ b/src/crappy/blocks/canvas.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 from datetime import timedelta
 from time import time
-from typing import Any, Optional, Iterable
+from typing import Any, Optional
+from collections.abc import Iterable
 import logging
 
 from .meta_block import Block

--- a/src/crappy/blocks/client_server.py
+++ b/src/crappy/blocks/client_server.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Dict, Union, Any, Optional, Iterable, List, Tuple
+from typing import Union, Any, Optional, Iterable
 from time import time, sleep
 from subprocess import Popen, PIPE, STDOUT, TimeoutExpired
 from threading import Thread
@@ -45,7 +45,7 @@ class ClientServer(Block):
                broker: bool = False,
                address: str = 'localhost',
                port: int = 1883,
-               init_output: Optional[Dict[str, Any]] = None,
+               init_output: Optional[dict[str, Any]] = None,
                topics: Optional[TopicsType] = None,
                cmd_labels: Optional[TopicsType] = None,
                labels_to_send: Optional[TopicsType] = None,
@@ -238,11 +238,11 @@ class ClientServer(Block):
     self._stop_mosquitto = False
     
     # These attributes may be set later
-    self._topics: Optional[List[Tuple[str, ...]]] = None
-    self._last_out_val: Dict[str, Any] = dict()
-    self._buffer_output: Optional[Dict[Tuple[str, ...], Queue]] = None
-    self._cmd_labels: Optional[List[Tuple[str, ...]]] = None
-    self._labels_to_send: Optional[List[Tuple[str, ...]]] = None
+    self._topics: Optional[list[tuple[str, ...]]] = None
+    self._last_out_val: dict[str, Any] = dict()
+    self._buffer_output: Optional[dict[tuple[str, ...], Queue]] = None
+    self._cmd_labels: Optional[list[tuple[str, ...]]] = None
+    self._labels_to_send: Optional[list[tuple[str, ...]]] = None
 
     if topics is None and cmd_labels is None:
       self.log(logging.WARNING, "The Client-server Block is neither an input "

--- a/src/crappy/blocks/client_server.py
+++ b/src/crappy/blocks/client_server.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Union, Any, Optional, Iterable
+from typing import Union, Any, Optional
+from collections.abc import Iterable
 from time import time, sleep
 from subprocess import Popen, PIPE, STDOUT, TimeoutExpired
 from threading import Thread

--- a/src/crappy/blocks/dashboard.py
+++ b/src/crappy/blocks/dashboard.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import List, Optional, Iterable, Union
+from typing import Optional, Iterable, Union
 import tkinter as tk
 import logging
 
@@ -15,7 +15,7 @@ class DashboardWindow(tk.Tk):
      renamed from *Dashboard_window* to *DashboardWindow*
   """
 
-  def __init__(self, labels: List[str]) -> None:
+  def __init__(self, labels: list[str]) -> None:
     """Initializes the GUI and sets the layout."""
 
     super().__init__()

--- a/src/crappy/blocks/dashboard.py
+++ b/src/crappy/blocks/dashboard.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Iterable, Union
+from typing import Optional, Union
+from collections.abc import Iterable
 import tkinter as tk
 import logging
 

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable
+from typing import Optional, Callable, Union, Tuple, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -55,7 +55,7 @@ class DICVE(Camera):
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                config: bool = True,
                display_images: bool = False,
-               displayer_backend: Optional[str] = None,
+               displayer_backend: Optional[Literal['cv2', 'mpl']] = None,
                displayer_framerate: float = 5,
                software_trig_label: Optional[str] = None,
                display_freq: bool = False,
@@ -65,14 +65,16 @@ class DICVE(Camera):
                img_extension: str = "tiff",
                save_folder: Optional[Union[str, Path]] = None,
                save_period: int = 1,
-               save_backend: Optional[str] = None,
+               save_backend: Optional[Literal['sitk', 'pil',
+                                              'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
                img_shape: Optional[Tuple[int, int]] = None,
                img_dtype: Optional[str] = None,
                patches: Optional[Iterable[Tuple[int, int, int, int]]] = None,
                labels: Optional[Union[str, Iterable[str]]] = None,
-               method: str = 'Disflow',
+               method: Literal['Disflow', 'Lucas Kanade',
+                               'Pixel precision', 'Parabola'] = 'Disflow',
                alpha: float = 3,
                delta: float = 1,
                gamma: float = 0,

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable, Literal
+from typing import Optional, Callable, Union, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -69,9 +69,9 @@ class DICVE(Camera):
                                               'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
-               img_shape: Optional[Tuple[int, int]] = None,
+               img_shape: Optional[tuple[int, int]] = None,
                img_dtype: Optional[str] = None,
-               patches: Optional[Iterable[Tuple[int, int, int, int]]] = None,
+               patches: Optional[Iterable[tuple[int, int, int, int]]] = None,
                labels: Optional[Union[str, Iterable[str]]] = None,
                method: Literal['Disflow', 'Lucas Kanade',
                                'Pixel precision', 'Parabola'] = 'Disflow',

--- a/src/crappy/blocks/dic_ve.py
+++ b/src/crappy/blocks/dic_ve.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Iterable, Literal
+from typing import Optional, Union, Literal
+from collections.abc import Iterable, Callable
 import numpy as np
 from pathlib import Path
 

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -9,7 +9,8 @@ from .camera import Camera
 from ..tool.camera_config import DISCorrelConfig, Box
 from .._global import CameraConfigError
 
-field_type = Literal['x', 'y', 'r', 'exx', 'eyy', 'exy', 'eyx', 'exy2', 'z']
+field_type = Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+                           'exy', 'eyx', 'exy2', 'z'], np.ndarray]
 
 
 class DISCorrel(Camera):

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable
+from typing import Optional, Callable, Union, Tuple, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -8,6 +8,8 @@ from .camera_processes import DISCorrelProcess
 from .camera import Camera
 from ..tool.camera_config import DISCorrelConfig, Box
 from .._global import CameraConfigError
+
+field_type = Literal['x', 'y', 'r', 'exx', 'eyy', 'exy', 'eyx', 'exy2', 'z']
 
 
 class DISCorrel(Camera):
@@ -47,7 +49,7 @@ class DISCorrel(Camera):
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                config: bool = True,
                display_images: bool = False,
-               displayer_backend: Optional[str] = None,
+               displayer_backend: Optional[Literal['cv2', 'mpl']] = None,
                displayer_framerate: float = 5,
                software_trig_label: Optional[str] = None,
                display_freq: bool = False,
@@ -57,13 +59,14 @@ class DISCorrel(Camera):
                img_extension: str = "tiff",
                save_folder: Optional[Union[str, Path]] = None,
                save_period: int = 1,
-               save_backend: Optional[str] = None,
+               save_backend: Optional[Literal['sitk', 'pil', 
+                                              'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
                img_shape: Optional[Tuple[int, int]] = None,
                img_dtype: Optional[str] = None,
                patch: Optional[Tuple[int, int, int, int]] = None,
-               fields: Union[str, Iterable[str]] = None,
+               fields: Union[field_type, Iterable[field_type]] = None,
                labels: Union[str, Iterable[str]] = None,
                alpha: float = 3,
                delta: float = 1,

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Iterable, Literal
+from typing import Optional, Union, Literal
+from collections.abc import Iterable, Callable
 import numpy as np
 from pathlib import Path
 

--- a/src/crappy/blocks/dis_correl.py
+++ b/src/crappy/blocks/dis_correl.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable, Literal
+from typing import Optional, Callable, Union, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -63,9 +63,9 @@ class DISCorrel(Camera):
                                               'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
-               img_shape: Optional[Tuple[int, int]] = None,
+               img_shape: Optional[tuple[int, int]] = None,
                img_dtype: Optional[str] = None,
-               patch: Optional[Tuple[int, int, int, int]] = None,
+               patch: Optional[tuple[int, int, int, int]] = None,
                fields: Union[field_type, Iterable[field_type]] = None,
                labels: Union[str, Iterable[str]] = None,
                alpha: float = 3,

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -2,7 +2,7 @@
 
 from time import time
 import numpy as np
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Literal
 import logging
 
 from .meta_block import Block
@@ -46,7 +46,7 @@ class FakeMachine(Block):
                nu: float = 0.3,
                plastic_law: Callable[[float], float] = plastic,
                max_speed: float = 5,
-               mode: str = 'speed',
+               mode: Literal['speed', 'position'] = 'speed',
                cmd_label: str = 'cmd',
                freq: Optional[float] = 100,
                display_freq: bool = False,

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -2,7 +2,7 @@
 
 from time import time
 import numpy as np
-from typing import Callable, Dict, Optional, Literal
+from typing import Callable, Optional, Literal
 import logging
 
 from .meta_block import Block
@@ -42,7 +42,7 @@ class FakeMachine(Block):
                rigidity: float = 8.4E6,
                l0: float = 200,
                max_strain: float = 1.51,
-               sigma: Optional[Dict[str, float]] = None,
+               sigma: Optional[dict[str, float]] = None,
                nu: float = 0.3,
                plastic_law: Callable[[float], float] = plastic,
                max_speed: float = 5,
@@ -164,7 +164,7 @@ class FakeMachine(Block):
     # Finally, sending the values
     self._send_values()
 
-  def _add_noise(self, to_send: Dict[str, float]) -> Dict[str, float]:
+  def _add_noise(self, to_send: dict[str, float]) -> dict[str, float]:
     """Adds noise to the data to be sent, according to the sigma values
     provided by the user. Then returns the noised data."""
 

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -2,7 +2,8 @@
 
 from time import time
 import numpy as np
-from typing import Callable, Optional, Literal
+from typing import Optional, Literal
+from collections.abc import Callable
 import logging
 
 from .meta_block import Block

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -127,8 +127,7 @@ class FakeMachine(Block):
     is, and finally returns the data."""
 
     # Getting the latest command
-    data = self.recv_last_data(fill_missing=True)
-    if self._cmd_label not in data:
+    if self._cmd_label not in (data := self.recv_last_data(fill_missing=True)):
       return
     else:
       cmd = data[self._cmd_label]

--- a/src/crappy/blocks/generator.py
+++ b/src/crappy/blocks/generator.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Dict, Any, Optional, Iterator, Iterable
+from typing import Any, Optional, Iterator, Iterable
 from itertools import cycle
 from copy import deepcopy
 import logging
@@ -37,7 +37,7 @@ class Generator(Block):
   """
 
   def __init__(self,
-               path: Iterable[Dict[str, Any]],
+               path: Iterable[dict[str, Any]],
                freq: Optional[float] = 200,
                cmd_label: str = 'cmd',
                path_index_label: str = 'index',
@@ -218,7 +218,7 @@ class Generator(Block):
     Path.last_cmd = self._last_cmd
     self._current_path = path_type(**next_path_dict)
 
-  def _check_path_validity(self, path: Iterator[Dict[str, Any]]) -> None:
+  def _check_path_validity(self, path: Iterator[dict[str, Any]]) -> None:
     """Simply instantiates all the Paths in a row to check no error is
     raised."""
 

--- a/src/crappy/blocks/generator.py
+++ b/src/crappy/blocks/generator.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Any, Optional, Iterator, Iterable
+from typing import Any, Optional
+from collections.abc import Iterator, Iterable
 from itertools import cycle
 from copy import deepcopy
 import logging

--- a/src/crappy/blocks/generator_path/conditional.py
+++ b/src/crappy/blocks/generator_path/conditional.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Union, Dict
+from typing import Union
 import logging
 
 from .meta_path import Path, ConditionType
@@ -58,7 +58,7 @@ class Conditional(Path):
     self._condition2 = self.parse_condition(condition2)
     self._prev = self._value0
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """Sends either ``value1`` if ``condition1`` is met, or ``value2`` if only
     ``condition2`` is met, or ``value0`` if none of the conditions are met."""
 

--- a/src/crappy/blocks/generator_path/constant.py
+++ b/src/crappy/blocks/generator_path/constant.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Union, Dict
+from typing import Union
 import logging
 
 from .meta_path import Path, ConditionType
@@ -39,7 +39,7 @@ class Constant(Path):
 
     self._value = self.last_cmd if value is None else value
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """Returns the value to send or raises :exc:`StopIteration` if the stop
     condition is met.
     

--- a/src/crappy/blocks/generator_path/custom.py
+++ b/src/crappy/blocks/generator_path/custom.py
@@ -2,7 +2,7 @@
 
 from time import time
 from numpy import loadtxt, interp
-from typing import Dict, Union
+from typing import Union
 import pathlib
 import logging
 
@@ -52,7 +52,7 @@ class Custom(Path):
     self._timestamps = array[:, 0]
     self._values = array[:, 1]
 
-  def get_cmd(self, _: Dict[str, list]) -> float:
+  def get_cmd(self, _: dict[str, list]) -> float:
     """Returns the value to send or raises :exc:`StopIteration` if the stop
     condition is met.
 

--- a/src/crappy/blocks/generator_path/cyclic.py
+++ b/src/crappy/blocks/generator_path/cyclic.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Union, Dict
+from typing import Union
 from itertools import cycle, islice
 import logging
 
@@ -79,7 +79,7 @@ class Cyclic(Path):
     self._condition = None
     self._value = None
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """Returns either the first or second value depending on the current state
     of the cycle. Raises :exc:`StopIteration` when the cycles are exhausted.
 

--- a/src/crappy/blocks/generator_path/cyclic_ramp.py
+++ b/src/crappy/blocks/generator_path/cyclic_ramp.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Union, Dict, Optional
+from typing import Union, Optional
 from itertools import cycle, islice
 import logging
 
@@ -91,7 +91,7 @@ class CyclicRamp(Path):
     # The last extreme command sent
     self._last_peak_cmd = self.last_cmd if init_value is None else init_value
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """Returns the current value of the signal and raises :exc:`StopIteration`
     when the cycles are exhausted.
 

--- a/src/crappy/blocks/generator_path/integrator.py
+++ b/src/crappy/blocks/generator_path/integrator.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from numpy import trapz
-from typing import Union, Dict
+from typing import Union
 import logging
 
 from .meta_path import Path, ConditionType
@@ -69,7 +69,7 @@ class Integrator(Path):
     self._last_t = None
     self._last_val = None
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """Gets the latest values of the incoming label, integrates them and
     changes the output accordingly.
 

--- a/src/crappy/blocks/generator_path/meta_path/path.py
+++ b/src/crappy/blocks/generator_path/meta_path/path.py
@@ -1,14 +1,15 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Callable, Union, Dict, Optional
+from typing import Union, Optional
+from collections.abc import Callable
 from re import split, IGNORECASE, match
 import logging
 from multiprocessing import current_process
 
 from .meta_path import MetaPath
 
-ConditionType = Callable[[Dict[str, list]], bool]
+ConditionType = Callable[[dict[str, list]], bool]
 
 
 class Path(metaclass=MetaPath):

--- a/src/crappy/blocks/generator_path/meta_path/path.py
+++ b/src/crappy/blocks/generator_path/meta_path/path.py
@@ -44,7 +44,7 @@ class Path(metaclass=MetaPath):
 
     self._logger: Optional[logging.Logger] = None
 
-  def get_cmd(self, data: Dict[str, list]) -> Optional[float]:
+  def get_cmd(self, data: dict[str, list]) -> Optional[float]:
     """This method is called by the :class:`~crappy.blocks.Generator` Block to
     get the next command to send.
 
@@ -140,7 +140,7 @@ class Path(metaclass=MetaPath):
       if condition is None:
         self.log(logging.DEBUG, "Condition is None")
 
-        def cond(_: Dict[str, list]) -> bool:
+        def cond(_: dict[str, list]) -> bool:
           """Condition always returning False."""
 
           return False
@@ -157,7 +157,7 @@ class Path(metaclass=MetaPath):
       var, thresh = split(r'\s*<\s*', condition)
 
       # Return a function that checks if received data is inferior to threshold
-      def cond(data: Dict[str, list]) -> bool:
+      def cond(data: dict[str, list]) -> bool:
         """Condition checking that the label values are below a given
         threshold."""
 
@@ -173,7 +173,7 @@ class Path(metaclass=MetaPath):
       var, thresh = split(r'\s*>\s*', condition)
 
       # Return a function that checks if received data is superior to threshold
-      def cond(data: Dict[str, list]) -> bool:
+      def cond(data: dict[str, list]) -> bool:
         """Condition checking that the label values are above a given
         threshold."""
 
@@ -189,7 +189,7 @@ class Path(metaclass=MetaPath):
       delay = float(split(r'=\s*', condition)[1])
 
       # Return a function that checks if the delay is expired
-      def cond(_: Dict[str, list]) -> bool:
+      def cond(_: dict[str, list]) -> bool:
         """Condition checking if a given delay is expired."""
 
         return time() - self.t0 > delay

--- a/src/crappy/blocks/generator_path/ramp.py
+++ b/src/crappy/blocks/generator_path/ramp.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Union, Dict, Optional
+from typing import Union, Optional
 import logging
 
 from .meta_path import Path, ConditionType
@@ -46,7 +46,7 @@ class Ramp(Path):
     self._speed = speed
     self._init_value = init_value if init_value is not None else self.last_cmd
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """Returns the value to send or raises :exc:`StopIteration` if the stop
     condition is met."""
 

--- a/src/crappy/blocks/generator_path/sine.py
+++ b/src/crappy/blocks/generator_path/sine.py
@@ -56,5 +56,5 @@ class Sine(Path):
       raise StopIteration
 
     # Returning the current signal value
-    return sin((time() - self.t0) * self._k - self._phase) * \
-        self._amplitude + self._offset
+    return (sin((time() - self.t0) * self._k - self._phase) *
+            self._amplitude + self._offset)

--- a/src/crappy/blocks/generator_path/sine.py
+++ b/src/crappy/blocks/generator_path/sine.py
@@ -2,7 +2,7 @@
 
 from time import time
 from numpy import sin, pi
-from typing import Union, Dict
+from typing import Union
 import logging
 
 from .meta_path import Path, ConditionType
@@ -46,7 +46,7 @@ class Sine(Path):
     self._phase = phase
     self._k = 2 * pi * freq
 
-  def get_cmd(self, data: Dict[str, list]) -> float:
+  def get_cmd(self, data: dict[str, list]) -> float:
     """Returns the value to send or raises :exc:`StopIteration` if the stop
     condition is met."""
 

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Iterable, Literal
+from typing import Optional, Union, Literal
+from collections.abc import Callable, Iterable
 import numpy as np
 from pathlib import Path
 

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -1,11 +1,13 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable
+from typing import Optional, Callable, Union, Tuple, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
 from .camera_processes import GPUCorrelProcess
 from .camera import Camera
+
+field_type = Literal['x', 'y', 'r', 'exx', 'eyy', 'exy', 'eyx', 'exy2', 'z']
 
 
 class GPUCorrel(Camera):
@@ -45,12 +47,12 @@ class GPUCorrel(Camera):
 
   def __init__(self,
                camera: str,
-               fields: Union[str, Iterable[str]],
+               fields: Union[field_type, Iterable[field_type]],
                img_shape: Tuple[int, int],
                img_dtype: str,
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                display_images: bool = False,
-               displayer_backend: Optional[str] = None,
+               displayer_backend: Optional[Literal['cv2', 'mpl']] = None,
                displayer_framerate: float = 5,
                software_trig_label: Optional[str] = None,
                verbose: int = 0,
@@ -60,7 +62,8 @@ class GPUCorrel(Camera):
                img_extension: str = "tiff",
                save_folder: Optional[Union[str, Path]] = None,
                save_period: int = 1,
-               save_backend: Optional[str] = None,
+               save_backend: Optional[Literal['sitk', 'pil', 
+                                              'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
                labels: Optional[Union[str, Iterable[str]]] = None,

--- a/src/crappy/blocks/gpu_correl.py
+++ b/src/crappy/blocks/gpu_correl.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable, Literal
+from typing import Optional, Callable, Union, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -48,7 +48,7 @@ class GPUCorrel(Camera):
   def __init__(self,
                camera: str,
                fields: Union[field_type, Iterable[field_type]],
-               img_shape: Tuple[int, int],
+               img_shape: tuple[int, int],
                img_dtype: str,
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                display_images: bool = False,

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Iterable, Literal
+from typing import Optional, Union, Literal
+from collections.abc import Callable, Iterable
 import numpy as np
 from pathlib import Path
 

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable, Literal
+from typing import Optional, Callable, Union, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -39,8 +39,8 @@ class GPUVE(Camera):
 
   def __init__(self,
                camera: str,
-               patches: Iterable[Tuple[int, int, int, int]],
-               img_shape: Tuple[int, int],
+               patches: Iterable[tuple[int, int, int, int]],
+               img_shape: tuple[int, int],
                img_dtype: str,
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                display_images: bool = False,

--- a/src/crappy/blocks/gpu_ve.py
+++ b/src/crappy/blocks/gpu_ve.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable
+from typing import Optional, Callable, Union, Tuple, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -44,7 +44,7 @@ class GPUVE(Camera):
                img_dtype: str,
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                display_images: bool = False,
-               displayer_backend: Optional[str] = None,
+               displayer_backend: Optional[Literal['cv2', 'mpl']] = None,
                displayer_framerate: float = 5,
                software_trig_label: Optional[str] = None,
                verbose: bool = False,
@@ -54,7 +54,8 @@ class GPUVE(Camera):
                img_extension: str = "tiff",
                save_folder: Optional[Union[str, Path]] = None,
                save_period: int = 1,
-               save_backend: Optional[str] = None,
+               save_backend: Optional[Literal['sitk', 'pil', 
+                                              'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
                labels: Optional[Union[str, Iterable[str]]] = None,

--- a/src/crappy/blocks/grapher.py
+++ b/src/crappy/blocks/grapher.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, Tuple
+from typing import Optional
 import logging
 from _tkinter import TclError
 
@@ -32,12 +32,12 @@ class Grapher(Block):
   """
 
   def __init__(self,
-               *labels: Tuple[str, str],
+               *labels: tuple[str, str],
                length: int = 0,
                freq: Optional[float] = 2,
                max_pt: int = 20000,
-               window_size: Tuple[int, int] = (8, 8),
-               window_pos: Optional[Tuple[int, int]] = None,
+               window_size: tuple[int, int] = (8, 8),
+               window_pos: Optional[tuple[int, int]] = None,
                interp: bool = True,
                backend: str = "TkAgg",
                display_freq: bool = False,

--- a/src/crappy/blocks/hdf_recorder.py
+++ b/src/crappy/blocks/hdf_recorder.py
@@ -152,9 +152,7 @@ class HDFRecorder(Block):
       else:
         return
 
-    data = self.recv_all_data()
-
-    if self._label in data:
+    if self._label in (data := self.recv_all_data()):
       for elt in data[self._label]:
         self._array.append(elt)
 
@@ -168,9 +166,7 @@ class HDFRecorder(Block):
   def _first_loop(self) -> None:
     """Initializes the array for saving data."""
 
-    data = self.recv_all_data()
-
-    if self._label not in data:
+    if self._label not in (data := self.recv_all_data()):
       raise KeyError(f'The data received by the HDF Recorder block does not '
                      f'contain the label {self._label} !')
 

--- a/src/crappy/blocks/ioblock.py
+++ b/src/crappy/blocks/ioblock.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Union, Optional, Iterable, Any
+from typing import Union, Optional, Any
+from collections.abc import Iterable
 import logging
 
 from .meta_block import Block

--- a/src/crappy/blocks/ioblock.py
+++ b/src/crappy/blocks/ioblock.py
@@ -242,7 +242,7 @@ class IOBlock(Block):
                              f"{type(self._device).__name__} InOut")
       self._device.set_cmd(*self._initial_cmd)
       self._last_cmd = self._initial_cmd
-      self._prev_values.update(zip(self._cmd_labels, self._initial_cmd))
+      self._prev_values |= zip(self._cmd_labels, self._initial_cmd)
 
   def loop(self) -> None:
     """Reads data from the InOut and/or sets the received commands.
@@ -282,8 +282,8 @@ class IOBlock(Block):
     if self._write:
       # The missing values are completed here, because the trig label must not
       # be artificially created
-      self._prev_values.update(data)
-      data.update(self._prev_values)
+      self._prev_values |= data
+      data |= self._prev_values
 
       # Keeping only the labels in cmd_labels
       data = {key: val for key, val in data.items() if key in self._cmd_labels}

--- a/src/crappy/blocks/link_reader.py
+++ b/src/crappy/blocks/link_reader.py
@@ -79,8 +79,7 @@ class LinkReader(Block):
     """Flushes the incoming :class:`~crappy.links.Link` and displays their
     data."""
 
-    data = self.recv_all_data_raw()
-    for link_data in data:
+    for link_data in self.recv_all_data_raw():
       for dic in (dict(i) for i in
                   zip(*([(key, value) for value in values]
                         for key, values in link_data.items()))):

--- a/src/crappy/blocks/machine.py
+++ b/src/crappy/blocks/machine.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from time import time
-from typing import Any, Optional, Iterable
+from typing import Any, Optional
+from collections.abc import Iterable
 from dataclasses import dataclass, fields
 import logging
 

--- a/src/crappy/blocks/machine.py
+++ b/src/crappy/blocks/machine.py
@@ -234,15 +234,12 @@ class Machine(Block):
     position and speed values respectively.
     """
 
-    # Receiving the latest command
-    recv = self.recv_last_data(fill_missing=self._spam)
-
     # Iterating over the actuators for setting the commands
-    if recv:
+    if recv := self.recv_last_data(fill_missing=self._spam):
       for actuator in self._actuators:
         # Setting the speed attribute if it was received
-        if actuator.speed_cmd_label is not None and \
-            actuator.speed_cmd_label in recv:
+        if (actuator.speed_cmd_label is not None
+            and actuator.speed_cmd_label in recv):
           self.log(logging.DEBUG,
                    f"Updating the speed of the "
                    f"{type(actuator.actuator).__name__} Actuator from "

--- a/src/crappy/blocks/machine.py
+++ b/src/crappy/blocks/machine.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Dict, List, Any, Optional, Iterable
+from typing import Any, Optional, Iterable
 from dataclasses import dataclass, fields
 import logging
 
@@ -51,8 +51,8 @@ class Machine(Block):
   """
 
   def __init__(self,
-               actuators: Iterable[Dict[str, Any]],
-               common: Optional[Dict[str, Any]] = None,
+               actuators: Iterable[dict[str, Any]],
+               common: Optional[dict[str, Any]] = None,
                time_label: str = 't(s)',
                ft232h_ser_num: Optional[str] = None,
                spam: bool = False,
@@ -123,7 +123,7 @@ class Machine(Block):
           value is updated. It will also overwrite the ``speed`` key if given.
     """
 
-    self._actuators: List[ActuatorInstance] = list()
+    self._actuators: list[ActuatorInstance] = list()
     self._ft232h_args = None
 
     super().__init__()

--- a/src/crappy/blocks/machine.py
+++ b/src/crappy/blocks/machine.py
@@ -140,7 +140,7 @@ class Machine(Block):
 
     # Updating the settings with the common information
     for actuator in actuators:
-      actuator.update(common)
+      actuator |= common
 
     # Making sure all the dicts contain the 'type' key
     if not all('type' in dic for dic in actuators):

--- a/src/crappy/blocks/mean.py
+++ b/src/crappy/blocks/mean.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, Union, Iterable
+from typing import Optional, Union
+from collections.abc import Iterable
 from time import time
 import logging
 

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -1035,10 +1035,8 @@ class Block(Process, metaclass=MetaBlock):
 
       # Correcting the error of the sleep function through a recursive approach
       # The last 2 milliseconds are in free loop
-      remaining = self._last_t + 1 / self.freq - t
-      while remaining > 0:
+      while (remaining := self._last_t + 1 / self.freq - t) > 0:
         t = time_ns() / 1e9
-        remaining = self._last_t + 1 / self.freq - t
         sleep(max(0., remaining / 2 - 2e-3))
 
     self._last_t = t

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -11,7 +11,8 @@ import logging
 import logging.handlers
 from time import sleep, time, time_ns
 from weakref import WeakSet
-from typing import Union, Optional, Any, Iterable
+from typing import Union, Optional, Any
+from collections.abc import Iterable
 from collections import defaultdict
 import subprocess
 from sys import stdout, stderr, argv

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -1223,7 +1223,7 @@ class Block(Process, metaclass=MetaBlock):
     ret = dict()
 
     for link in self.inputs:
-      ret.update(link.recv())
+      ret |= link.recv()
 
     self.log(logging.DEBUG, f"Called recv_data, got {ret}")
     return ret
@@ -1264,13 +1264,13 @@ class Block(Process, metaclass=MetaBlock):
     # Storing the received values in the return dict and in the buffer
     for link, buffer in zip(self.inputs, self._last_values):
       data = link.recv_last()
-      ret.update(data)
-      buffer.update(data)
+      ret |= data
+      buffer |= data
 
     # If requested, filling up the missing values in the return dict
     if fill_missing:
       for buffer in self._last_values:
-        ret.update(buffer)
+        ret |= buffer
 
     self.log(logging.DEBUG, f"Called recv_last_data, got {ret}")
     return ret
@@ -1319,7 +1319,7 @@ class Block(Process, metaclass=MetaBlock):
     # If simple recv_all, just receiving from all input links
     if delay is None:
       for link in self.inputs:
-        ret.update(link.recv_chunk())
+        ret |= link.recv_chunk()
 
     # Otherwise, receiving during the given period
     else:
@@ -1370,7 +1370,7 @@ class Block(Process, metaclass=MetaBlock):
     # If simple recv_all, just receiving from all input links
     if delay is None:
       for dic, link in zip(ret, self.inputs):
-        dic.update(link.recv_chunk())
+        dic |= link.recv_chunk()
 
     # Otherwise, receiving during the given period
     else:

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -11,7 +11,7 @@ import logging
 import logging.handlers
 from time import sleep, time, time_ns
 from weakref import WeakSet
-from typing import Union, Optional, List, Dict, Any, Iterable
+from typing import Union, Optional, Any, Iterable
 from collections import defaultdict
 import subprocess
 from sys import stdout, stderr, argv
@@ -44,7 +44,7 @@ class Block(Process, metaclass=MetaBlock):
   """
 
   instances = WeakSet()
-  names: List[str] = list()
+  names: list[str] = list()
   log_level: Optional[int] = logging.DEBUG
 
   # The synchronization objects will be set later
@@ -69,8 +69,8 @@ class Block(Process, metaclass=MetaBlock):
     super().__init__()
 
     # The lists of input and output links
-    self.outputs: List[Link] = list()
-    self.inputs: List[Link] = list()
+    self.outputs: list[Link] = list()
+    self.inputs: list[Link] = list()
 
     # Various objects that should be set by child classes
     self.niceness: int = 0
@@ -1142,7 +1142,7 @@ class Block(Process, metaclass=MetaBlock):
       return
     self._logger.log(log_level, msg)
 
-  def send(self, data: Optional[Union[Dict[str, Any], Iterable[Any]]]) -> None:
+  def send(self, data: Optional[Union[dict[str, Any], Iterable[Any]]]) -> None:
     """Method for sending data to downstream Blocks.
 
     The exact same :obj:`dict` is sent to every downstream Block.
@@ -1199,7 +1199,7 @@ class Block(Process, metaclass=MetaBlock):
     self.log(logging.DEBUG, "Data availability requested")
     return self.inputs and any(link.poll() for link in self.inputs)
 
-  def recv_data(self) -> Dict[str, Any]:
+  def recv_data(self) -> dict[str, Any]:
     """Reads the first available values from each incoming
     :class:`~crappy.links.Link` and returns them all in a single dict.
 
@@ -1228,7 +1228,7 @@ class Block(Process, metaclass=MetaBlock):
     self.log(logging.DEBUG, f"Called recv_data, got {ret}")
     return ret
 
-  def recv_last_data(self, fill_missing: bool = True) -> Dict[str, Any]:
+  def recv_last_data(self, fill_missing: bool = True) -> dict[str, Any]:
     """Reads all the available values from each incoming
     :class:`~crappy.links.Link`, and returns the newest ones in a single dict.
 
@@ -1277,7 +1277,7 @@ class Block(Process, metaclass=MetaBlock):
 
   def recv_all_data(self,
                     delay: Optional[float] = None,
-                    poll_delay: float = 0.1) -> Dict[str, List[Any]]:
+                    poll_delay: float = 0.1) -> dict[str, list[Any]]:
     """Reads all the available values from each incoming
     :class:`~crappy.links.Link`, and returns them all in a single dict.
 
@@ -1339,7 +1339,7 @@ class Block(Process, metaclass=MetaBlock):
 
   def recv_all_data_raw(self,
                         delay: Optional[float] = None,
-                        poll_delay: float = 0.1) -> List[Dict[str, List[Any]]]:
+                        poll_delay: float = 0.1) -> list[dict[str, list[Any]]]:
     """Reads all the available values from each incoming
     :class:`~crappy.links.Link`, and returns them separately in a list of
     dicts.

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -2,7 +2,7 @@
 
 import logging
 import numpy as np
-from typing import Dict, Optional, Iterable, Union
+from typing import Optional, Iterable, Union
 from collections import defaultdict
 
 from .meta_block import Block
@@ -93,7 +93,7 @@ class Multiplexer(Block):
     # Initializing the attributes
     self._time_label = time_label
     self._interp_freq = interp_freq
-    self._data: Dict[str, np.ndarray] = defaultdict(self._default_array)
+    self._data: dict[str, np.ndarray] = defaultdict(self._default_array)
     self._delta: float = 1 / self._interp_freq / 20
     self._last_max_t: float = -float('inf')
 

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -2,7 +2,8 @@
 
 import logging
 import numpy as np
-from typing import Optional, Iterable, Union
+from typing import Optional, Union
+from collections.abc import Iterable
 from collections import defaultdict
 
 from .meta_block import Block

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -109,11 +109,8 @@ class Multiplexer(Block):
     """Receives data, interpolates it, and sends it to the downstream
     Blocks."""
 
-    # Receiving all the upcoming data
-    data = self.recv_all_data_raw()
-
     # Iterating over all the links
-    for link_data in data:
+    for link_data in self.recv_all_data_raw():
       # Only data associated with a time label can be multiplexed
       if self._time_label not in link_data:
         continue

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, Tuple
+from typing import Optional
 import logging
 
 from .meta_block import Block
@@ -37,9 +37,9 @@ class PID(Block):
                kp_label: str = 'kp',
                ki_label: str = 'ki',
                kd_label: str = 'kd',
-               labels: Optional[Tuple[str, str]] = None,
+               labels: Optional[tuple[str, str]] = None,
                reverse: bool = False,
-               i_limit: Tuple[Optional[float], Optional[float]] = (None, None),
+               i_limit: tuple[Optional[float], Optional[float]] = (None, None),
                send_terms: bool = False,
                freq: Optional[float] = 500,
                display_freq: bool = False,

--- a/src/crappy/blocks/recorder.py
+++ b/src/crappy/blocks/recorder.py
@@ -92,10 +92,8 @@ class Recorder(Block):
     elif len(self.inputs) > 1:
       raise ValueError('Cannot link more than one block to a Recorder block !')
 
-    parent_folder = self._path.parent
-
     # Creating the folder for storing the data if it does not already exist
-    if not Path.is_dir(parent_folder):
+    if not Path.is_dir(parent_folder := self._path.parent):
       self.log(logging.INFO, f"Creating the folder containing the file to save"
                              f" data to ({parent_folder})")
       Path.mkdir(parent_folder, exist_ok=True, parents=True)

--- a/src/crappy/blocks/recorder.py
+++ b/src/crappy/blocks/recorder.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Iterable, Optional, Union
+from typing import Optional, Union
+from collections.abc import Iterable
 from pathlib import Path
 import logging
 

--- a/src/crappy/blocks/stop_block.py
+++ b/src/crappy/blocks/stop_block.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Iterable, Union, Callable
+from typing import Optional, Union
+from collections.abc import Iterable, Callable
 import logging
 from re import split
 from time import time

--- a/src/crappy/blocks/stop_block.py
+++ b/src/crappy/blocks/stop_block.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Iterable, Union, Callable, Dict
+from typing import Optional, Iterable, Union, Callable
 import logging
 from re import split
 from time import time
@@ -102,7 +102,7 @@ class StopBlock(Block):
       var, thresh = split(r'\s*<\s*', criterion)
 
       # Return a function that checks if received data is inferior to threshold
-      def cond(data: Dict[str, list]) -> bool:
+      def cond(data: dict[str, list]) -> bool:
         """Criterion checking that the label values are below a given
         threshold."""
 
@@ -122,7 +122,7 @@ class StopBlock(Block):
         self.log(logging.DEBUG, "Criterion is about the elapsed time")
 
         # Return a function that checks if the given time was reached
-        def cond(_: Dict[str, list]) -> bool:
+        def cond(_: dict[str, list]) -> bool:
           """Criterion checking if a given delay is expired."""
 
           return time() - self.t0 > float(thresh)
@@ -134,7 +134,7 @@ class StopBlock(Block):
 
         # Return a function that checks if received data is superior to
         # threshold
-        def cond(data: Dict[str, list]) -> bool:
+        def cond(data: dict[str, list]) -> bool:
           """Criterion checking that the label values are above a given
           threshold."""
 

--- a/src/crappy/blocks/synchronizer.py
+++ b/src/crappy/blocks/synchronizer.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, Union, Iterable
+from typing import Optional, Union
+from collections.abc import Iterable
 from collections import defaultdict
 import logging
 

--- a/src/crappy/blocks/synchronizer.py
+++ b/src/crappy/blocks/synchronizer.py
@@ -84,11 +84,8 @@ class Synchronizer(Block):
     """Receives data, interpolates it, and sends it to the downstream
     Blocks."""
 
-    # Receiving all the upcoming data
-    data = self.recv_all_data_raw()
-
     # Iterating over all the links
-    for link_data in data:
+    for link_data in self.recv_all_data_raw():
       # Only data associated with a time label can be synchronized
       if self._time_label not in link_data:
         continue

--- a/src/crappy/blocks/synchronizer.py
+++ b/src/crappy/blocks/synchronizer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Optional, Union, Iterable, Dict
+from typing import Optional, Union, Iterable
 from collections import defaultdict
 import logging
 
@@ -70,7 +70,7 @@ class Synchronizer(Block):
     # Initializing the attributes
     self._ref_label = reference_label
     self._time_label = time_label
-    self._data: Dict[str, np.ndarray] = defaultdict(self._default_array)
+    self._data: dict[str, np.ndarray] = defaultdict(self._default_array)
 
     # Forcing the labels_to_sync into a list
     if labels_to_sync is not None and isinstance(labels_to_sync, str):

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -2,7 +2,8 @@
 
 from struct import unpack
 from time import time
-from typing import Optional, Callable, Iterable, Union
+from typing import Optional, Union
+from collections.abc import Callable, Iterable
 import logging
 
 from .meta_block import Block

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -205,7 +205,7 @@ class UController(Block):
     # The presence of the label 't(s)' indicates that the device should return
     # a timestamp along with the data
     if self._labels is not None and self._t_device:
-      self._labels_table.update({'t(s)': 0})
+      self._labels_table |= {'t(s)': 0}
 
     self.log(logging.DEBUG, f"Labels table : {self._labels_table}")
 

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -2,7 +2,7 @@
 
 from struct import unpack
 from time import time
-from typing import Optional, Dict, Callable, Iterable, Union
+from typing import Optional, Callable, Iterable, Union
 import logging
 
 from .meta_block import Block
@@ -32,8 +32,8 @@ class UController(Block):
   def __init__(self,
                labels: Optional[Union[str, Iterable[str]]] = None,
                cmd_labels: Optional[Union[str, Iterable[str]]] = None,
-               init_output: Optional[Dict[str, float]] = None,
-               post_process: Optional[Dict[str,
+               init_output: Optional[dict[str, float]] = None,
+               post_process: Optional[dict[str,
                                            Callable[[float], float]]] = None,
                t_device: bool = False,
                port: str = '/dev/ttyUSB0',

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable, Literal
+from typing import Optional, Callable, Union, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -60,7 +60,7 @@ class VideoExtenso(Camera):
                                               'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
-               img_shape: Optional[Tuple[int, int]] = None,
+               img_shape: Optional[tuple[int, int]] = None,
                img_dtype: Optional[str] = None,
                labels: Optional[Union[str, Iterable[str]]] = None,
                raise_on_lost_spot: bool = True,

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Iterable, Literal
+from typing import Optional, Union, Literal
+from collections.abc import Callable, Iterable
 import numpy as np
 from pathlib import Path
 

--- a/src/crappy/blocks/video_extenso.py
+++ b/src/crappy/blocks/video_extenso.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union, Tuple, Iterable
+from typing import Optional, Callable, Union, Tuple, Iterable, Literal
 import numpy as np
 from pathlib import Path
 
@@ -46,7 +46,7 @@ class VideoExtenso(Camera):
                transform: Optional[Callable[[np.ndarray], np.ndarray]] = None,
                config: bool = True,
                display_images: bool = False,
-               displayer_backend: Optional[str] = None,
+               displayer_backend: Optional[Literal['cv2', 'mpl']] = None,
                displayer_framerate: float = 5,
                software_trig_label: Optional[str] = None,
                display_freq: bool = False,
@@ -56,7 +56,8 @@ class VideoExtenso(Camera):
                img_extension: str = "tiff",
                save_folder: Optional[Union[str, Path]] = None,
                save_period: int = 1,
-               save_backend: Optional[str] = None,
+               save_backend: Optional[Literal['sitk', 'pil', 
+                                              'cv2', 'npy']] = None,
                image_generator: Optional[Callable[[float, float],
                                                   np.ndarray]] = None,
                img_shape: Optional[Tuple[int, int]] = None,

--- a/src/crappy/camera/__init__.py
+++ b/src/crappy/camera/__init__.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from typing import Dict, Type
-
 from .fake_camera import FakeCamera
 from .file_reader import FileReader
 from .opencv_camera_webcam import Webcam
@@ -30,4 +28,4 @@ else:
   from .opencv_camera_basic import CameraOpencv
 
 from ._deprecated import deprecated_cameras
-camera_dict: Dict[str, Type[Camera]] = MetaCamera.classes
+camera_dict: dict[str, type[Camera]] = MetaCamera.classes

--- a/src/crappy/camera/_v4l2_base.py
+++ b/src/crappy/camera/_v4l2_base.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import annotations
-from typing import Tuple, Optional, Callable, Union
+from typing import Optional, Callable, Union
 from re import findall, search, finditer, split, Match, compile
 from dataclasses import dataclass
 import logging
@@ -21,7 +21,7 @@ class V4L2Parameter:
   default: Optional[str] = None
   value: Optional[str] = None
   flags: Optional[str] = None
-  options: Optional[Tuple[str, ...]] = None
+  options: Optional[tuple[str, ...]] = None
 
   # Regex to extract the different parameters and their information
   param_pattern = (r'(\w+)\s+0x\w+\s+\((\w+)\)\s+:\s*'

--- a/src/crappy/camera/_v4l2_base.py
+++ b/src/crappy/camera/_v4l2_base.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from __future__ import annotations
-from typing import Optional, Callable, Union
+from typing import Optional, Union
+from collections.abc import Callable
 from re import findall, search, finditer, split, Match, compile
 from dataclasses import dataclass
 import logging

--- a/src/crappy/camera/cameralink/basler_ironman_cameralink.py
+++ b/src/crappy/camera/cameralink/basler_ironman_cameralink.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, Tuple
+from typing import Optional
 import numpy as np
 import logging
 from  warnings import warn
@@ -132,7 +132,7 @@ class BaslerIronmanCameraLink(Camera):
     self._cap.set(Cl.FG_TRIGGERMODE, 1)
     self._cap.set(Cl.FG_EXSYNCON, 1)
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Reads a frame from the camera and returns it as is."""
 
     ret, frame = self._cap.read()

--- a/src/crappy/camera/cameralink/jai_go_5000c_pmcl.py
+++ b/src/crappy/camera/cameralink/jai_go_5000c_pmcl.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Tuple
+from typing import Optional
 import numpy as np
 import logging
 from  warnings import warn
@@ -166,7 +166,7 @@ class JaiGO5000CPMCL(JaiGO5000CPMCL8Bits):
     self._cap.set(Cl.FG_CAMERA_LINK_CAMTYP, 212)  # Set the input to 12 bits
     self._cap.set(Cl.FG_SENSORREADOUT, 7)  # Sets the correct framegrabber mode
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Grabs a frame using the parent class' method, and returns if after
     shifting bits."""
 

--- a/src/crappy/camera/fake_camera.py
+++ b/src/crappy/camera/fake_camera.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Tuple, Optional
+from typing import Optional
 import numpy as np
 import logging
 
@@ -56,7 +56,7 @@ class FakeCamera(Camera):
 
     self._gen_image()
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Returns the updated image, depending only on the current timestamp.
 
     Also includes a waiting loop in order to achieve the right frame rate.

--- a/src/crappy/camera/file_reader.py
+++ b/src/crappy/camera/file_reader.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Tuple, Union, Optional
+from typing import Union, Optional
 import numpy as np
 from pathlib import Path
 from re import fullmatch
@@ -128,7 +128,7 @@ class FileReader(Camera):
     # The images are stored as an iterator
     self._images = iter(images)
 
-  def get_image(self) -> Optional[Tuple[float, np.ndarray]]:
+  def get_image(self) -> Optional[tuple[float, np.ndarray]]:
     """Reads the next image in the image folder, and returns it at the right
     time so that the achieved framerate matches the original framerate.
 

--- a/src/crappy/camera/gstreamer_camera_basic.py
+++ b/src/crappy/camera/gstreamer_camera_basic.py
@@ -2,7 +2,7 @@
 
 from time import time, sleep
 from numpy import uint8, ndarray, uint16, copy, squeeze
-from typing import Tuple, Optional, Union, List
+from typing import Optional, Union
 from re import findall, search
 from subprocess import Popen, PIPE, run
 from fractions import Fraction
@@ -74,7 +74,7 @@ class CameraGstreamer(Camera):
     self._user_pipeline: Optional[str] = None
     self._nb_channels: int = 3
     self._img_depth: int = 8
-    self._formats: List[str] = list()
+    self._formats: list[str] = list()
     self._app_sink = None
 
   def open(self,
@@ -324,7 +324,7 @@ videoconvert ! autovideosink
     # Setting the kwargs if any
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, ndarray]:
+  def get_image(self) -> tuple[float, ndarray]:
     """Reads the last image acquired from the camera.
 
     Returns:

--- a/src/crappy/camera/gstreamer_camera_v4l2.py
+++ b/src/crappy/camera/gstreamer_camera_v4l2.py
@@ -2,7 +2,7 @@
 
 from time import time, sleep
 from numpy import uint8, ndarray, uint16, copy, squeeze
-from typing import Tuple, Optional, Union, List
+from typing import Optional, Union
 from subprocess import Popen, PIPE, run
 from re import findall, search
 import logging
@@ -75,7 +75,7 @@ class CameraGstreamer(Camera, V4L2Helper):
     self._user_pipeline: Optional[str] = None
     self._nb_channels: int = 3
     self._img_depth: int = 8
-    self._formats: List[str] = list()
+    self._formats: list[str] = list()
     self._app_sink = None
 
   def open(self,
@@ -290,7 +290,7 @@ videoconvert ! autovideosink
     # Setting the kwargs if any
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, ndarray]:
+  def get_image(self) -> tuple[float, ndarray]:
     """Reads the last image acquired from the camera.
 
     Returns:

--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Callable, Optional, Union, Any, Iterable
+from typing import Optional, Union, Any
+from collections.abc import Callable, Iterable
 from time import sleep
 import numpy as np
 from multiprocessing import current_process

--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Callable, Optional, Tuple, Union, Any, Dict, Iterable
+from typing import Callable, Optional, Union, Any, Iterable
 from time import sleep
 import numpy as np
 from multiprocessing import current_process
@@ -37,7 +37,7 @@ class Camera(metaclass=MetaCamera):
     .. versionchanged:: 2.0.0 now accepts *args* and *kwargs*
     """
 
-    self.settings: Dict[str, CameraSetting] = dict()
+    self.settings: dict[str, CameraSetting] = dict()
 
     # These names are reserved for special settings
     self.trigger_name = 'trigger'
@@ -109,7 +109,7 @@ class Camera(metaclass=MetaCamera):
 
     self.set_all(**kwargs)
 
-  def get_image(self) -> Optional[Tuple[Union[Dict[str, Any], float],
+  def get_image(self) -> Optional[tuple[Union[dict[str, Any], float],
                                         np.ndarray]]:
     """Acquires an image and returns it along with its metadata or timestamp.
 

--- a/src/crappy/camera/meta_camera/camera_setting/camera_bool_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_bool_setting.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable
+from typing import Optional
+from collections.abc import Callable
 
 from .camera_setting import CameraSetting
 

--- a/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable
+from typing import Optional
+from collections.abc import Callable
 from itertools import zip_longest
 import logging
 

--- a/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Tuple
+from typing import Optional, Callable
 from itertools import zip_longest
 import logging
 
@@ -21,7 +21,7 @@ class CameraChoiceSetting(CameraSetting):
 
   def __init__(self,
                name: str,
-               choices: Tuple[str, ...],
+               choices: tuple[str, ...],
                getter: Optional[Callable[[], str]] = None,
                setter: Optional[Callable[[str], None]] = None,
                default: Optional[str] = None) -> None:
@@ -45,7 +45,7 @@ class CameraChoiceSetting(CameraSetting):
     self.tk_obj = list()
 
   def reload(self,
-             choices: Tuple[str, ...],
+             choices: tuple[str, ...],
              default: Optional[str] = None) -> None:
     """Allows modifying the choices of the radio buttons once they have been
     instantiated.

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Optional, Callable, Union
+from typing import Optional, Union
+from collections.abc import Callable
 import logging
 
 from .camera_setting import CameraSetting

--- a/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Callable, Optional, Union, Any
+from typing import Optional, Union, Any
+from collections.abc import Callable
 from multiprocessing import current_process
 import logging
 

--- a/src/crappy/camera/opencv_camera_basic.py
+++ b/src/crappy/camera/opencv_camera_basic.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Tuple, Optional
+from typing import Optional
 from numpy import ndarray
 import logging
 from .meta_camera import Camera
@@ -105,7 +105,7 @@ class CameraOpencv(Camera):
     # Setting the kwargs if any
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, ndarray]:
+  def get_image(self) -> tuple[float, ndarray]:
     """Grabs a frame from the videocapture object and returns it along with a
     timestamp."""
 
@@ -130,7 +130,7 @@ class CameraOpencv(Camera):
       self.log(logging.INFO, "Closing the image stream from the camera")
       self._cap.release()
 
-  def _get_min_max(self, prop_id: int) -> Tuple[int, int]:
+  def _get_min_max(self, prop_id: int) -> tuple[int, int]:
     """Gets the min and max values of a parameter."""
 
     self._cap.set(prop_id, 99999)

--- a/src/crappy/camera/opencv_camera_v4l2.py
+++ b/src/crappy/camera/opencv_camera_v4l2.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Tuple, List, Optional
+from typing import Optional
 from numpy import ndarray
 from subprocess import run
 from re import findall, search
@@ -46,7 +46,7 @@ class CameraOpencv(Camera, V4L2Helper):
 
     self._cap = None
     self._device_num: Optional[int] = None
-    self._formats: List[str] = list()
+    self._formats: list[str] = list()
 
   def open(self, device_num: int = 0, **kwargs) -> None:
     """Opens the video stream and sets any user-specified settings.
@@ -131,7 +131,7 @@ class CameraOpencv(Camera, V4L2Helper):
     # Setting the kwargs if any
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, ndarray]:
+  def get_image(self) -> tuple[float, ndarray]:
     """Grabs a frame from the videocapture object and returns it along with a
     timestamp."""
 

--- a/src/crappy/camera/opencv_camera_webcam.py
+++ b/src/crappy/camera/opencv_camera_webcam.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Tuple, Optional
+from typing import Optional
 from numpy import ndarray
 import logging
 from .meta_camera import Camera
@@ -54,7 +54,7 @@ class Webcam(Camera):
     # Setting the kwargs if any
     self.set_all(**kwargs)
 
-  def get_image(self) -> Tuple[float, ndarray]:
+  def get_image(self) -> tuple[float, ndarray]:
     """Grabs a frame from the videocapture object and returns it along with a
     timestamp."""
 

--- a/src/crappy/camera/raspberry_pi_camera.py
+++ b/src/crappy/camera/raspberry_pi_camera.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Tuple, Any, Optional
+from typing import Any, Optional
 import numpy as np
 from threading import Thread, RLock
 import logging
@@ -106,7 +106,7 @@ class RaspberryPiCamera(Camera):
     sleep(1)
     self._started = True
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Simply returns the last image in the acquisition buffer.
 
     The captured image is in GBR format, and converted into black and white if

--- a/src/crappy/camera/seek_thermal_pro.py
+++ b/src/crappy/camera/seek_thermal_pro.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Tuple, List, Any
+from typing import Any
 import numpy as np
 from time import time
 import logging
@@ -158,7 +158,7 @@ MODE=\\"0777\\\"" | sudo tee seek_thermal.rules > /dev/null 2>&1
       elif i == 9:
         raise TimeoutError("Could not set the camera")
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Reads a single image from the camera.
 
     Returns:
@@ -230,7 +230,7 @@ MODE=\\"0777\\\"" | sudo tee seek_thermal.rules > /dev/null 2>&1
     else:
       return status, None
 
-  def _get_dead_pixels_list(self, data: np.ndarray) -> List[Tuple[Any]]:
+  def _get_dead_pixels_list(self, data: np.ndarray) -> list[tuple[Any]]:
     """Identifies the dead pixels on an image.
 
     Args:

--- a/src/crappy/camera/ximea_xiapi.py
+++ b/src/crappy/camera/ximea_xiapi.py
@@ -541,8 +541,8 @@ class XiAPI(Camera):
     and `'Hdw after config'`.
     """
 
-    r = self._cam.get_trigger_source()
-    if r == 'XI_TRG_OFF' and self._trig == 'Hardware':
+    if ((r := self._cam.get_trigger_source()) == 'XI_TRG_OFF' and
+        self._trig == 'Hardware'):
       self._trig = 'Free run'
     elif r != 'XI_TRG_OFF' and self._trig != 'Hardware':
       self._trig = 'Hardware'

--- a/src/crappy/camera/ximea_xiapi.py
+++ b/src/crappy/camera/ximea_xiapi.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, strftime, gmtime
-from typing import Optional, Tuple, Dict, Any, Literal
+from typing import Optional, Any, Literal
 import numpy as np
 import logging
 from warnings import warn
@@ -421,7 +421,7 @@ class XiAPI(Camera):
     self._cam.start_acquisition()
     self._started = True
 
-  def get_image(self) -> Tuple[Dict[str, Any], np.ndarray]:
+  def get_image(self) -> tuple[dict[str, Any], np.ndarray]:
     """Reads a frame from the camera, and returns it along with its metadata.
 
     The acquired metadata contains the following fields :

--- a/src/crappy/camera/ximea_xiapi.py
+++ b/src/crappy/camera/ximea_xiapi.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, strftime, gmtime
-from typing import Optional, Tuple, Dict, Any
+from typing import Optional, Tuple, Dict, Any, Literal
 import numpy as np
 import logging
 from warnings import warn
@@ -82,8 +82,9 @@ class XiAPI(Camera):
   def open(self,
            serial_number: Optional[str] = None,
            timeout: Optional[int] = None,
-           trigger: Optional[str] = None,
-           data_format: Optional[str] = None,
+           trigger: Literal['Free run', 'Hdw after config', 'Hardware'] = None,
+           data_format: Literal['Mono (8 bits)', 'Mono (16 bits)',
+                                'Raw (8 bits)', 'Raw (16 bits)'] = None,
            exposure_time_us: Optional[int] = None,
            gain: Optional[float] = None,
            auto_exposure_auto_gain: Optional[bool] = None,
@@ -94,16 +95,17 @@ class XiAPI(Camera):
            image_height: Optional[int] = None,
            x_offset: Optional[int] = None,
            y_offset: Optional[int] = None,
-           framerate_mode: Optional[str] = None,
+           framerate_mode: Literal['Free run', 'Framerate target',
+                                   'Framerate limit'] = None,
            framerate: Optional[float] = None,
-           downsampling_mode: Optional[str] = None,
+           downsampling_mode: Literal['1x1', '2x2'] = None,
            width: Optional[int] = None,
            height: Optional[int] = None,
            xoffset: Optional[int] = None,
            yoffset: Optional[int] = None,
            exposure: Optional[float] = None,
            AEAG: Optional[bool] = None,
-           external_trig: Optional[bool] = None,) -> None:
+           external_trig: Optional[bool] = None) -> None:
     """Opens the connection to the camera, instantiates the available settings
     and starts the acquisition.
 
@@ -475,7 +477,8 @@ class XiAPI(Camera):
       self.log(logging.INFO, "Closing the connection to the camera")
       self._cam.close_device()
 
-  def _get_data_format(self) -> str:
+  def _get_data_format(self) -> Literal['Mono (8 bits)', 'Mono (16 bits)',
+                                        'Raw (8 bits)', 'Raw (16 bits)']:
     """Returns the current data format of the acquired images."""
 
     return DATA_FORMATS[self._model][self._cam.get_imgdataformat()]
@@ -530,7 +533,7 @@ class XiAPI(Camera):
 
     return self._cam.get_offsetY()
 
-  def _get_extt(self) -> str:
+  def _get_extt(self) -> Literal['Free run', 'Hdw after config', 'Hardware']:
     """Returns the current trigger mode value, and updates the last read
     trigger mode value if needed.
 
@@ -550,17 +553,21 @@ class XiAPI(Camera):
 
     return self._cam.get_framerate()
 
-  def _get_framerate_mode(self) -> str:
+  def _get_framerate_mode(self) -> Literal['Free run', 'Framerate target',
+                                           'Framerate limit']:
     """Returns the current frame rate mode for the camera."""
 
     return FRAMERATE_MODES[self._model][self._cam.get_acq_timing_mode()]
 
-  def _get_downsampling_mode(self) -> str:
+  def _get_downsampling_mode(self) -> Literal['1x1', '2x2']:
     """Returns the current downsampling mode."""
 
     return DOWNSAMPLING_MODES[self._model][self._cam.get_downsampling()]
 
-  def _set_data_format(self, fmt: str) -> None:
+  def _set_data_format(self, fmt: Literal['Mono (8 bits)',
+                                          'Mono (16 bits)',
+                                          'Raw (8 bits)',
+                                          'Raw (16 bits)']) -> None:
     """sets the requested data format."""
 
     if self._started:
@@ -686,7 +693,8 @@ class XiAPI(Camera):
       self.log(logging.DEBUG, "Starting the image acquisition")
       self._cam.start_acquisition()
 
-  def _set_ext_trig(self, trig: str) -> None:
+  def _set_ext_trig(self, trig: Literal['Free run', 'Hdw after config',
+                                        'Hardware']) -> None:
     """Sets the requested trigger mode value, and updates the last requested
     trigger mode value.
 
@@ -710,7 +718,8 @@ class XiAPI(Camera):
       self.log(logging.DEBUG, "Starting the image acquisition")
       self._cam.start_acquisition()
 
-  def _set_framerate_mode(self, mode: str) -> None:
+  def _set_framerate_mode(self, mode: Literal['Free run', 'Framerate target',
+                                              'Framerate limit']) -> None:
     """Sets the framerate mode for the camera to use."""
 
     self._cam.set_acq_timing_mode(FRAMERATE_MODES_INV[self._model][mode])
@@ -730,7 +739,7 @@ class XiAPI(Camera):
                                 "the camera is in free run mode !")
     self._cam.set_framerate(framerate)
 
-  def _set_downsampling_mode(self, mode: str) -> None:
+  def _set_downsampling_mode(self, mode: Literal['1x1', '2x2']) -> None:
     """Sets the downsampling mode on the camera."""
 
     if self._started:

--- a/src/crappy/inout/__init__.py
+++ b/src/crappy/inout/__init__.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from typing import Dict, Type
-
 from .ads1115 import ADS1115
 from .agilent_34420A import Agilent34420a
 from .comedi import Comedi
@@ -36,4 +34,4 @@ from .meta_inout import InOut, MetaIO
 
 # All the inout objects
 from ._deprecated import deprecated_inouts
-inout_dict: Dict[str, Type[InOut]] = MetaIO.classes
+inout_dict: dict[str, type[InOut]] = MetaIO.classes

--- a/src/crappy/inout/ads1115.py
+++ b/src/crappy/inout/ads1115.py
@@ -2,7 +2,7 @@
 
 from time import time
 from re import findall
-from typing import List, Optional
+from typing import List, Optional, Literal
 import logging
 
 from .meta_inout import InOut
@@ -93,12 +93,13 @@ class ADS1115(InOut):
   """
 
   def __init__(self,
-               backend: str,
+               backend: Literal['Pi4', 'blinka'],
                device_address: int = 0x48,
                i2c_port: int = 1,
                sample_rate: int = 128,
                v_range: float = 2.048,
-               multiplexer: str = 'A1',
+               multiplexer: Literal['A0', 'A1', 'A2', 'A3', 'A0 - A1',
+                                    'A0 - A3', 'A1 - A3', 'A2 - A3'] = 'A1',
                dry_pin: Optional[int] = None,
                gain: float = 1,
                offset: float = 0) -> None:

--- a/src/crappy/inout/ads1115.py
+++ b/src/crappy/inout/ads1115.py
@@ -2,7 +2,7 @@
 
 from time import time
 from re import findall
-from typing import List, Optional, Literal
+from typing import Optional, Literal
 import logging
 
 from .meta_inout import InOut
@@ -259,7 +259,7 @@ class ADS1115(InOut):
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(self._dry_pin, GPIO.IN)
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the registers containing the conversion result.
 
     The output is in Volts, unless a gain and offset are applied.

--- a/src/crappy/inout/agilent_34420A.py
+++ b/src/crappy/inout/agilent_34420A.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List
+from typing import List, Literal
 import logging
 from  warnings import warn
 
@@ -27,7 +27,7 @@ class Agilent34420a(InOut):
   """
 
   def __init__(self,
-               mode: bytes = b"VOLT",
+               mode: Literal[b'VOLT', b'RES'] = b"VOLT",
                device: str = '/dev/ttyUSB0',
                baudrate: int = 9600,
                timeout: float = 1) -> None:

--- a/src/crappy/inout/agilent_34420A.py
+++ b/src/crappy/inout/agilent_34420A.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Literal
+from typing import Literal
 import logging
 from  warnings import warn
 
@@ -75,7 +75,7 @@ class Agilent34420a(InOut):
     self.log(logging.DEBUG, f"Writing b'SYST:REM\\n' to port {self._device}")
     self._ser.write(b"SYST:REM\n")
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Asks the Agilent to acquire a value and returns it, except if an error
     occurs in which case `0` is returned."""
 

--- a/src/crappy/inout/comedi.py
+++ b/src/crappy/inout/comedi.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, Iterable
+from typing import Optional
+from collections.abc import Iterable
 from dataclasses import dataclass
 import logging
 from  warnings import warn

--- a/src/crappy/inout/comedi.py
+++ b/src/crappy/inout/comedi.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, List, Iterable
+from typing import Optional, Iterable
 from dataclasses import dataclass
 import logging
 from  warnings import warn
@@ -249,7 +249,7 @@ class Comedi(InOut):
       comedi.comedi_data_write(self._device, self._out_sub_device, chan.num,
                                chan.range_num, comedi.AREF_GROUND, out_a)
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads and returns the value of each channel, adjusted with the given
     gain and offset."""
 

--- a/src/crappy/inout/daqmx.py
+++ b/src/crappy/inout/daqmx.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from time import time
-from typing import List, Optional, Iterable
+from typing import Optional, Iterable
 from dataclasses import dataclass
 import logging
 
@@ -229,7 +229,7 @@ class DAQmx(InOut):
         self._compensations = [comp if chan.make_zero else 0 for comp, chan
                                in zip(self._compensations, self._channels)]
   
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Creates and starts an acquisition task, and returns the acquired
     values."""
 

--- a/src/crappy/inout/daqmx.py
+++ b/src/crappy/inout/daqmx.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 from time import time
-from typing import Optional, Iterable
+from typing import Optional
+from collections.abc import Iterable
 from dataclasses import dataclass
 import logging
 

--- a/src/crappy/inout/fake_inout.py
+++ b/src/crappy/inout/fake_inout.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Optional, Tuple
+from typing import Optional
 import numpy as np
 
 from .meta_inout import InOut
@@ -61,7 +61,7 @@ class FakeInOut(InOut):
       except IndexError:
         return
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Just returns the timestamp and the current memory usage."""
 
     return [time(), virtual_memory().percent]
@@ -82,7 +82,7 @@ class FakeInOut(InOut):
 
     ...
 
-  def get_stream(self) -> Tuple[np.ndarray, np.ndarray]:
+  def get_stream(self) -> tuple[np.ndarray, np.ndarray]:
     """This method calls 10 times the :meth:`get_data` method and returns the
     10 values at once in the streamer format.
 

--- a/src/crappy/inout/ft232h/ads1115.py
+++ b/src/crappy/inout/ft232h/ads1115.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Optional
+from typing import List, Optional, Literal
 import logging
 
 from ..meta_inout import InOut
@@ -62,7 +62,8 @@ class ADS1115FT232H(InOut):
                device_address: int = 0x48,
                sample_rate: int = 128,
                v_range: float = 2.048,
-               multiplexer: str = 'A1',
+               multiplexer: Literal['A0', 'A1', 'A2', 'A3', 'A0 - A1',
+                                    'A0 - A3', 'A1 - A3', 'A2 - A3'] = 'A1',
                dry_pin: Optional[str] = None,
                gain: float = 1,
                offset: float = 0,

--- a/src/crappy/inout/ft232h/ads1115.py
+++ b/src/crappy/inout/ft232h/ads1115.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Optional, Literal
+from typing import Optional, Literal
 import logging
 
 from ..meta_inout import InOut
@@ -180,7 +180,7 @@ class ADS1115FT232H(InOut):
       self._set_register(Ads1115_pointer_lo_thresh, 0x0000)
       self._set_register(Ads1115_pointer_hi_thresh, 0xFFFF)
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the registers containing the conversion result.
 
     The output is in Volts, unless a gain and offset are applied.

--- a/src/crappy/inout/ft232h/mcp9600.py
+++ b/src/crappy/inout/ft232h/mcp9600.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Literal
+from typing import Literal
 import logging
 from  warnings import warn
 
@@ -220,7 +220,7 @@ class MCP9600FT232H(InOut):
                                    Mcp9600_registers['Device Configuration'],
                                    [config_device])
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the registers containing the conversion result.
 
     The output is in `°C` for all modes except the raw data ADC one, which

--- a/src/crappy/inout/ft232h/mcp9600.py
+++ b/src/crappy/inout/ft232h/mcp9600.py
@@ -289,7 +289,7 @@ class MCP9600FT232H(InOut):
     return out
 
   def close(self) -> None:
-    """Switches the MCP9600 to shutdown mode and closes the I2C bus."""
+    """Switches the MCP9600 to shut down mode and closes the I2C bus."""
 
     if self._bus is not None:
       # Switching to shut down mode, keeping configuration

--- a/src/crappy/inout/ft232h/mcp9600.py
+++ b/src/crappy/inout/ft232h/mcp9600.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List
+from typing import List, Literal
 import logging
 from  warnings import warn
 
@@ -80,12 +80,16 @@ class MCP9600FT232H(InOut):
   ft232h = True
 
   def __init__(self,
-               thermocouple_type: str,
+               thermocouple_type: Literal['J', 'K', 'T', 'N', 'S',
+                                          'E', 'B', 'R'],
                device_address: int = 0x67,
                adc_resolution: int = 18,
                sensor_resolution: float = 0.0625,
                filter_coefficient: int = 0,
-               mode: str = 'Hot Junction Temperature',
+               mode: Literal['Hot Junction Temperature',
+                             'Junction Temperature Delta',
+                             'Cold Junction Temperature',
+                             'Raw Data ADC'] = 'Hot Junction Temperature',
                _ft232h_args: USBArgsType = tuple()) -> None:
     """Checks the validity of the arguments.
 

--- a/src/crappy/inout/ft232h/mprls.py
+++ b/src/crappy/inout/ft232h/mprls.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, List
+from typing import Optional
 import logging
 
 from ..meta_inout import InOut
@@ -77,7 +77,7 @@ class MPRLSFT232H(InOut):
 
     self._i2c_msg = I2CMessage
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the pressure value.
 
     Returns:

--- a/src/crappy/inout/ft232h/nau7802.py
+++ b/src/crappy/inout/ft232h/nau7802.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Optional, List
+from typing import Optional
 import logging
 
 from ..meta_inout import InOut
@@ -247,7 +247,7 @@ class NAU7802FT232H(InOut):
       if self._cal_afe_status() == NAU7802_Cal_Status['CAL_FAILURE']:
         raise IOError("Calibration failed !")
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the registers containing the conversion result.
 
     The output is in Volts by default, and can be converted to Newtons using

--- a/src/crappy/inout/ft232h/waveshare_ad_da.py
+++ b/src/crappy/inout/ft232h/waveshare_ad_da.py
@@ -2,7 +2,8 @@
 
 from time import time, sleep
 from re import fullmatch, findall
-from typing import Union, Optional, Iterable, Literal
+from typing import Union, Optional, Literal
+from collections.abc import Iterable
 import logging
 from  warnings import warn
 

--- a/src/crappy/inout/ft232h/waveshare_ad_da.py
+++ b/src/crappy/inout/ft232h/waveshare_ad_da.py
@@ -2,7 +2,7 @@
 
 from time import time, sleep
 from re import fullmatch, findall
-from typing import List, Union, Optional, Iterable
+from typing import List, Union, Optional, Iterable, Literal
 import logging
 from  warnings import warn
 
@@ -89,7 +89,8 @@ class WaveshareADDAFT232H(InOut):
   ft232h = True
 
   def __init__(self,
-               dac_channels: Optional[Iterable[str]] = None,
+               dac_channels: Optional[Iterable[Literal['DAC0',
+                                                       'DAC1']]] = None,
                adc_channels: Optional[Iterable[str]] = None,
                gain_hardware: int = 1,
                v_ref: float = 3.3,

--- a/src/crappy/inout/ft232h/waveshare_ad_da.py
+++ b/src/crappy/inout/ft232h/waveshare_ad_da.py
@@ -2,7 +2,7 @@
 
 from time import time, sleep
 from re import fullmatch, findall
-from typing import List, Union, Optional, Iterable, Literal
+from typing import Union, Optional, Iterable, Literal
 import logging
 from  warnings import warn
 
@@ -289,7 +289,7 @@ class WaveshareADDAFT232H(InOut):
     self._bus.set_gpio(self._cs_pin_ads, True)
     sleep(0.001)
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads data from all the user-specified ADC channels, in a sequential
     way.
 

--- a/src/crappy/inout/gpio_switch.py
+++ b/src/crappy/inout/gpio_switch.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Union
+from typing import Union, Literal
 import logging
 
 from .meta_inout import InOut
@@ -37,7 +37,7 @@ class GPIOSwitch(InOut):
 
   def __init__(self,
                pin_out: Union[int, str],
-               backend: str) -> None:
+               backend: Literal['Pi4', 'blinka']) -> None:
     """Checks the validity of the arguments.
 
     Args:

--- a/src/crappy/inout/kollmorgen_akd_pdmm.py
+++ b/src/crappy/inout/kollmorgen_akd_pdmm.py
@@ -2,7 +2,8 @@
 
 from time import time
 from struct import pack, unpack
-from typing import Iterable, Literal
+from typing import Literal
+from collections.abc import Iterable
 import logging
 from  warnings import warn
 

--- a/src/crappy/inout/kollmorgen_akd_pdmm.py
+++ b/src/crappy/inout/kollmorgen_akd_pdmm.py
@@ -2,7 +2,7 @@
 
 from time import time
 from struct import pack, unpack
-from typing import List, Iterable
+from typing import List, Iterable, Literal
 import logging
 from  warnings import warn
 
@@ -47,7 +47,7 @@ class KollmorgenAKDPDMM(InOut):
 
   def __init__(self,
                axes: Iterable[int],
-               mode: str = 'position',
+               mode: Literal['position', 'speed'] = 'position',
                host: str = '192.168.0.109',
                port: int = 502) -> None:
     """Sets the arguments and initializes the parent class.

--- a/src/crappy/inout/kollmorgen_akd_pdmm.py
+++ b/src/crappy/inout/kollmorgen_akd_pdmm.py
@@ -2,7 +2,7 @@
 
 from time import time
 from struct import pack, unpack
-from typing import List, Iterable, Literal
+from typing import Iterable, Literal
 import logging
 from  warnings import warn
 
@@ -96,7 +96,7 @@ class KollmorgenAKDPDMM(InOut):
                            f"{self._host} on port {self._port}")
     self._variator.connect()
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """For each motor, reads its current speed or position depending on the
     selected mode.
 

--- a/src/crappy/inout/labjack_t7.py
+++ b/src/crappy/inout/labjack_t7.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Optional, Dict, Any, Union, Tuple, Iterable
+from typing import List, Optional, Dict, Any, Union, Tuple, Iterable, Literal
 from itertools import chain
 from dataclasses import dataclass, field
 from multiprocessing import current_process
@@ -40,7 +40,7 @@ class _Channel:
   range: float = 10
   limits: Optional[Tuple[float, float]] = None
   resolution: int = 1
-  thermocouple: Optional[str] = None
+  thermocouple: Optional[Literal['E', 'J', 'K', 'R', 'T', 'S', 'C']] = None
   write_at_open: List[Tuple[str, float]] = field(default_factory=list)
 
   def update(self, dic_in: Dict[str, Any]) -> None:
@@ -75,8 +75,9 @@ class LabjackT7(InOut):
 
   def __init__(self,
                channels: Iterable[Dict[str, Any]],
-               device: str = 'ANY',
-               connection: str = 'ANY',
+               device: Literal['ANY', 'T7', 'T4', 'DIGIT'] = 'ANY',
+               connection: Literal['ANY', 'TCP', 'USB',
+                                   'ETHERNET', 'WIFI'] = 'ANY',
                identifier: str = 'ANY',
                write_at_open: Optional[Iterable[tuple]] = None,
                no_led: bool = False) -> None:

--- a/src/crappy/inout/labjack_t7.py
+++ b/src/crappy/inout/labjack_t7.py
@@ -379,7 +379,7 @@ class LabjackT7(InOut):
 
   def get_data(self) -> List[float]:
     """Reads the signal on all pre-defined input channels, and returns the
-    values along with a timestamp.."""
+    values along with a timestamp."""
 
     return [time()] + ljm.eReadAddresses(handle=self._handle,
                                          numFrames=len(self._read_addresses),

--- a/src/crappy/inout/labjack_t7.py
+++ b/src/crappy/inout/labjack_t7.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Optional, Dict, Any, Union, Tuple, Iterable, Literal
+from typing import Optional, Any, Union, Iterable, Literal
 from itertools import chain
 from dataclasses import dataclass, field
 from multiprocessing import current_process
@@ -38,12 +38,12 @@ class _Channel:
   offset: float = 0
   make_zero: bool = False
   range: float = 10
-  limits: Optional[Tuple[float, float]] = None
+  limits: Optional[tuple[float, float]] = None
   resolution: int = 1
   thermocouple: Optional[Literal['E', 'J', 'K', 'R', 'T', 'S', 'C']] = None
-  write_at_open: List[Tuple[str, float]] = field(default_factory=list)
+  write_at_open: list[tuple[str, float]] = field(default_factory=list)
 
-  def update(self, dic_in: Dict[str, Any]) -> None:
+  def update(self, dic_in: dict[str, Any]) -> None:
     """Updates the channel keys based on the user input."""
 
     for key, val in dic_in.items():
@@ -74,7 +74,7 @@ class LabjackT7(InOut):
   """
 
   def __init__(self,
-               channels: Iterable[Dict[str, Any]],
+               channels: Iterable[dict[str, Any]],
                device: Literal['ANY', 'T7', 'T4', 'DIGIT'] = 'ANY',
                connection: Literal['ANY', 'TCP', 'USB',
                                    'ETHERNET', 'WIFI'] = 'ANY',
@@ -377,7 +377,7 @@ class LabjackT7(InOut):
         # Resetting the software offsets to avoid double compensation
         self._compensations = list()
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the signal on all pre-defined input channels, and returns the
     values along with a timestamp."""
 
@@ -435,7 +435,7 @@ class LabjackT7(InOut):
       ljm.close(self._handle)
 
   @staticmethod
-  def _parse(name: str) -> Tuple[int, int]:
+  def _parse(name: str) -> tuple[int, int]:
     """Wrapper around :meth:`ljm.nameToAddress` to make the code clearer."""
 
     return ljm.nameToAddress(name)

--- a/src/crappy/inout/labjack_t7.py
+++ b/src/crappy/inout/labjack_t7.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, Any, Union, Iterable, Literal
+from typing import Optional, Any, Union, Literal
+from collections.abc import Iterable
 from itertools import chain
 from dataclasses import dataclass, field
 from multiprocessing import current_process

--- a/src/crappy/inout/labjack_t7_streamer.py
+++ b/src/crappy/inout/labjack_t7_streamer.py
@@ -2,7 +2,8 @@
 
 from time import time
 import numpy as np
-from typing import Any, Optional, Iterable, Literal
+from typing import Any, Optional, Literal
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from itertools import chain
 from multiprocessing import current_process

--- a/src/crappy/inout/labjack_t7_streamer.py
+++ b/src/crappy/inout/labjack_t7_streamer.py
@@ -2,7 +2,7 @@
 
 from time import time
 import numpy as np
-from typing import List, Dict, Any, Optional, Tuple, Iterable
+from typing import List, Dict, Any, Optional, Tuple, Iterable, Literal
 from dataclasses import dataclass, field
 from itertools import chain
 from multiprocessing import current_process
@@ -72,8 +72,9 @@ class T7Streamer(InOut):
 
   def __init__(self,
                channels: Iterable[Dict[str, Any]],
-               device: str = 'ANY',
-               connection: str = 'ANY',
+               device: Literal['ANY', 'T7', 'T4', 'DIGIT']  = 'ANY',
+               connection: Literal['ANY', 'TCP', 'USB',
+                                   'ETHERNET', 'WIFI'] = 'ANY',
                identifier: str = 'ANY',
                scan_rate: int = 100000,
                scan_per_read: int = 10000,

--- a/src/crappy/inout/labjack_t7_streamer.py
+++ b/src/crappy/inout/labjack_t7_streamer.py
@@ -2,7 +2,7 @@
 
 from time import time
 import numpy as np
-from typing import List, Dict, Any, Optional, Tuple, Iterable, Literal
+from typing import Any, Optional, Iterable, Literal
 from dataclasses import dataclass, field
 from itertools import chain
 from multiprocessing import current_process
@@ -30,9 +30,9 @@ class _Channel:
   offset: float = 0
   make_zero: bool = False
   range: float = 10
-  write_at_open: List[Tuple[str, Any]] = field(default_factory=list)
+  write_at_open: list[tuple[str, Any]] = field(default_factory=list)
 
-  def update(self, dic_in: Dict[str, Any]) -> None:
+  def update(self, dic_in: dict[str, Any]) -> None:
     """Updates the channel keys based on the user input."""
 
     for key, val in dic_in.items():
@@ -71,7 +71,7 @@ class T7Streamer(InOut):
   """
 
   def __init__(self,
-               channels: Iterable[Dict[str, Any]],
+               channels: Iterable[dict[str, Any]],
                device: Literal['ANY', 'T7', 'T4', 'DIGIT']  = 'ANY',
                connection: Literal['ANY', 'TCP', 'USB',
                                    'ETHERNET', 'WIFI'] = 'ANY',
@@ -248,7 +248,7 @@ class T7Streamer(InOut):
     self._stream_t0 = time()
     self._stream_started = True
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads single data points, applies the given gains and offsets, and
     returns the data along with a timestamp."""
 
@@ -259,7 +259,7 @@ class T7Streamer(InOut):
     return [time()] + [val * chan.gain + chan.offset for chan, val
                        in zip(self._channels, data)]
 
-  def get_stream(self) -> Optional[List[np.ndarray]]:
+  def get_stream(self) -> Optional[list[np.ndarray]]:
     """Acquires the stream, reshapes the data, applies the gains and offsets,
     and returns the data along with a time array."""
 

--- a/src/crappy/inout/labjack_ue9.py
+++ b/src/crappy/inout/labjack_ue9.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, Iterable
+from typing import Optional
+from collections.abc import Iterable
 from dataclasses import dataclass
 import logging
 from  warnings import warn

--- a/src/crappy/inout/labjack_ue9.py
+++ b/src/crappy/inout/labjack_ue9.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, List, Iterable
+from typing import Optional, Iterable
 from dataclasses import dataclass
 import logging
 from  warnings import warn
@@ -135,7 +135,7 @@ class LabjackUE9(InOut):
         self._compensations = [comp if chan.make_zero else 0 for comp, chan
                                in zip(self._compensations, self._channels)]
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads sequentially the channels and returns the acquired values,
     corrected by the given gains and offsets."""
 

--- a/src/crappy/inout/mcp9600.py
+++ b/src/crappy/inout/mcp9600.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List, Literal
+from typing import Literal
 import logging
 from  warnings import warn
 
@@ -271,7 +271,7 @@ class MCP9600(InOut):
                                      Mcp9600_registers['Device Configuration'],
                                      [config_device])
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the registers containing the conversion result.
 
     The output is in `°C` for all modes except the raw data ADC one, which

--- a/src/crappy/inout/mcp9600.py
+++ b/src/crappy/inout/mcp9600.py
@@ -350,7 +350,7 @@ class MCP9600(InOut):
     return out
 
   def close(self) -> None:
-    """Switches the MCP9600 to shutdown mode and closes the I2C bus."""
+    """Switches the MCP9600 to shut down mode and closes the I2C bus."""
 
     if self._backend != 'blinka' and self._bus is not None:
       # Switching to shut down mode, keeping configuration

--- a/src/crappy/inout/mcp9600.py
+++ b/src/crappy/inout/mcp9600.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import List
+from typing import List, Literal
 import logging
 from  warnings import warn
 
@@ -104,14 +104,19 @@ class MCP9600(InOut):
   """
 
   def __init__(self,
-               backend: str,
-               thermocouple_type: str,
+               backend: Literal['Pi4', 'blinka'],
+               thermocouple_type: Literal['J', 'K', 'T', 'N', 'S',
+                                          'E', 'B', 'R'],
                i2c_port: int = 1,
                device_address: int = 0x67,
                adc_resolution: int = 18,
                sensor_resolution: float = 0.0625,
                filter_coefficient: int = 0,
-               mode: str = 'Hot Junction Temperature') -> None:
+               mode: Literal['Hot Junction Temperature',
+                             'Junction Temperature Delta',
+                             'Cold Junction Temperature',
+                             'Raw Data ADC'] = 'Hot Junction Temperature'
+               ) -> None:
     """Checks the validity of the arguments.
 
     Args:

--- a/src/crappy/inout/meta_inout/inout.py
+++ b/src/crappy/inout/meta_inout/inout.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Optional, Dict, Any, Union, List, Iterable
+from typing import Optional, Any, Union, Iterable
 import numpy as np
 import logging
 from multiprocessing import current_process
@@ -28,8 +28,8 @@ class InOut(metaclass=MetaIO):
     .. versionchanged:: 2.0.0 now accepts args and kwargs
     """
 
-    self._compensations: List[float] = list()
-    self._compensations_dict: Dict[str, float] = dict()
+    self._compensations: list[float] = list()
+    self._compensations_dict: dict[str, float] = dict()
     self._logger: Optional[logging.Logger] = None
 
   def log(self, level: int, msg: str) -> None:
@@ -67,7 +67,7 @@ class InOut(metaclass=MetaIO):
 
     ...
 
-  def get_data(self) -> Optional[Union[Iterable, Dict[str, Any]]]:
+  def get_data(self) -> Optional[Union[Iterable, dict[str, Any]]]:
     """This method should acquire data from a device and return it along with a
     timestamp.
 
@@ -147,7 +147,7 @@ class InOut(metaclass=MetaIO):
                               "defined !")
 
   def get_stream(self) -> Optional[Union[Iterable[np.ndarray],
-                                         Dict[str, np.ndarray]]]:
+                                         dict[str, np.ndarray]]]:
     """This method should acquire a stream as a :obj:`numpy.array`, and return
     it along with another array carrying the timestamps.
 
@@ -282,7 +282,7 @@ class InOut(metaclass=MetaIO):
                    "the InOut doesn't return only numbers in the dict")
           return
 
-  def return_data(self) -> Optional[Union[List[Any], Dict[str, Any]]]:
+  def return_data(self) -> Optional[Union[list[Any], dict[str, Any]]]:
     """Returns the data from :meth:`get_data`, corrected by an offset if the
     ``make_zero_delay`` argument of the :class:`~crappy.blocks.IOBlock` is
     set.
@@ -337,8 +337,8 @@ class InOut(metaclass=MetaIO):
         raise ValueError("The number of offsets doesn't match the number of "
                          "acquired values.")
 
-  def return_stream(self) -> Optional[Union[List[np.ndarray],
-                                            Dict[str, np.ndarray]]]:
+  def return_stream(self) -> Optional[Union[list[np.ndarray],
+                                            dict[str, np.ndarray]]]:
     """Returns the data from :meth:`get_stream`, corrected by an offset if the
     ``make_zero_delay`` argument of the :class:`~crappy.blocks.IOBlock` is
     set.

--- a/src/crappy/inout/meta_inout/inout.py
+++ b/src/crappy/inout/meta_inout/inout.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Optional, Any, Union, Iterable
+from typing import Optional, Any, Union
+from collections.abc import Iterable
 import numpy as np
 import logging
 from multiprocessing import current_process

--- a/src/crappy/inout/mprls.py
+++ b/src/crappy/inout/mprls.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Union, Optional, List, Literal
+from typing import Union, Optional, Literal
 import logging
 
 from .meta_inout import InOut
@@ -148,7 +148,7 @@ class MPRLS(InOut):
 
     self._i2c_msg = i2c_msg
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the pressure value.
 
     Returns:

--- a/src/crappy/inout/mprls.py
+++ b/src/crappy/inout/mprls.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Union, Optional, List
+from typing import Union, Optional, List, Literal
 import logging
 
 from .meta_inout import InOut
@@ -49,7 +49,7 @@ class MPRLS(InOut):
   """
 
   def __init__(self,
-               backend: str,
+               backend: Literal['Pi4', 'blinka'],
                eoc_pin: Optional[Union[str, int]] = None,
                device_address: int = 0x18,
                i2c_port: int = 1) -> None:

--- a/src/crappy/inout/nau7802.py
+++ b/src/crappy/inout/nau7802.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time, sleep
-from typing import Optional, List
+from typing import Optional
 import logging
 
 from .meta_inout import InOut
@@ -252,7 +252,7 @@ class NAU7802(InOut):
       GPIO.setmode(GPIO.BCM)
       GPIO.setup(self._int_pin, GPIO.IN)
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the registers containing the conversion result.
 
     The output is in Volts by default, and can be converted to Newtons using

--- a/src/crappy/inout/ni_daqmx.py
+++ b/src/crappy/inout/ni_daqmx.py
@@ -55,7 +55,7 @@ class _Channel:
 
       # All the other keys are put together in the kwargs attribute
       else:
-        self.kwargs.update({key: val})
+        self.kwargs |= {key: val}
 
 
 class NIDAQmx(InOut):

--- a/src/crappy/inout/ni_daqmx.py
+++ b/src/crappy/inout/ni_daqmx.py
@@ -2,7 +2,7 @@
 
 from time import time
 import numpy as np
-from typing import List, Optional, Dict, Any, Iterable
+from typing import Optional, Any, Iterable
 from dataclasses import dataclass, field
 from re import fullmatch
 from collections import defaultdict
@@ -41,9 +41,9 @@ class _Channel:
 
   meas_type: str = 'voltage'
   name: Optional[str] = None
-  kwargs: Dict[str, Any] = field(default_factory=dict)
+  kwargs: dict[str, Any] = field(default_factory=dict)
 
-  def update(self, dic_in: Dict[str, Any]) -> None:
+  def update(self, dic_in: dict[str, Any]) -> None:
     """Updates the channel keys based on the user input."""
 
     for key, val in dic_in.items():
@@ -75,7 +75,7 @@ class NIDAQmx(InOut):
   """
 
   def __init__(self,
-               channels: Iterable[Dict[str, Any]],
+               channels: Iterable[dict[str, Any]],
                sample_rate: float = 100,
                n_samples: Optional[int] = None) -> None:
     """Sets the arguments and initializes the parent class.
@@ -295,7 +295,7 @@ class NIDAQmx(InOut):
 
     self._stream_started = True
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads data from the analog and digital input channels, and returns it
     along with a timestamp.
 
@@ -324,7 +324,7 @@ class NIDAQmx(InOut):
 
     return ret
 
-  def get_stream(self) -> Optional[List[np.ndarray]]:
+  def get_stream(self) -> Optional[list[np.ndarray]]:
     """Reads data from the device, and returns it in an array along with an
     array holding the timestamps.
 

--- a/src/crappy/inout/ni_daqmx.py
+++ b/src/crappy/inout/ni_daqmx.py
@@ -2,7 +2,8 @@
 
 from time import time
 import numpy as np
-from typing import Optional, Any, Iterable
+from typing import Optional, Any
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from re import fullmatch
 from collections import defaultdict

--- a/src/crappy/inout/opsens_handysens.py
+++ b/src/crappy/inout/opsens_handysens.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 from time import time
-from typing import List
 import logging
 from  warnings import warn
 
@@ -53,7 +52,7 @@ class HandySens(InOut):
     self._dev = serial.Serial(port=self._addr, baudrate=57600, timeout=0.1)
     self._send_cmd("meas:rate min")
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads data from the OpSens and returns it."""
 
     return [time(), float(self._send_cmd("ch1:data? 1")[:-3])]

--- a/src/crappy/inout/phidgets_wheatstone_bridge.py
+++ b/src/crappy/inout/phidgets_wheatstone_bridge.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from time import time
-from typing import Optional, List
+from typing import Optional
 import logging
 from math import log2
 
@@ -103,7 +103,7 @@ class PhidgetWheatstoneBridge(InOut):
     except PhidgetException:
       raise TimeoutError("Waited too long for the motor to attach !")
 
-  def get_data(self) -> Optional[List[float]]:
+  def get_data(self) -> Optional[list[float]]:
     """Returns the last known voltage ratio value, adjusted with the gain and
     the offset."""
 

--- a/src/crappy/inout/phidgets_wheatstone_bridge.py
+++ b/src/crappy/inout/phidgets_wheatstone_bridge.py
@@ -128,9 +128,8 @@ class PhidgetWheatstoneBridge(InOut):
     self._load_cell.setBridgeGain(int(round(log2(self._hardware_gain), 0) + 1))
 
     # Setting the data rate
-    min_rate = self._load_cell.getMinDataRate()
-    max_rate = self._load_cell.getMaxDataRate()
-    if not min_rate <= self._data_rate <= max_rate:
+    if not ((min_rate := self._load_cell.getMinDataRate()) <= self._data_rate
+            <= (max_rate := self._load_cell.getMaxDataRate())):
       raise ValueError(f"The data rate should be between {min_rate} and "
                        f"{max_rate}, got {self._data_rate} !")
     else:

--- a/src/crappy/inout/pijuice_hat.py
+++ b/src/crappy/inout/pijuice_hat.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Literal
 from time import time
 import logging
 from  warnings import warn
@@ -58,7 +58,7 @@ class PiJuice(InOut):
   def __init__(self,
                i2c_port: int = 1,
                address: int = 0x14,
-               backend: str = 'Pi4') -> None:
+               backend: Literal['Pi4', 'blinka'] = 'Pi4') -> None:
     """Checks the validity of the arguments.
 
     Args:

--- a/src/crappy/inout/pijuice_hat.py
+++ b/src/crappy/inout/pijuice_hat.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Dict, Any, List, Literal
+from typing import Any, Literal
 from time import time
 import logging
 from  warnings import warn
@@ -109,7 +109,7 @@ class PiJuice(InOut):
                              f"port {self._i2c_port} with backend pijuice")
       self._pijuice = PiJuiceModule(self._i2c_port, self._address)
 
-  def get_data(self) -> Dict[str, Any]:
+  def get_data(self) -> dict[str, Any]:
     """Reads all the available information on the battery status.
 
     Returns:
@@ -217,7 +217,7 @@ class PiJuice(InOut):
       self._bus.close()
 
   @staticmethod
-  def _checksum(data: List[int]) -> List[int]:
+  def _checksum(data: list[int]) -> list[int]:
     """Compares the received checksum (last byte) to the one calculated over
     the other bytes.
 

--- a/src/crappy/inout/sim868.py
+++ b/src/crappy/inout/sim868.py
@@ -96,8 +96,7 @@ class Sim868(InOut):
     ret = ''
     while time() - t < 2:
       # Reading the answers
-      ret = self._ser.readline().strip().decode()
-      if ret:
+      if ret := self._ser.readline().strip().decode():
         self.log(logging.DEBUG, f"Read {ret} from port {self._port}")
       # Just waiting for the answer to be 'OK'
       if 'OK' in ret:
@@ -121,13 +120,11 @@ class Sim868(InOut):
     need_pin = False
     while time() - t < 2:
       # Reading the answers
-      ret = self._ser.readline().strip().decode()
-      if ret:
+      if ret := self._ser.readline().strip().decode():
         self.log(logging.DEBUG, f"Read {ret} from port {self._port}")
 
       # Expecting an answer giving the SIM status, and parsing it
-      status = fullmatch(r'\+CPIN:\s(.+)', ret)
-      if status is not None:
+      if (status := fullmatch(r'\+CPIN:\s(.+)', ret)) is not None:
         status, = status.groups()
         # Several possible answers from the Sim868
         if status == 'READY':
@@ -168,8 +165,7 @@ class Sim868(InOut):
         ret = ''
         while time() - t < 2:
           # Reading the answers
-          ret = self._ser.readline().strip().decode()
-          if ret:
+          if ret := self._ser.readline().strip().decode():
             self.log(logging.DEBUG, f"Read {ret} from port {self._port}")
 
           # Only exiting when receiving the final answer 'OK'
@@ -197,13 +193,11 @@ class Sim868(InOut):
         ret = ''
         while time() - t < 2:
           # Reading the answers
-          ret = self._ser.readline().strip().decode()
-          if ret:
+          if ret := self._ser.readline().strip().decode():
             self.log(logging.DEBUG, f"Read {ret} from port {self._port}")
 
           # Expecting an answer giving the SIM status, and parsing it
-          status = fullmatch(r'\+CPIN:\s(.+)', ret)
-          if status is not None:
+          if (status := fullmatch(r'\+CPIN:\s(.+)', ret)) is not None:
             status, = status.groups()
             # Several possible answers from the Sim868
             if status == 'READY':
@@ -238,13 +232,11 @@ class Sim868(InOut):
       # Reading the answers
       while time() - t < self._reg_timeout:
         # Sometimes the Sim868 sends back non UTF-8 characters, ignoring them
-        ret = self._ser.readline().strip().decode()
-        if ret:
+        if ret := self._ser.readline().strip().decode():
           self.log(logging.DEBUG, f"Read {ret} from port {self._port}")
 
         # Expecting an answer giving the registration status, and parsing it
-        status = fullmatch(r'\+CGREG:\s\d,(\d).*', ret)
-        if status is not None:
+        if (status := fullmatch(r'\+CGREG:\s\d,(\d).*', ret)) is not None:
           status, = status.groups()
           # Several possible answers from the Sim868
           if status in ('0', '3', '4'):
@@ -292,8 +284,7 @@ class Sim868(InOut):
     ret = ''
     while time() - t < 9:
       # Reading the answers
-      ret = self._ser.readline().strip().decode()
-      if ret:
+      if ret := self._ser.readline().strip().decode():
         self.log(logging.DEBUG, f"Read {ret} from port {self._port}")
 
       # Only exiting when receiving the final answer 'OK'
@@ -365,8 +356,7 @@ class Sim868(InOut):
           ret = ''
           while time() - t < 2:
             # Reading the answers
-            ret = self._ser.readline().strip().decode()
-            if ret:
+            if ret := self._ser.readline().strip().decode():
               self.log(logging.DEBUG, f"Read {ret} from port {self._port}")
 
             # Only exiting when receiving the final answer 'OK'

--- a/src/crappy/inout/sim868.py
+++ b/src/crappy/inout/sim868.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 from time import sleep, time
-from typing import Iterable, Optional
+from typing import Optional
+from collections.abc import Iterable
 from re import fullmatch
 import logging
 from  warnings import warn

--- a/src/crappy/inout/spectrum_m2i4711.py
+++ b/src/crappy/inout/spectrum_m2i4711.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from time import time
-from typing import List, Optional, Iterable
+from typing import Optional, Iterable
 import logging
 from  warnings import warn
 
@@ -129,7 +129,7 @@ class SpectrumM2I4711(InOut):
     self._stream_t0 = time()
     self._stream_started = True
 
-  def get_stream(self) -> List[np.ndarray]:
+  def get_stream(self) -> list[np.ndarray]:
     """Waits for data to be available, and returns it along with an array of
     timestamps."""
 

--- a/src/crappy/inout/spectrum_m2i4711.py
+++ b/src/crappy/inout/spectrum_m2i4711.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 from time import time
-from typing import Optional, Iterable
+from typing import Optional
+from collections.abc import Iterable
 import logging
 from  warnings import warn
 

--- a/src/crappy/inout/waveshare_ad_da.py
+++ b/src/crappy/inout/waveshare_ad_da.py
@@ -3,7 +3,8 @@
 import time
 from time import sleep, time
 from re import fullmatch, findall
-from typing import Union, Optional, Iterable
+from typing import Union, Optional
+from collections.abc import Iterable
 import logging
 from  warnings import warn
 

--- a/src/crappy/inout/waveshare_ad_da.py
+++ b/src/crappy/inout/waveshare_ad_da.py
@@ -3,7 +3,7 @@
 import time
 from time import sleep, time
 from re import fullmatch, findall
-from typing import Union, Optional, List, Iterable
+from typing import Union, Optional, Iterable
 import logging
 from  warnings import warn
 
@@ -284,7 +284,7 @@ class WaveshareADDA(InOut):
     GPIO.output(AD_DA_pins['CS_PIN_ADS'], GPIO.HIGH)
     sleep(0.001)
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads data from all the user-specified ADC channels, in a sequential
     way.
 

--- a/src/crappy/inout/waveshare_high_precision.py
+++ b/src/crappy/inout/waveshare_high_precision.py
@@ -2,7 +2,7 @@
 
 from time import time, sleep
 from re import fullmatch, findall
-from typing import Union, List, Optional, Iterable
+from typing import Union, Optional, Iterable
 import logging
 from  warnings import warn
 
@@ -271,7 +271,7 @@ class WaveshareHighPrecision(InOut):
     # Starting the acquisition
     self._write_cmd(ADS1263_CMD['CMD_START1'])
 
-  def get_data(self) -> List[float]:
+  def get_data(self) -> list[float]:
     """Reads the channels sequentially, and returns all the values along with a
     timestamp.
 

--- a/src/crappy/inout/waveshare_high_precision.py
+++ b/src/crappy/inout/waveshare_high_precision.py
@@ -2,7 +2,8 @@
 
 from time import time, sleep
 from re import fullmatch, findall
-from typing import Union, Optional, Iterable
+from typing import Union, Optional
+from collections.abc import Iterable
 import logging
 from  warnings import warn
 

--- a/src/crappy/lamcube/bispectral.py
+++ b/src/crappy/lamcube/bispectral.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Tuple
 import logging
 from warnings import warn
 
@@ -121,7 +120,7 @@ class BiSpectral(BaslerIronmanCameraLink):
     self._send_cmd('@W1A084')  # Restore unwindowed Mode
     self._send_cmd('@W10012')  # Make sure the image is not inverted
 
-  def get_image(self) -> Tuple[float, np.ndarray]:
+  def get_image(self) -> tuple[float, np.ndarray]:
     """Grabs an image using the parent class' method, transforms it, and
     returns it."""
 
@@ -151,7 +150,7 @@ class BiSpectral(BaslerIronmanCameraLink):
     else:
       self._send_cmd('@W10274')  # 3rd bit to 0
 
-  def _get_roi(self) -> Tuple[int, int, int, int]:
+  def _get_roi(self) -> tuple[int, int, int, int]:
     """Returns the minimum and maximum x and y coordinates of the current
     ROI."""
 
@@ -194,7 +193,7 @@ class BiSpectral(BaslerIronmanCameraLink):
     self._send_cmd("@W1D6" + lsb_ymax)
     self._send_cmd("@W1D7" + msb_ymax)
 
-  def _get_it(self) -> Tuple[float, float]:
+  def _get_it(self) -> tuple[float, float]:
     """Reads the integration time from the Camera and returns it."""
 
     mc = 10.35  # MHz

--- a/src/crappy/links/link.py
+++ b/src/crappy/links/link.py
@@ -3,7 +3,7 @@
 from multiprocessing import Pipe
 from time import time
 from copy import deepcopy
-from typing import Callable, Union, Any, Dict, Optional, List, Iterable
+from typing import Callable, Union, Any, Optional, Iterable
 from collections import defaultdict
 from select import select
 from platform import system
@@ -12,7 +12,7 @@ import logging
 
 from .._global import LinkDataError
 
-ModifierType = Callable[[Dict[str, Any]], Dict[str, Any]]
+ModifierType = Callable[[dict[str, Any]], dict[str, Any]]
 
 
 class Link:
@@ -37,7 +37,7 @@ class Link:
   def __init__(self,
                input_block,
                output_block,
-               modifiers: Optional[List[ModifierType]] = None,
+               modifiers: Optional[list[ModifierType]] = None,
                name: Optional[str] = None) -> None:
     """Sets the instance attributes.
 
@@ -113,7 +113,7 @@ class Link:
 
     return self._in.poll()
 
-  def send(self, value: Dict[str, Any]) -> None:
+  def send(self, value: dict[str, Any]) -> None:
     """Sends a value from the upstream Block to the downstream Block.
 
     Before sending, applies the given Modifiers and makes sure there's room in
@@ -145,7 +145,7 @@ class Link:
     else:
       self._out.send(value)
 
-  def recv(self) -> Dict[str, Any]:
+  def recv(self) -> dict[str, Any]:
     """Reads a single value from the Link and returns it.
 
     The read value is the oldest available in the Link, see :meth:`recv_last`
@@ -165,7 +165,7 @@ class Link:
     else:
       return dict()
 
-  def recv_last(self) -> Dict[str, Any]:
+  def recv_last(self) -> dict[str, Any]:
     """Reads all the available values in the Link, and returns the newest one.
 
     If no data is available in the Link, returns an empty :obj:`dict`. All the
@@ -185,7 +185,7 @@ class Link:
 
     return data
 
-  def recv_chunk(self) -> Dict[str, List[Any]]:
+  def recv_chunk(self) -> dict[str, list[Any]]:
     """Reads all the available values in the Link, and returns them all.
 
     Returns:

--- a/src/crappy/links/link.py
+++ b/src/crappy/links/link.py
@@ -3,7 +3,8 @@
 from multiprocessing import Pipe
 from time import time
 from copy import deepcopy
-from typing import Callable, Union, Any, Optional, Iterable
+from typing import Union, Any, Optional
+from collections.abc import Callable, Iterable
 from collections import defaultdict
 from select import select
 from platform import system

--- a/src/crappy/links/link.py
+++ b/src/crappy/links/link.py
@@ -210,6 +210,7 @@ class Link:
 
 def link(in_block,
          out_block,
+         /, *,
          modifier: Optional[Union[Iterable[ModifierType],
                                   ModifierType]] = None,
          name: Optional[str] = None) -> None:
@@ -224,15 +225,27 @@ def link(in_block,
 
   Args:
     in_block: The Block sending data through the Link.
+
+      .. versionchanged:: 2.0.7
+         now a positional-only argument
     out_block: The Block receiving data through the Link.
+
+      .. versionchanged:: 2.0.7
+         now a positional-only argument
     modifier: Either a callable, or an iterable (like a :obj:`list` or a
       :obj:`tuple`) containing callables. If several given (in an iterable),
       they are called in the given order. They should preferably be children of
       :class:`~crappy.modifier.Modifier`. Refer to  the associated
       documentation for more information.
+
+      .. versionchanged:: 2.0.7
+         now a keyword-only argument
     name: Name of the Link, to differentiate it from the others when debugging.
       If no specific name is given, the Links are numbered in the order in
       which they are instantiated in the script.
+
+      .. versionchanged:: 2.0.7
+         now a keyword-only argument
       
   .. versionadded:: 1.4.0
   .. versionchanged:: 1.5.9

--- a/src/crappy/modifier/__init__.py
+++ b/src/crappy/modifier/__init__.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from typing import Dict, Type
-
 from .meta_modifier import Modifier, MetaModifier
 
 from .demux import Demux
@@ -18,4 +16,4 @@ from .trig_on_value import TrigOnValue
 
 from ._deprecated import Moving_avg, Moving_med, Trig_on_change, Trig_on_value
 
-modifier_dict: Dict[str, Type[Modifier]] = MetaModifier.classes
+modifier_dict: dict[str, type[Modifier]] = MetaModifier.classes

--- a/src/crappy/modifier/demux.py
+++ b/src/crappy/modifier/demux.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Any, Union, Iterable
+from typing import Any, Union
+from collections.abc import Iterable
 import logging
 
 from .meta_modifier import Modifier

--- a/src/crappy/modifier/demux.py
+++ b/src/crappy/modifier/demux.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Dict, Any, Union, Iterable
+from typing import Any, Union, Iterable
 import logging
 
 from .meta_modifier import Modifier
@@ -66,7 +66,7 @@ class Demux(Modifier):
     self._time_label = time_label
     self._transpose = transpose
 
-  def __call__(self, data: Dict[str, np.ndarray]) -> Dict[str, Any]:
+  def __call__(self, data: dict[str, np.ndarray]) -> dict[str, Any]:
     """Retrieves for each label its value in the stream, also gets the
     corresponding timestamp, and returns them.
     

--- a/src/crappy/modifier/differentiate.py
+++ b/src/crappy/modifier/differentiate.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import logging
 
 from .meta_modifier import Modifier
@@ -36,7 +36,7 @@ class Diff(Modifier):
     self._last_t = None
     self._last_val = None
 
-  def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
     """Gets the data from the upstream Block, updates the derivative value,
     appends it to the data and returns the data.
     

--- a/src/crappy/modifier/differentiate.py
+++ b/src/crappy/modifier/differentiate.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 
-from typing import Optional, Any
+from typing import Optional, TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class Diff(Modifier):
@@ -36,7 +38,7 @@ class Diff(Modifier):
     self._last_t = None
     self._last_val = None
 
-  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+  def __call__(self, data: dict[str, T]) -> dict[str, T]:
     """Gets the data from the upstream Block, updates the derivative value,
     appends it to the data and returns the data.
     

--- a/src/crappy/modifier/downsampler.py
+++ b/src/crappy/modifier/downsampler.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from .meta_modifier import Modifier
@@ -29,7 +29,7 @@ class DownSampler(Modifier):
     self._n_points: int = n_points
     self._count: int = n_points - 1
 
-  def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
     """Receives data from the upstream Block, and if the counter matches the 
     threshold, returns the data.
 

--- a/src/crappy/modifier/downsampler.py
+++ b/src/crappy/modifier/downsampler.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 
-from typing import Any, Optional
+from typing import Optional, TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class DownSampler(Modifier):
@@ -29,7 +31,7 @@ class DownSampler(Modifier):
     self._n_points: int = n_points
     self._count: int = n_points - 1
 
-  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
+  def __call__(self, data: dict[str, T]) -> Optional[dict[str, T]]:
     """Receives data from the upstream Block, and if the counter matches the 
     threshold, returns the data.
 

--- a/src/crappy/modifier/integrate.py
+++ b/src/crappy/modifier/integrate.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import logging
 
 from .meta_modifier import Modifier
@@ -37,7 +37,7 @@ class Integrate(Modifier):
     self._last_val = None
     self._integration = 0
 
-  def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
     """Gets the data from the upstream Block, updates the integration value,
     adds it to the data and returns the data.
     

--- a/src/crappy/modifier/integrate.py
+++ b/src/crappy/modifier/integrate.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 
-from typing import Optional, Any
+from typing import Optional, TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class Integrate(Modifier):
@@ -37,7 +39,7 @@ class Integrate(Modifier):
     self._last_val = None
     self._integration = 0
 
-  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+  def __call__(self, data: dict[str, T]) -> dict[str, T]:
     """Gets the data from the upstream Block, updates the integration value,
     adds it to the data and returns the data.
     

--- a/src/crappy/modifier/mean.py
+++ b/src/crappy/modifier/mean.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Any, Optional
+from typing import Optional, TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class Mean(Modifier):
@@ -30,7 +32,7 @@ class Mean(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
+  def __call__(self, data: dict[str, T]) -> Optional[dict[str, T]]:
     """Receives data from the upstream Block, and computes the average of every
     label once the right number of points have been received. Then empties the
     buffer and returns the averages.

--- a/src/crappy/modifier/mean.py
+++ b/src/crappy/modifier/mean.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from .meta_modifier import Modifier
@@ -30,7 +30,7 @@ class Mean(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
     """Receives data from the upstream Block, and computes the average of every
     label once the right number of points have been received. Then empties the
     buffer and returns the averages.

--- a/src/crappy/modifier/median.py
+++ b/src/crappy/modifier/median.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 import logging
 
 from .meta_modifier import Modifier
@@ -30,7 +30,7 @@ class Median(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
     """Receives data from the upstream Block, and computes the median of every
     label once the right number of points have been received. Then empties the
     buffer and returns the medians.

--- a/src/crappy/modifier/median.py
+++ b/src/crappy/modifier/median.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Any, Optional
+from typing import Optional, TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class Median(Modifier):
@@ -30,7 +32,7 @@ class Median(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
+  def __call__(self, data: dict[str, T]) -> Optional[dict[str, T]]:
     """Receives data from the upstream Block, and computes the median of every
     label once the right number of points have been received. Then empties the
     buffer and returns the medians.

--- a/src/crappy/modifier/meta_modifier/modifier.py
+++ b/src/crappy/modifier/meta_modifier/modifier.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
-from typing import Optional, Any
+from typing import Optional, TypeVar
 import logging
 from multiprocessing import current_process
 
 from .meta_modifier import MetaModifier
+
+T = TypeVar('T')
 
 
 class Modifier(metaclass=MetaModifier):
@@ -31,7 +33,7 @@ class Modifier(metaclass=MetaModifier):
 
     self._logger: Optional[logging.Logger] = None
 
-  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
+  def __call__(self, data: dict[str, T]) -> Optional[dict[str, T]]:
     """The main method altering the inout data and returning the altered data.
 
     It should take a :obj:`dict` as its only argument, and return another

--- a/src/crappy/modifier/meta_modifier/modifier.py
+++ b/src/crappy/modifier/meta_modifier/modifier.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import logging
 from multiprocessing import current_process
 
@@ -31,7 +31,7 @@ class Modifier(metaclass=MetaModifier):
 
     self._logger: Optional[logging.Logger] = None
 
-  def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
     """The main method altering the inout data and returning the altered data.
 
     It should take a :obj:`dict` as its only argument, and return another

--- a/src/crappy/modifier/moving_avg.py
+++ b/src/crappy/modifier/moving_avg.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Dict, Any
+from typing import Any
 import logging
 
 from .meta_modifier import Modifier
@@ -31,7 +31,7 @@ class MovingAvg(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
     """Receives data from the upstream Block, computes the average of every
     label and replaces the original data with it.
     

--- a/src/crappy/modifier/moving_avg.py
+++ b/src/crappy/modifier/moving_avg.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Any
+from typing import TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class MovingAvg(Modifier):
@@ -31,7 +33,7 @@ class MovingAvg(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+  def __call__(self, data: dict[str, T]) -> dict[str, T]:
     """Receives data from the upstream Block, computes the average of every
     label and replaces the original data with it.
     

--- a/src/crappy/modifier/moving_med.py
+++ b/src/crappy/modifier/moving_med.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Dict, Any
+from typing import Any
 import logging
 
 from .meta_modifier import Modifier
@@ -31,7 +31,7 @@ class MovingMed(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
     """Receives data from the upstream Block, computes the median of every
     label and replaces the original data with it.
     

--- a/src/crappy/modifier/moving_med.py
+++ b/src/crappy/modifier/moving_med.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
 import numpy as np
-from typing import Any
+from typing import TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class MovingMed(Modifier):
@@ -31,7 +33,7 @@ class MovingMed(Modifier):
     self._n_points = n_points
     self._buf = None
 
-  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+  def __call__(self, data: dict[str, T]) -> dict[str, T]:
     """Receives data from the upstream Block, computes the median of every
     label and replaces the original data with it.
     

--- a/src/crappy/modifier/offset.py
+++ b/src/crappy/modifier/offset.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Dict, Any, Union, Iterable
+from typing import Any, Union, Iterable
 import logging
 
 from .meta_modifier import Modifier
@@ -60,7 +60,7 @@ class Offset(Modifier):
     self._compensations = None
     self._compensated = False
 
-  def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
     """If the compensations are not set, sets them, and then offsets the
     required labels.
     

--- a/src/crappy/modifier/offset.py
+++ b/src/crappy/modifier/offset.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
-from typing import Any, Union, Iterable
+from typing import Union, TypeVar
+from collections.abc import Iterable
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class Offset(Modifier):
@@ -60,7 +63,7 @@ class Offset(Modifier):
     self._compensations = None
     self._compensated = False
 
-  def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+  def __call__(self, data: dict[str, T]) -> dict[str, T]:
     """If the compensations are not set, sets them, and then offsets the
     required labels.
     

--- a/src/crappy/modifier/trig_on_change.py
+++ b/src/crappy/modifier/trig_on_change.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 
-from typing import Optional, Any
+from typing import Optional, TypeVar
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class TrigOnChange(Modifier):
@@ -30,7 +32,7 @@ class TrigOnChange(Modifier):
     self._label = label
     self._last = None
 
-  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
+  def __call__(self, data: dict[str, T]) -> Optional[dict[str, T]]:
     """Compares the received value with the last sent one, and if they're
     different sends the received data and stores the latest value.
     

--- a/src/crappy/modifier/trig_on_change.py
+++ b/src/crappy/modifier/trig_on_change.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 import logging
 
 from .meta_modifier import Modifier
@@ -30,7 +30,7 @@ class TrigOnChange(Modifier):
     self._label = label
     self._last = None
 
-  def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
     """Compares the received value with the last sent one, and if they're
     different sends the received data and stores the latest value.
     

--- a/src/crappy/modifier/trig_on_value.py
+++ b/src/crappy/modifier/trig_on_value.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
-from typing import Optional, Any, Union, Iterable
+from typing import Optional, Any, Union, TypeVar
+from collections.abc import Iterable
 import logging
 
 from .meta_modifier import Modifier
+
+T = TypeVar('T')
 
 
 class TrigOnValue(Modifier):
@@ -44,7 +47,7 @@ class TrigOnValue(Modifier):
 
     self._values = tuple(values)
 
-  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
+  def __call__(self, data: dict[str, T]) -> Optional[dict[str, T]]:
     """Checks if the value of ``label`` is in the predefined set of accepted
     values, and if so transmits the data.
     

--- a/src/crappy/modifier/trig_on_value.py
+++ b/src/crappy/modifier/trig_on_value.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Optional, Dict, Any, Union, Iterable
+from typing import Optional, Any, Union, Iterable
 import logging
 
 from .meta_modifier import Modifier
@@ -44,7 +44,7 @@ class TrigOnValue(Modifier):
 
     self._values = tuple(values)
 
-  def __call__(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+  def __call__(self, data: dict[str, Any]) -> Optional[dict[str, Any]]:
     """Checks if the value of ``label`` is in the predefined set of accepted
     values, and if so transmits the data.
     

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -6,7 +6,7 @@ from _tkinter import TclError
 from platform import system
 import numpy as np
 from time import time, sleep
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 from pkg_resources import resource_string
 from io import BytesIO
 import logging
@@ -83,7 +83,7 @@ class CameraConfig(tk.Tk):
 
     super().__init__()
     self._camera = camera
-    self.shape: Optional[Union[Tuple[int, int], Tuple[int, int, int]]] = None
+    self.shape: Optional[Union[tuple[int, int], tuple[int, int, int]]] = None
     self.dtype = None
     self._logger: Optional[logging.Logger] = None
 
@@ -530,7 +530,7 @@ class CameraConfig(tk.Tk):
       self._reticle_val.set(int(np.average(
           self._original_img[self._y_pos.get(), self._x_pos.get()])))
 
-  def _coord_to_pix(self, x: int, y: int) -> Tuple[int, int]:
+  def _coord_to_pix(self, x: int, y: int) -> tuple[int, int]:
     """Converts the coordinates of the mouse in the GUI referential to
     coordinates on the original image."""
 

--- a/src/crappy/tool/camera_config/config_tools/box.py
+++ b/src/crappy/tool/camera_config/config_tools/box.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional
 import logging
 import numpy as np
 
@@ -114,7 +114,7 @@ class Box(Overlay):
     self.x_centroid = None
     self.y_centroid = None
 
-  def sorted(self) -> Tuple[int, int, int, int]:
+  def sorted(self) -> tuple[int, int, int, int]:
     """Returns the four coordinates but sorted in the order : min x, max x,
     min y, max y."""
 

--- a/src/crappy/tool/camera_config/config_tools/spots_boxes.py
+++ b/src/crappy/tool/camera_config/config_tools/spots_boxes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Optional, List, Tuple
+from typing import Optional
 
 from .box import Box
 
@@ -69,7 +69,7 @@ class SpotsBoxes:
     return len([spot for spot in self if spot is not None])
 
   def set_spots(self,
-                spots: List[Tuple[int, int, int, int]]) -> None:
+                spots: list[tuple[int, int, int, int]]) -> None:
     """Parses a list of tuples and instantiates the corresponding
     :class:`~crappy.tool.camera_config.config_tools.Box` objects."""
 

--- a/src/crappy/tool/ft232h/ft232h.py
+++ b/src/crappy/tool/ft232h/ft232h.py
@@ -3,7 +3,7 @@
 from enum import IntEnum
 from collections import namedtuple
 from struct import calcsize, unpack, pack
-from typing import Union, Callable, Optional, Tuple, List
+from typing import Union, Callable, Optional, Tuple, List, Literal
 from multiprocessing import current_process
 import logging
 
@@ -181,7 +181,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     SYNCFF = 0x40  # Single Channel Synchronous FIFO mode
 
   def __init__(self,
-               mode: str,
+               mode: Literal['SPI', 'I2C', 'GPIO_only', 'Write_serial_nr'],
                serial_nr: Optional[str] = None,
                i2c_speed: float = 100E3,
                spi_turbo: bool = False) -> None:

--- a/src/crappy/tool/ft232h/ft232h.py
+++ b/src/crappy/tool/ft232h/ft232h.py
@@ -3,7 +3,8 @@
 from enum import IntEnum
 from collections import namedtuple
 from struct import calcsize, unpack, pack
-from typing import Union, Callable, Optional, Literal
+from typing import Union, Optional, Literal
+from collections.abc import Callable
 from multiprocessing import current_process
 import logging
 

--- a/src/crappy/tool/ft232h/ft232h.py
+++ b/src/crappy/tool/ft232h/ft232h.py
@@ -326,8 +326,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
                      idProduct=ft232h_product_id)
 
     # Checking if there's only 1 device matching
-    devices = list(devices)
-    if len(devices) == 0:
+    if len(devices := list(devices)) == 0:
       raise IOError("No matching ft232h connected")
     elif len(devices) > 1:
       raise IOError("Several ft232h devices found, please specify a serial_nr")
@@ -826,10 +825,8 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
           if length >= 2:
             if tempbuf[1] & ft232h_tx_empty_bits:
               if request_gen:
-                req_size -= length - 2
-                if req_size > 0:
-                  cmd = request_gen(req_size)
-                  if cmd:
+                if (req_size := req_size - (length - 2)) > 0:
+                  if cmd := request_gen(req_size):
                     self._write_data(cmd)
           if length > 2:
             retry = attempt
@@ -1005,10 +1002,8 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     # limit RX chunk size to the count of I2C packable commands in the FTDI
     # TX FIFO (minus one byte for the last 'send immediate' command)
     tx_count = (self._tx_size - 1) // cmd_size
-    chunk_size = min(tx_count, chunk_size)
     chunks = []
-    rem = readlen
-    if rem > chunk_size:
+    if (rem := readlen) > (chunk_size := min(tx_count, chunk_size)):
       chunk_size //= 2
       cmd_chunk = bytearray()
       cmd_chunk.extend(read_not_last * chunk_size)
@@ -1056,8 +1051,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     cmd.extend((ft232h_cmds['read_bits_PVE_MSB'], 0))
     cmd.extend((ft232h_cmds['send_immediate'],))
     self._write_data(cmd)
-    ack = self._read_data_bytes(1, 8)
-    if not ack:
+    if not (ack := self._read_data_bytes(1, 8)):
       raise IOError('No answer from FTDI')
     if ack[0] & 0x01:
       raise IOError('NACK from slave')
@@ -1106,8 +1100,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     while True:
       try:
         self._do_prolog(i2caddress | 0x01)
-        data = self._do_read(length)
-        if len(data) < length:
+        if len(data := self._do_read(length)) < length:
           raise IOError
         return data
       except (IOError, OSError):
@@ -1148,8 +1141,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
         self._do_prolog(i2caddress)
         self._do_write(out)
         self._do_prolog(i2caddress | 0x01)
-        data = self._do_read(readlen)
-        if len(data) < readlen:
+        if len(data := self._do_read(readlen)) < readlen:
           raise IOError
         return data
       except (IOError, OSError):
@@ -1964,8 +1956,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     if gpio_str not in ft232h_pin_nr:
       raise ValueError("gpio_id should be in {}".format(
         list(ft232h_pin_nr.values())))
-    gpio_bit = ft232h_pin_nr[gpio_str]
-    if not self._gpio_all_pins & gpio_bit:
+    if not self._gpio_all_pins & (gpio_bit := ft232h_pin_nr[gpio_str]):
       raise ValueError("Cannot use pin {} as a GPIO".format(gpio_str))
 
     # Changing the _direction and _gpio_dir bitfields
@@ -1990,8 +1981,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     if gpio_str not in ft232h_pin_nr:
       raise ValueError("gpio_id should be in {}".format(
         list(ft232h_pin_nr.values())))
-    gpio_bit = ft232h_pin_nr[gpio_str]
-    if not self._gpio_all_pins & gpio_bit:
+    if not self._gpio_all_pins & (gpio_bit := ft232h_pin_nr[gpio_str]):
       raise ValueError("Cannot use pin {} as a GPIO".format(gpio_str))
 
     # Changing the _direction and _gpio_dir bitfields

--- a/src/crappy/tool/ft232h/ft232h.py
+++ b/src/crappy/tool/ft232h/ft232h.py
@@ -3,7 +3,7 @@
 from enum import IntEnum
 from collections import namedtuple
 from struct import calcsize, unpack, pack
-from typing import Union, Callable, Optional, Tuple, List, Literal
+from typing import Union, Callable, Optional, Literal
 from multiprocessing import current_process
 import logging
 
@@ -877,7 +877,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     raise ValueError("Internal error")
 
   @property
-  def _clk_hi_data_lo(self) -> Tuple[int, int, int]:
+  def _clk_hi_data_lo(self) -> tuple[int, int, int]:
     """Returns the MPSSE command for driving CLK line high and SDA line low,
        while preserving the GPIO outputs."""
 
@@ -886,7 +886,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
             self._i2c_dir | (self._gpio_dir & 0xFF))
 
   @property
-  def _clk_lo_data_input(self) -> Tuple[int, int, int]:
+  def _clk_lo_data_input(self) -> tuple[int, int, int]:
     """Returns the MPSSE command for driving CLK line low and listening to SDA
        line, while preserving the GPIO outputs."""
 
@@ -895,7 +895,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
             ft232h_pins['SCL'] | (self._gpio_dir & 0xFF))
 
   @property
-  def _clk_lo_data_hi(self) -> Tuple[int, int, int]:
+  def _clk_lo_data_hi(self) -> tuple[int, int, int]:
     """Returns the MPSSE command for driving CLK line low and SDA line high,
        while preserving the GPIO outputs."""
 
@@ -904,7 +904,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
             self._i2c_dir | (self._gpio_dir & 0xFF))
 
   @property
-  def _clk_lo_data_lo(self) -> Tuple[int, int, int]:
+  def _clk_lo_data_lo(self) -> tuple[int, int, int]:
     """Returns the MPSSE command for driving CLK line low and SDA line low,
        while preserving the GPIO outputs."""
 
@@ -913,7 +913,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
             self._i2c_dir | (self._gpio_dir & 0xFF))
 
   @property
-  def _idle(self) -> Tuple[int, int, int]:
+  def _idle(self) -> tuple[int, int, int]:
     """Returns the MPSSE command for driving CLK line high and SDA line high,
        while preserving the GPIO outputs."""
 
@@ -922,14 +922,14 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
             self._i2c_dir | (self._gpio_dir & 0xFF))
 
   @property
-  def _start(self) -> Tuple[int, ...]:
+  def _start(self) -> tuple[int, ...]:
     """Returns the MPSSE command for issuing and I2C start condition."""
 
     return self._clk_hi_data_lo * self._ck_hd_sta + \
         self._clk_lo_data_lo * self._ck_hd_sta
 
   @property
-  def _stop(self) -> Tuple[int, ...]:
+  def _stop(self) -> tuple[int, ...]:
     """Returns the MPSSE command for issuing and I2C stop condition."""
 
     return self._clk_lo_data_hi * self._ck_hd_sta + \
@@ -1323,7 +1323,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
   def read_i2c_block_data(self,
                           i2c_addr: int,
                           register: int,
-                          length: int) -> List[int]:
+                          length: int) -> list[int]:
     """Reads a given number of bytes from an I2C slave, starting at the
     specified register.
 
@@ -1742,7 +1742,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
   def readbytes(self,
                 len: int,
                 start: bool = True,
-                stop: bool = True) -> List[int]:
+                stop: bool = True) -> list[int]:
     """Reads the specified number of bytes from an SPI slave.
 
     Args:
@@ -1808,7 +1808,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
            delay: float = 0.0,
            bits: int = 8,
            start: bool = True,
-           stop: bool = True) -> List[int]:
+           stop: bool = True) -> list[int]:
     """Simultaneously reads and write bytes to an SPI slave.
 
     The number of bytes to read is equal to the number of bytes in the write
@@ -1853,7 +1853,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
             delay: float = 0.0,
             bits: int = 8,
             start: bool = True,
-            stop: bool = True) -> List[int]:
+            stop: bool = True) -> list[int]:
     """Actually calls the :meth:`xfer` method with the same arguments."""
 
     self.log(logging.DEBUG, f"Requested SPI xfer with values {values}")
@@ -1871,7 +1871,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
             delay: float = 0.0,
             bits: int = 8,
             start: bool = True,
-            stop: bool = True) -> List[int]:
+            stop: bool = True) -> list[int]:
     """Actually calls the :meth:`xfer` method with the same arguments."""
 
     self.log(logging.DEBUG, f"Requested SPI xfer with values {values}")

--- a/src/crappy/tool/ft232h/ft232h_server.py
+++ b/src/crappy/tool/ft232h/ft232h_server.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 from struct import unpack
-from typing import Union, List, Tuple, Optional, Callable, Literal
+from typing import Union, Optional, Callable, Literal
 from _io import FileIO
 from multiprocessing.synchronize import RLock
 from multiprocessing.sharedctypes import Synchronized
@@ -352,7 +352,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
     return cmd
 
   def _send_server(self, command: list) -> Union[int, bytes, None,
-                                                 Tuple[int, ...]]:
+                                                 tuple[int, ...]]:
     """Sends a command to the server and gets the corresponding answer.
 
     Args:
@@ -401,7 +401,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
               self.log(logging.DEBUG, "Acquired the block lock")
               # Reading the answer
               self._answer_file.seek(0)
-              answer: List[bytes] = self._answer_file.read().split(b',')
+              answer: list[bytes] = self._answer_file.read().split(b',')
               self.log(logging.DEBUG, f"Read {answer} from the answer file")
               self._answer_file.seek(0)
               self._answer_file.truncate(0)

--- a/src/crappy/tool/ft232h/ft232h_server.py
+++ b/src/crappy/tool/ft232h/ft232h_server.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 from struct import unpack
-from typing import Union, List, Tuple, Optional, Callable
+from typing import Union, List, Tuple, Optional, Callable, Literal
 from _io import FileIO
 from multiprocessing.synchronize import RLock
 from multiprocessing.sharedctypes import Synchronized
@@ -176,7 +176,7 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
   """
 
   def __init__(self,
-               mode: str,
+               mode: Literal['SPI', 'I2C', 'GPIO_only', 'Write_serial_nr'],
                block_index: int,
                current_block: Synchronized,
                command_file: FileIO,

--- a/src/crappy/tool/ft232h/ft232h_server.py
+++ b/src/crappy/tool/ft232h/ft232h_server.py
@@ -2,7 +2,8 @@
 
 from collections import namedtuple
 from struct import unpack
-from typing import Union, Optional, Callable, Literal
+from typing import Union, Optional, Literal
+from collections.abc import Callable
 from _io import FileIO
 from multiprocessing.synchronize import RLock
 from multiprocessing.sharedctypes import Synchronized

--- a/src/crappy/tool/ft232h/ft232h_server.py
+++ b/src/crappy/tool/ft232h/ft232h_server.py
@@ -685,10 +685,8 @@ MODE=\\"0666\\\"" | sudo tee ftdi.rules > /dev/null 2>&1
           if length >= 2:
             if tempbuf[1] & ft232h_tx_empty_bits:
               if request_gen:
-                req_size -= length - 2
-                if req_size > 0:
-                  cmd = request_gen(req_size)
-                  if cmd:
+                if (req_size := req_size - (length - 2)) > 0:
+                  if cmd := request_gen(req_size):
                     self._write_data(cmd)
           if length > 2:
             retry = attempt

--- a/src/crappy/tool/ft232h/i2c_message.py
+++ b/src/crappy/tool/ft232h/i2c_message.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import annotations
-from typing import Optional, List
+from typing import Optional, List, Literal
 
 
 class I2CMessage:
@@ -16,7 +16,7 @@ class I2CMessage:
   """
 
   def __init__(self,
-               type_: str,
+               type_: Literal['r', 'w'],
                address: int,
                length: Optional[int] = None,
                buf: Optional[list] = None) -> None:

--- a/src/crappy/tool/ft232h/i2c_message.py
+++ b/src/crappy/tool/ft232h/i2c_message.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import annotations
-from typing import Optional, List, Literal
+from typing import Optional, Literal
 
 
 class I2CMessage:
@@ -73,13 +73,13 @@ class I2CMessage:
     self._addr = addr_
 
   @property
-  def buf(self) -> List[int]:
+  def buf(self) -> list[int]:
     """The list of bytes to be written, or the list of bytes read."""
 
     return self._buf
 
   @buf.setter
-  def buf(self, buf_: List[int]) -> None:
+  def buf(self, buf_: list[int]) -> None:
     if self.type == 'w' and not buf_:
       raise ValueError("buf can't be empty for a write operation !")
     self._buf = buf_

--- a/src/crappy/tool/ft232h/usb_server.py
+++ b/src/crappy/tool/ft232h/usb_server.py
@@ -340,9 +340,8 @@ class USBServer(Process):
         break
 
       # A Block has acquired the lock and shared its index
-      if self._current_block.value:
+      if index := self._current_block.value:
         # Reading the index and resetting the value
-        index = self._current_block.value
         self._current_block.value = 0
         self._log(logging.DEBUG, f"Block with index {index} now has control")
 

--- a/src/crappy/tool/ft232h/usb_server.py
+++ b/src/crappy/tool/ft232h/usb_server.py
@@ -8,7 +8,7 @@ from multiprocessing.sharedctypes import Synchronized
 import signal
 from _io import FileIO
 from tempfile import TemporaryFile
-from typing import List, Dict, Any, Optional, Tuple
+from typing import Any, Optional
 from contextlib import contextmanager
 from dataclasses import dataclass
 import logging
@@ -24,7 +24,7 @@ except (FileNotFoundError, ModuleNotFoundError):
   USBTimeoutError = OptionalModule('pyusb')
   util = OptionalModule('pyusb')
 
-USBArgsType = Tuple[int, multiprocessing.synchronize.RLock, FileIO,
+USBArgsType = tuple[int, multiprocessing.synchronize.RLock, FileIO,
                     FileIO, multiprocessing.synchronize.RLock,
                     Synchronized]
 
@@ -67,7 +67,7 @@ class USBServer(Process):
 
   process: Optional[multiprocessing.context.Process] = None
   block_nr: int = 0
-  devices: Dict[str, Device] = dict()
+  devices: dict[str, Device] = dict()
 
   # Objects for synchronizing with the server
   stop_event: Optional[multiprocessing.synchronize.Event] = None
@@ -75,13 +75,13 @@ class USBServer(Process):
   command_file: Optional[FileIO] = None
   answer_file: Optional[FileIO] = None
   shared_lock: Optional[multiprocessing.synchronize.RLock] = None
-  block_dict: Dict[int, BlockObjects] = dict()
+  block_dict: dict[int, BlockObjects] = dict()
 
   def __init__(self,
                current_block: Synchronized,
                command_file: FileIO,
                answer_file: FileIO,
-               block_dict: Dict[int, BlockObjects],
+               block_dict: dict[int, BlockObjects],
                stop_event: multiprocessing.synchronize.Event,
                log_queue: multiprocessing.queues.Queue,
                log_level: Optional[int]) -> None:
@@ -278,7 +278,7 @@ class USBServer(Process):
         lock.release()
 
   @staticmethod
-  def _get_devices() -> Dict[str, Any]:
+  def _get_devices() -> dict[str, Any]:
     """Detects all the connected FT232H devices and returns them as a 
     :obj:`dict`.
 
@@ -289,7 +289,7 @@ class USBServer(Process):
     """
 
     # Searching for the FT232H devices
-    devices: List[Device] = list(find(find_all=True,
+    devices: list[Device] = list(find(find_all=True,
                                       idVendor=0x0403,
                                       idProduct=0x6014))
     if not devices:
@@ -527,7 +527,7 @@ class USBServer(Process):
     self._logger.log(level, msg)
 
   @staticmethod
-  def _return_config_info(device) -> Tuple[int, int, int, int]:
+  def _return_config_info(device) -> tuple[int, int, int, int]:
     """Returns some configuration information from a USB object.
 
     Args:

--- a/src/crappy/tool/image_processing/dic_ve.py
+++ b/src/crappy/tool/image_processing/dic_ve.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import List, Tuple
+from typing import List, Tuple, Literal
 from ..._global import OptionalModule
 from ..camera_config import SpotsBoxes, Box
 
@@ -28,7 +28,8 @@ class DICVETool:
 
   def __init__(self,
                patches: SpotsBoxes,
-               method: str = 'Disflow',
+               method: Literal['Disflow', 'Lucas Kanade',
+                               'Pixel precision', 'Parabola'] = 'Disflow',
                alpha: float = 3,
                delta: float = 1,
                gamma: float = 0,

--- a/src/crappy/tool/image_processing/dic_ve.py
+++ b/src/crappy/tool/image_processing/dic_ve.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import numpy as np
-from typing import List, Tuple, Literal
+from typing import Literal
 from ..._global import OptionalModule
 from ..camera_config import SpotsBoxes, Box
 
@@ -129,8 +129,8 @@ class DICVETool:
       self._check_offsets()
 
   def calculate_displacement(
-      self, img: np.ndarray) -> Tuple[List[Tuple[float, float]], float, float,
-                                      List[Tuple[float, float]]]:
+      self, img: np.ndarray) -> tuple[list[tuple[float, float]], float, float,
+                                      list[tuple[float, float]]]:
     """Returns the displacement of every patch, calculated according to the
     chosen method.
 
@@ -239,7 +239,7 @@ class DICVETool:
   def _calc_disflow(self,
                     patch: Box,
                     img: np.ndarray,
-                    offset: Tuple[int, int]) -> List[float]:
+                    offset: tuple[int, int]) -> list[float]:
     """Returns the displacement between the original and the current image with
     a sub-pixel precision, using DISFlow."""
 
@@ -250,7 +250,7 @@ class DICVETool:
   def _calc_pixel_precision(self,
                             patch: Box,
                             img: np.ndarray,
-                            offset: Tuple[int, int]) -> List[float]:
+                            offset: tuple[int, int]) -> list[float]:
     """Returns the displacement between the original and the current image with
     a precision limited to 1 pixel."""
 
@@ -263,7 +263,7 @@ class DICVETool:
   def _calc_parabola(self,
                      patch: Box,
                      img: np.ndarray,
-                     offset: Tuple[int, int]) -> List[float]:
+                     offset: tuple[int, int]) -> list[float]:
     """Returns the displacement between the original and the current image with
     a sub-pixel precision, using two parabola fits (one in x and one in y)."""
 
@@ -284,7 +284,7 @@ class DICVETool:
   def _calc_lucas_kanade(self,
                          patch: Box,
                          img: np.ndarray,
-                         offset: Tuple[int, int]) -> List[float]:
+                         offset: tuple[int, int]) -> list[float]:
     """Returns the displacement between the original and the current image with
     a sub-pixel precision, using the Lucas Kanade algorithm."""
 
@@ -312,7 +312,7 @@ class DICVETool:
 
   @staticmethod
   def _cross_correlation(img0: np.ndarray,
-                         img1: np.ndarray) -> Tuple[np.ndarray, int, int]:
+                         img1: np.ndarray) -> tuple[np.ndarray, int, int]:
     """Performs a cross-correlation operation on two patches in the Fourier
     domain.
 
@@ -359,7 +359,7 @@ class DICVETool:
   @staticmethod
   def _get_patch(img: np.ndarray,
                  patch: Box,
-                 offset: Tuple[int, int] = (0, 0)) -> np.ndarray:
+                 offset: tuple[int, int] = (0, 0)) -> np.ndarray:
     """Returns the part of the image corresponding to the given patch at the
     given offset."""
 

--- a/src/crappy/tool/image_processing/dis_correl.py
+++ b/src/crappy/tool/image_processing/dis_correl.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import List, Optional, Union, Literal
+from typing import Optional, Union, Literal
 import numpy as np
 
 from ..._global import OptionalModule
@@ -27,7 +27,7 @@ class DISCorrelTool:
 
   def __init__(self,
                box: Box,
-               fields: Optional[List[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+               fields: Optional[list[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
                                                    'exy', 'eyx', 'exy2', 'z'],
                                            np.ndarray]]] = None,
                alpha: float = 3,
@@ -99,9 +99,9 @@ class DISCorrelTool:
         raise ValueError(f"The only allowed values for the fields given as "
                          f"strings are {allowed_fields}")
 
-      self._fields: List[Union[str, np.ndarray]] = fields
+      self._fields: list[Union[str, np.ndarray]] = fields
     else:
-      self._fields: List[Union[str, np.ndarray]] = ["x", "y", "exx", "eyy"]
+      self._fields: list[Union[str, np.ndarray]] = ["x", "y", "exx", "eyy"]
 
     self._init = init
 
@@ -163,7 +163,7 @@ class DISCorrelTool:
 
   def get_data(self,
                img: np.ndarray,
-               residuals: bool = False) -> List[float]:
+               residuals: bool = False) -> list[float]:
     """Processes the input image and returns the requested data in a
     :obj:`list`.
 

--- a/src/crappy/tool/image_processing/dis_correl.py
+++ b/src/crappy/tool/image_processing/dis_correl.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Literal
 import numpy as np
 
 from ..._global import OptionalModule
@@ -27,7 +27,9 @@ class DISCorrelTool:
 
   def __init__(self,
                box: Box,
-               fields: Optional[List[Union[str, np.ndarray]]] = None,
+               fields: Optional[List[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+                                                   'exy', 'eyx', 'exy2', 'z'],
+                                           np.ndarray]]] = None,
                alpha: float = 3,
                delta: float = 1,
                gamma: float = 0,

--- a/src/crappy/tool/image_processing/fields.py
+++ b/src/crappy/tool/image_processing/fields.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Tuple
+from typing import Tuple, Literal
 import numpy as np
 
 from ..._global import OptionalModule
@@ -13,7 +13,8 @@ except (ModuleNotFoundError, ImportError):
 allowed_fields = ('x', 'y', 'r', 'exx', 'eyy', 'exy', 'eyx', 'exy2', 'z')
 
 
-def get_field(field_string: str,
+def get_field(field_string: Literal['x', 'y', 'r', 'exx', 'eyy',
+                                    'exy', 'eyx', 'exy2', 'z'],
               h: int,
               w: int) -> Tuple[np.ndarray, np.ndarray]:
   """Creates and returns the two fields on which the image will be projected,

--- a/src/crappy/tool/image_processing/fields.py
+++ b/src/crappy/tool/image_processing/fields.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import Tuple, Literal
+from typing import Literal
 import numpy as np
 
 from ..._global import OptionalModule
@@ -16,7 +16,7 @@ allowed_fields = ('x', 'y', 'r', 'exx', 'eyy', 'exy', 'eyx', 'exy2', 'z')
 def get_field(field_string: Literal['x', 'y', 'r', 'exx', 'eyy',
                                     'exy', 'eyx', 'exy2', 'z'],
               h: int,
-              w: int) -> Tuple[np.ndarray, np.ndarray]:
+              w: int) -> tuple[np.ndarray, np.ndarray]:
   """Creates and returns the two fields on which the image will be projected,
   as :mod:`numpy` arrays.
   

--- a/src/crappy/tool/image_processing/gpu_correl.py
+++ b/src/crappy/tool/image_processing/gpu_correl.py
@@ -4,7 +4,7 @@ import warnings
 from math import ceil
 import numpy as np
 from pkg_resources import resource_filename
-from typing import Any, Tuple, Optional, Union, List
+from typing import Any, Tuple, Optional, Union, List, Literal
 from pathlib import Path
 from itertools import chain
 import logging
@@ -524,7 +524,9 @@ class GPUCorrelTool:
                resampling_factor: float = 2,
                kernel_file: Optional[Union[str, Path]] = None,
                iterations: int = 4,
-               fields: Optional[List[Union[str, np.ndarray]]] = None,
+               fields: Optional[List[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+                                                   'exy', 'eyx', 'exy2', 'z'],
+                                           np.ndarray]]] = None,
                ref_img: Optional[np.ndarray] = None,
                mask: Optional[np.ndarray] = None,
                mul: float = 3) -> None:
@@ -823,7 +825,9 @@ class GPUCorrelTool:
     if level <= self._verbose:
       self._logger.log(logging.INFO, msg)
 
-  def _set_fields(self, fields: List[str]) -> None:
+  def _set_fields(self, fields: List[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+                                                   'exy', 'eyx', 'exy2', 'z'],
+                                           np.ndarray]]) -> None:
     """Computes the fields based on the provided field strings, and sets them
     for each stage."""
 

--- a/src/crappy/tool/image_processing/gpu_correl.py
+++ b/src/crappy/tool/image_processing/gpu_correl.py
@@ -4,7 +4,7 @@ import warnings
 from math import ceil
 import numpy as np
 from pkg_resources import resource_filename
-from typing import Any, Tuple, Optional, Union, List, Literal
+from typing import Any, Optional, Union, Literal
 from pathlib import Path
 from itertools import chain
 import logging
@@ -67,7 +67,7 @@ class CorrelStage:
   """
 
   def __init__(self,
-               img_size: Tuple[int, int],
+               img_size: tuple[int, int],
                logger_name: str,
                verbose: int = 0,
                iterations: int = 5,
@@ -524,7 +524,7 @@ class GPUCorrelTool:
                resampling_factor: float = 2,
                kernel_file: Optional[Union[str, Path]] = None,
                iterations: int = 4,
-               fields: Optional[List[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+               fields: Optional[list[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
                                                    'exy', 'eyx', 'exy2', 'z'],
                                            np.ndarray]]] = None,
                ref_img: Optional[np.ndarray] = None,
@@ -639,7 +639,7 @@ class GPUCorrelTool:
       self._kernel_file = kernel_file
     self._debug(3, f"Kernel file:{self._kernel_file}")
 
-  def set_img_size(self, img_size: Tuple[int, int]) -> None:
+  def set_img_size(self, img_size: tuple[int, int]) -> None:
     """Sets the image shape, and calls the methods that need this information
     for running."""
 
@@ -825,7 +825,7 @@ class GPUCorrelTool:
     if level <= self._verbose:
       self._logger.log(logging.INFO, msg)
 
-  def _set_fields(self, fields: List[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
+  def _set_fields(self, fields: list[Union[Literal['x', 'y', 'r', 'exx', 'eyy',
                                                    'exy', 'eyx', 'exy2', 'z'],
                                            np.ndarray]]) -> None:
     """Computes the fields based on the provided field strings, and sets them

--- a/src/crappy/tool/image_processing/video_extenso/tracker.py
+++ b/src/crappy/tool/image_processing/video_extenso/tracker.py
@@ -50,7 +50,7 @@ class Tracker(Process):
                log_queue: Queue,
                white_spots: bool = False,
                thresh: Optional[int] = None,
-               blur: Optional[float] = 5) -> None:
+               blur: Optional[int] = 5) -> None:
     """Sets the arguments.
 
     Args:

--- a/src/crappy/tool/image_processing/video_extenso/video_extenso.py
+++ b/src/crappy/tool/image_processing/video_extenso/video_extenso.py
@@ -3,7 +3,7 @@
 from multiprocessing import Pipe, current_process
 from multiprocessing.connection import Connection
 from multiprocessing.queues import Queue
-from typing import Optional, Tuple, List, Union
+from typing import Optional, Union
 import numpy as np
 from itertools import combinations
 from time import sleep, time
@@ -178,7 +178,7 @@ class VideoExtensoTool:
 
   def get_data(self,
                img: np.ndarray
-               ) -> Optional[Tuple[List[Tuple[float, ...]], float, float]]:
+               ) -> Optional[tuple[list[tuple[float, ...]], float, float]]:
     """Takes an image as an input, performs spot detection on it, computes the
     strain from the newly detected spots, and returns the spot positions and
     strain values.
@@ -302,7 +302,7 @@ class VideoExtensoTool:
 
   def _send(self,
             conn: Connection,
-            val: Union[str, Tuple[int, int, np.ndarray]]) -> None:
+            val: Union[str, tuple[int, int, np.ndarray]]) -> None:
     """Wrapper for sending messages to the Tracker processes.
 
     In Linux, checks that the Pipe is not full before sending the message.

--- a/tests/integration/blocks/test_machine.py
+++ b/tests/integration/blocks/test_machine.py
@@ -30,7 +30,7 @@ class FakeBlock:
 
     buf = dict()
     for link in self.inputs:
-      buf.update(link.recv_last())
+      buf |= link.recv_last()
 
     return buf
 


### PR DESCRIPTION
As detailed in #63, it is more than time to drop support for Python 3.7 and 3.8. This update allows using the features introduced in Python 3.8 and 3.9, which is what this PR does. The following improvements are brought to the code base:

- Use of the walrus operator `:=`
- Use of the `typing.Literal` class for improving documentation
- Replacement of `dict.update()` calls with `|=`
- Use of keyword-only and positional-only arguments
- Replacement of `typing.Tuple`, `typing.List`, `typing.Dict` and `typing.Type` with their associated builtins
- Use of `typing.TypeVar` to improve some type hints
- Replacement of `typing.Iterator`, `typing.Iterable` and `typing.Callable` with their `collections.abc` equivalents

closes #63