### PR TITLE
Fix bug with opencv camera

### DIFF
--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -258,7 +258,7 @@ class Camera(ABC):
     # Checking if the given name is valid
     if name in self._reserved:
       raise ValueError(f"The name {name} is reserved for a different type of "
-                       f"setting ! !")
+                       f"setting !")
     if name in self.settings:
       raise ValueError('This setting already exists !')
     self.log(logging.INFO, f"Adding the {name} scale setting")

--- a/src/crappy/camera/meta_camera/camera.py
+++ b/src/crappy/camera/meta_camera/camera.py
@@ -517,16 +517,22 @@ class Camera(ABC):
     It is called in case :meth:`~crappy.camera.Camera.__getattribute__` doesn't
     work properly, and tries to return the corresponding setting value."""
 
-    try:
-      return self.settings[item].value
-    except (AttributeError, KeyError):
-      raise AttributeError(f'No attribute nor setting named {item}')
+    settings = self.__dict__.get("settings")
+
+    if settings is not None:
+      try:
+        return self.settings[item].value
+      except (AttributeError, KeyError):
+        pass
+    raise AttributeError(f'No attribute nor setting named {item}')
 
   def __setattr__(self, key: str, val: Any) -> None:
     """Method for setting the value of a setting directly by calling
     ``self.<setting name> = <value>``."""
 
-    if key != 'settings' and key in self.settings:
+    settings = self.__dict__.get("settings")
+
+    if settings is not None and key != 'settings' and key in settings:
       self.settings[key].value = val
     else:
       super().__setattr__(key, val)

--- a/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_choice_setting.py
@@ -35,6 +35,8 @@ class CameraChoiceSetting(CameraSetting):
       default: The default value to assign to the setting.
     """
 
+    self._logger: logging.Logger | None = None
+
     self.choices = choices
 
     if default is not None and default not in choices:

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -51,7 +51,7 @@ class CameraScaleSetting(CameraSetting):
 
     # Ensuring that the two bounds are not equal
     if lowest == highest:
-      raise ValueError("The two given bounds are equal !")
+      raise ValueError(f"The two given bounds are equal for setting {name}!")
 
     # Ensuring that the given bounds are in the correct order
     if lowest > highest:

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -53,6 +53,11 @@ class CameraScaleSetting(CameraSetting):
     if lowest == highest:
       raise ValueError(f"The two given bounds are equal for setting {name}!")
 
+    # Ensure the step is greater than zero
+    if step == 0:
+      raise ValueError(f"The provided step is equal to zero for "
+                       f"setting {name}!")
+
     # Ensuring that the given bounds are in the correct order
     if lowest > highest:
       self.log(logging.WARNING, f"Lowest ({lowest}) higher than highest "

--- a/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_scale_setting.py
@@ -47,6 +47,8 @@ class CameraScaleSetting(CameraSetting):
     .. versionadded:: 2.0.0 add *step* argument
     """
 
+    self._logger: logging.Logger | None = None
+
     # Ensuring that the two bounds are not equal
     if lowest == highest:
       raise ValueError("The two given bounds are equal !")

--- a/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
+++ b/src/crappy/camera/meta_camera/camera_setting/camera_setting.py
@@ -53,7 +53,9 @@ class CameraSetting:
     self._value_no_getter = default
     self._getter = getter
     self._setter = setter
-    self._logger: logging.Logger | None = None
+
+    if not hasattr(self, '_logger'):
+      self._logger: logging.Logger | None = None
 
   def log(self, level: int, msg: str) -> None:
     """Records log messages for the CameraSetting.

--- a/src/crappy/camera/opencv_camera_v4l2.py
+++ b/src/crappy/camera/opencv_camera_v4l2.py
@@ -95,7 +95,7 @@ class CameraOpencv(Camera, V4L2Helper):
           highest=int(param.max),
           getter=self._add_scale_getter(param.name, self._device_num),
           setter=self._add_setter(param.name, self._device_num),
-          default=param.default,
+          default=int(param.default),
           step=int(param.step))
 
       elif param.type == 'bool':

--- a/src/crappy/camera/opencv_camera_v4l2.py
+++ b/src/crappy/camera/opencv_camera_v4l2.py
@@ -89,6 +89,16 @@ class CameraOpencv(Camera, V4L2Helper):
     # Creating the different settings
     for param in self._parameters:
       if param.type == 'int':
+
+        if int(param.min) == int(param.max):
+          self.log(logging.DEBUG, f"The maximum and minimum for setting "
+                                  f"{param.name} are equal, skipping")
+          continue
+        if int(param.step) == 0:
+          self.log(logging.DEBUG, f"The step for setting {param.name} is "
+                                  f"zero, skipping")
+          continue
+
         self.add_scale_setting(
           name=param.name,
           lowest=int(param.min),


### PR DESCRIPTION
This PR fixes inconsistent parameter type management in the [`CameraOpencv`](https://github.com/LaboratoireMecaniqueLille/crappy/blob/57095e0ab0faeb75b73701a6e3e4b4d307c63e60/src/crappy/camera/opencv_camera_v4l2.py) Camera. 

It also improves the settings access mechanism shared by all the Camera objects, to avoid infinite recursion in case of incorrect implementation.

Finally, it fixes a bug due to missing Logger definition in the CameraSetting classes.