### PR TITLE
Enable GitHub Actions for Python 3.14 on Windows and Linux

### DIFF
--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -24,12 +24,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         # Run on all the supported platforms
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # Tests fail because scikit-image does not distribute a wheel yet
-        exclude:
-          - os: windows-latest
-            python-version: "3.14"
-          - os: ubuntu-latest
-            python-version: "3.14"
 
     steps:
     # Checkout the repository

--- a/src/crappy/tool/camera_config/camera_config.py
+++ b/src/crappy/tool/camera_config/camera_config.py
@@ -230,6 +230,8 @@ class CameraConfig(tk.Tk):
     # Close the queues to properly end all multiprocessing objects
     self.log(logging.DEBUG, "Closing the queues communicating with the "
                             "histogram process")
+    self._img_in.cancel_join_thread()
+    self._img_out.cancel_join_thread()
     self._img_in.close()
     self._img_out.close()
 

--- a/tests/camera_configuration/camera_configuration_test_base.py
+++ b/tests/camera_configuration/camera_configuration_test_base.py
@@ -111,6 +111,7 @@ class ConfigurationWindowTestBase(unittest.TestCase):
       self._config.finish()
 
     if self._log_queue is not None:
+      self._log_queue.cancel_join_thread()
       self._log_queue.close()
 
   def customTearDown(self) -> None:


### PR DESCRIPTION
Wheels are now available for 3.14, avoiding troublesome compilation in the GitHub actions