### PR TITLE
Fix various bugs in Blocks

### DIFF
--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -130,13 +130,17 @@ class FakeMachine(Block):
     from it, checks whether the sample broke and what the plastic elongation
     is, and finally returns the data."""
 
+    # Avoid potential zero division later
+    t = time()
+    delta_t = t - self._prev_t
+    if not delta_t > 0:
+      return
+
     # Getting the latest command
     if self._cmd_label not in (data := self.recv_last_data(fill_missing=True)):
       return
     else:
       cmd = data[self._cmd_label]
-    t = time()
-    delta_t = t - self._prev_t
     self._prev_t = t
 
     # Calculating the speed based on the command and the mode

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -153,8 +153,9 @@ class FakeMachine(Block):
     else:
       raise ValueError(f'Invalid mode : {self._mode} !')
 
-    # Updating the current position
+    # Updating the current position, checking it's not going below zero
     self._current_pos += speed * delta_t
+    self._current_pos = max(self._current_pos, 0.0)
 
     # If the max strain is reached, consider that the sample broke
     if self._current_pos / self._l0 > self._max_strain:

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -120,7 +120,7 @@ class FakeMachine(Block):
     self._max_recorded_strain = 0
 
   def begin(self) -> None:
-    """Sends a first value that should be 0."""
+    """Sends a first value that should be 0, plus or minus the noise."""
 
     self._prev_t = self.t0
     self._send_values()

--- a/src/crappy/blocks/fake_machine.py
+++ b/src/crappy/blocks/fake_machine.py
@@ -106,6 +106,9 @@ class FakeMachine(Block):
                    'Exx(%)': 1e-3, 'Eyy(%)': 1e-3} if sigma is None else sigma
     self._plastic_law = plastic_law
 
+    if mode not in ('speed', 'position'):
+      raise ValueError(f"Invalid mode: {mode}, should be in 'speed' or "
+                       f"'position'")
     self._mode = mode
     self._cmd_label = cmd_label
 

--- a/src/crappy/blocks/grapher.py
+++ b/src/crappy/blocks/grapher.py
@@ -181,7 +181,7 @@ class Grapher(Block):
     else:
       # Below 10Hz, making sure to flush the pipes at least every 0.1s
       data = self.recv_all_data_raw(delay=1 / 2 / self.freq,
-                                    poll_delay=min(0.1, 1 / 2 / self.freq))
+                                    poll_delay=min(0.1, 1 / 4 / self.freq))
 
     update = False  # Should the graph be updated ?
 

--- a/src/crappy/blocks/link_reader.py
+++ b/src/crappy/blocks/link_reader.py
@@ -85,10 +85,11 @@ class LinkReader(Block):
 
   def loop(self) -> None:
     """Flushes the incoming :class:`~crappy.links.Link` and displays their
-    data."""
+    data.
 
-    for link_data in self.recv_all_data_raw():
-      for dic in (dict(i) for i in
-                  zip(*([(key, value) for value in values]
-                        for key, values in link_data.items()))):
-        self.log(logging.INFO, f'{self._reader_name} got: {dic}')
+    .. versionchanged:: 2.0.9 Now displaying individual received messages
+    """
+
+    for link in self.inputs:
+      while link.poll():
+        self.log(logging.INFO, f'{self._reader_name} got: {link.recv()}')

--- a/src/crappy/blocks/link_reader.py
+++ b/src/crappy/blocks/link_reader.py
@@ -74,6 +74,15 @@ class LinkReader(Block):
 
     return cls._index
 
+  def prepare(self) -> None:
+    """Checks that there's at least one incoming :class:`~crappy.links.Link`.
+
+    .. versionadded:: 2.0.9
+    """
+
+    if not self.inputs:
+      raise IOError("No Link pointing towards the LinkReader Block !")
+
   def loop(self) -> None:
     """Flushes the incoming :class:`~crappy.links.Link` and displays their
     data."""

--- a/src/crappy/blocks/mean.py
+++ b/src/crappy/blocks/mean.py
@@ -114,7 +114,13 @@ class MeanBlock(Block):
 
   def loop(self) -> None:
     """Receives all available data from the upstream Blocks, averages it and
-    sends it if the time delay is reached."""
+    sends it if the time delay is reached.
+
+    .. versionchanged:: 2.0.9 average time label computed directly from time
+      data when possible
+    """
+
+    time_data: list | None = None
 
     # Receiving data from each incoming link
     data = self.recv_all_data(delay=self._delay, poll_delay=self._delay / 10)
@@ -122,7 +128,7 @@ class MeanBlock(Block):
 
     # Removing the time label from the received data
     if self._time_label in data:
-      data.pop(self._time_label)
+      time_data = data.pop(self._time_label)
 
     # Building the output dict with the averaged values
     for label, values in data.items():
@@ -136,6 +142,10 @@ class MeanBlock(Block):
 
     # Sending the output dict
     if to_send:
-      to_send[self._time_label] = (time() + self._last_sent_t) / 2 - self.t0
+      if time_data is not None:
+        to_send[self._time_label] = (min(time_data) +
+                                     max(time_data)) / 2 - self.t0
+      else:
+        to_send[self._time_label] = (time() + self._last_sent_t) / 2 - self.t0
       self._last_sent_t = time()
       self.send(to_send)

--- a/src/crappy/blocks/mean.py
+++ b/src/crappy/blocks/mean.py
@@ -75,6 +75,10 @@ class MeanBlock(Block):
     self.freq = freq
     self.debug = debug
 
+    if delay <= 0:
+      raise ValueError("Delay must be a positive value")
+    self.delay = delay
+
     self._delay = delay
     self._time_label = time_label
 

--- a/src/crappy/blocks/mean.py
+++ b/src/crappy/blocks/mean.py
@@ -92,6 +92,18 @@ class MeanBlock(Block):
 
     self._last_sent_t = time()
 
+  def prepare(self) -> None:
+    """Checks that there's at least one incoming and one output
+    :class:`~crappy.links.Link`.
+
+    .. versionadded:: 2.0.9
+    """
+
+    if not self.inputs:
+      raise IOError("No Link pointing towards the Mean Block!")
+    if not self.outputs:
+      raise IOError("The Mean Block has no output Link!")
+
   def begin(self) -> None:
     """Initializes the time counter.
     

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -1321,7 +1321,7 @@ class Block(Process, ABC):
 
   def recv_all_data(self,
                     delay: float | None = None,
-                    poll_delay: float = 0.1) -> dict[str, list[Any]]:
+                    poll_delay: float | None = None) -> dict[str, list[Any]]:
     """Reads all the available values from each incoming
     :class:`~crappy.links.Link`, and returns them all in a single dict.
 
@@ -1347,6 +1347,10 @@ class Block(Process, ABC):
         once every this value seconds. It ensures that the method doesn't spam
         the CPU in vain.
 
+        .. versionchanged:: 2.0.9 now defaults to :obj:`None` as an argument,
+          and to ``delay / 10`` in practice if unset. Also, must be inferior to
+          ``delay``.
+
     Returns:
       A :obj:`dict` whose keys are the received labels and with a :obj:`list`
       of received values for each key. The first item in the list is the oldest
@@ -1356,6 +1360,7 @@ class Block(Process, ABC):
     .. versionadded:: 1.5.10 *blocking* argument
     .. versionremoved:: 2.0.0 *blocking* argument
     .. versionchanged:: 2.0.0 renamed from *get_all_last* to *recv_all_data*
+    .. versionchanged:: 2.0.9 add new mechanism to avoid oversleeping
     """
 
     if (delay is not None
@@ -1377,7 +1382,12 @@ class Block(Process, ABC):
 
     # Otherwise, receiving during the given period
     else:
-      while time() - t0 < delay:
+      # If the poll delay is not specified, setting it much lower than delay
+      if poll_delay is None:
+        poll_delay = delay / 10
+
+      deadline = t0 + delay
+      while time() < deadline:
         last_t = time()
         # Updating the list of received values
         for link in self.inputs:
@@ -1385,7 +1395,13 @@ class Block(Process, ABC):
           for label, values in data.items():
             ret[label].extend(values)
         # Sleeping to avoid useless CPU usage
-        sleep(max(0., last_t + poll_delay - time()))
+        sleep(max(0., min(poll_delay, deadline - time())))
+
+      # Draining once more catches data that arrived during the last sleep
+      for link in self.inputs:
+        data = link.recv_chunk()
+        for label, values in data.items():
+          ret[label].extend(values)
 
     # Returning a dict, not a defaultdict
     self.log(logging.DEBUG, f"Called recv_all_data, got {dict(ret)}")
@@ -1393,7 +1409,8 @@ class Block(Process, ABC):
 
   def recv_all_data_raw(self,
                         delay: float | None = None,
-                        poll_delay: float = 0.1) -> list[dict[str, list[Any]]]:
+                        poll_delay: float | None = None
+                        ) -> list[dict[str, list[Any]]]:
     """Reads all the available values from each incoming
     :class:`~crappy.links.Link`, and returns them separately in a list of
     dicts.
@@ -1411,11 +1428,16 @@ class Block(Process, ABC):
         once every this value seconds. It ensures that the method doesn't spam
         the CPU in vain.
 
+        .. versionchanged:: 2.0.9 now defaults to :obj:`None` as an argument,
+          and to ``delay / 10`` in practice if unset. Also, must be inferior to
+          ``delay``.
+
     Returns:
       A :obj:`list` containing :obj:`dict`, whose keys are the received labels
       and with a :obj:`list` of received value for each key.
     
     .. versionadded:: 2.0.0
+    .. versionchanged:: 2.0.9 add new mechanism to avoid oversleeping
     """
 
     if (delay is not None
@@ -1436,7 +1458,12 @@ class Block(Process, ABC):
 
     # Otherwise, receiving during the given period
     else:
-      while time() - t0 < delay:
+      # If the poll delay is not specified, setting it much lower than delay
+      if poll_delay is None:
+        poll_delay = delay / 10
+
+      deadline = t0 + delay
+      while time() < deadline:
         last_t = time()
         # Updating the list of received values
         for dic, link in zip(ret, self.inputs):
@@ -1444,7 +1471,13 @@ class Block(Process, ABC):
           for label, values in data.items():
             dic[label].extend(values)
         # Sleeping to avoid useless CPU usage
-        sleep(max(0., last_t + poll_delay - time()))
+        sleep(max(0., min(poll_delay, deadline - time())))
+
+      # Draining once more catches data that arrived during the last sleep
+      for dic, link in zip(ret, self.inputs):
+        data = link.recv_chunk()
+        for label, values in data.items():
+          dic[label].extend(values)
 
     self.log(logging.DEBUG, f"Called recv_all_data_raw, got "
                             f"{[dict(dic) for dic in ret]}")

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -1240,7 +1240,7 @@ class Block(Process, ABC):
     """
 
     self.log(logging.DEBUG, "Data availability requested")
-    return self.inputs and any(link.poll() for link in self.inputs)
+    return bool(self.inputs) and any(link.poll() for link in self.inputs)
 
   def recv_data(self) -> dict[str, Any]:
     """Reads the first available values from each incoming

--- a/src/crappy/blocks/meta_block/block.py
+++ b/src/crappy/blocks/meta_block/block.py
@@ -1358,6 +1358,14 @@ class Block(Process, ABC):
     .. versionchanged:: 2.0.0 renamed from *get_all_last* to *recv_all_data*
     """
 
+    if (delay is not None
+        and poll_delay is not None
+        and poll_delay >= 0.9 * delay):
+      raise ValueError("The poll_delay value must be lower than the delay")
+
+    if poll_delay is not None and poll_delay <= 0:
+      raise ValueError("poll_delay should be positive")
+
     ret = defaultdict(list)
     t0 = time()
 
@@ -1409,6 +1417,14 @@ class Block(Process, ABC):
     
     .. versionadded:: 2.0.0
     """
+
+    if (delay is not None
+        and poll_delay is not None
+        and poll_delay >= 0.9 * delay):
+      raise ValueError("The poll_delay value must be lower than the delay")
+
+    if poll_delay is not None and poll_delay <= 0:
+      raise ValueError("poll_delay should be positive")
 
     ret = [defaultdict(list) for _ in self.inputs]
     t0 = time()

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -97,7 +97,8 @@ class Multiplexer(Block):
     self._time_label = time_label
     self._interp_freq = interp_freq
     self._data: dict[str, np.ndarray] = defaultdict(self._default_array)
-    self._delta: float = 1 / self._interp_freq / 20
+    self._period: float = 1 / self._interp_freq
+    self._delta: float = self._period / 20
     self._last_max_t: float = -float('inf')
 
     # Forcing the out_labels into a list
@@ -163,7 +164,7 @@ class Multiplexer(Block):
       return
 
     # The two values should also be separated by at least one time period
-    if any(np.ptp(self._data[label][0]) < 1 / self._interp_freq
+    if any(np.ptp(self._data[label][0]) < self._period
            for label in self._data):
       self.log(logging.DEBUG, "At least one label has values too close "
                               "together compared to interpolation frequency")
@@ -186,7 +187,7 @@ class Multiplexer(Block):
       return
 
     # The array containing the timestamps for interpolating
-    interp_times = np.arange(min_t, max_t + self._delta, 1 / self._interp_freq)
+    interp_times = np.arange(min_t, max_t + self._delta, self._period)
 
     # Making sure there are points to interpolate
     if not interp_times.size:

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -99,6 +99,7 @@ class Multiplexer(Block):
     self._data: dict[str, np.ndarray] = defaultdict(self._default_array)
     self._period: float = 1 / self._interp_freq
     self._delta: float = self._period / 20
+    self._epsilon: float = self._period * 1e-12
     self._last_max_t: float = -float('inf')
 
     # Forcing the out_labels into a list
@@ -175,12 +176,12 @@ class Multiplexer(Block):
     # The minimum must be higher than the previous maximum
     min_t = max(min_t, self._last_max_t + self._delta)
     # Correcting to the closest upper multiple of the time interval
-    min_t = min_t + (1 / self._interp_freq) - min_t % (1 / self._interp_freq)
+    min_t = np.ceil((min_t - self._epsilon) / self._period) * self._period
 
     # Getting the maximum time for the interpolation (minimax over all labels)
     max_t = min(data[0, -1] for data in self._data.values())
     # Correcting to the closest lower multiple of the time interval
-    max_t = max_t - (1 / self._interp_freq) + max_t % (1 / self._interp_freq)
+    max_t = np.floor((max_t + self._epsilon) / self._period) * self._period
 
     if max_t < min_t:
       self.log(logging.DEBUG, "Ranges not matching for interpolation")

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -189,7 +189,7 @@ class Multiplexer(Block):
     interp_times = np.arange(min_t, max_t + self._delta, 1 / self._interp_freq)
 
     # Making sure there are points to interpolate
-    if not np.any(interp_times):
+    if not interp_times.size:
       self.log(logging.DEBUG, "No time points for interpolation")
       return
 

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -90,6 +90,9 @@ class Multiplexer(Block):
     self.display_freq = display_freq
     self.debug = debug
 
+    if interp_freq <= 0:
+      raise ValueError("interp_freq must be greater than 0")
+
     # Initializing the attributes
     self._time_label = time_label
     self._interp_freq = interp_freq

--- a/src/crappy/blocks/multiplexer.py
+++ b/src/crappy/blocks/multiplexer.py
@@ -108,6 +108,18 @@ class Multiplexer(Block):
     else:
       self._out_labels = None
 
+  def prepare(self) -> None:
+    """Checks that there's at least one incoming and one output
+    :class:`~crappy.links.Link`.
+
+    .. versionadded:: 2.0.9
+    """
+
+    if not self.inputs:
+      raise IOError("No Link pointing towards the Multiplexer Block!")
+    if not self.outputs:
+      raise IOError("The Multiplexer Block has no output Link!")
+
   def loop(self) -> None:
     """Receives data, interpolates it, and sends it to the downstream
     Blocks."""

--- a/src/crappy/blocks/pause.py
+++ b/src/crappy/blocks/pause.py
@@ -88,7 +88,7 @@ class Pause(Block):
 
     self._raw_crit: tuple[str |
                           Callable[[dict[str, list]], bool], ...] = criteria
-    self._criteria: tuple[Callable[[dict[str, list]], bool]] | None = None
+    self._criteria: tuple[Callable[[dict[str, list]], bool], ...] | None = None
 
   def prepare(self) -> None:
     """Converts all the given criteria to :obj:`~collections.abc.Callable`."""

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -144,7 +144,7 @@ class PID(Block):
     # Setting the variables
     self._setpoint: float | None = None
     self._last_input: float | None = None
-    self._prev_t: float = 0.
+    self._prev_t: float | None = None
     self._i_term: float = 0.
 
   def prepare(self) -> None:
@@ -200,14 +200,18 @@ class PID(Block):
     else:
       return
 
-    delta_t = t - self._prev_t
+    # Always calculate the P term
     error = self._setpoint - input_
     d_input = input_ - self._last_input
-
-    # Calculating the three PID terms
     p_term = self._kp * error
-    self._i_term += self._ki * error * delta_t
-    d_term = - self._kd * d_input / delta_t if delta_t > 0 else 0
+
+    # Calculate the I and D term only if a delta_t is defined
+    if self._prev_t is not None:
+      delta_t = t - self._prev_t
+      self._i_term += self._ki * error * delta_t
+      d_term = - self._kd * d_input / delta_t if delta_t > 0 else 0
+    else:
+      d_term = 0
 
     self._prev_t = t
     self._last_input = input_

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -127,8 +127,7 @@ class PID(Block):
     self._kd = sign * abs(kd)
 
     # Setting the limits
-    self._out_max = out_max
-    self._out_min = out_min
+    self._out_min, self._out_max = sorted((out_min, out_max))
     self._i_min, self._i_max = sorted(i_limit)
 
     # Setting the labels

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -38,7 +38,7 @@ class PID(Block):
                kd_label: str = 'kd',
                labels: tuple[str, str] | None = None,
                reverse: bool = False,
-               i_limit: tuple[float | None, float | None] = (None, None),
+               i_limit: tuple[float, float] = (-float('inf'), float('inf')),
                send_terms: bool = False,
                freq: float | None = 500,
                display_freq: bool = False,
@@ -89,6 +89,9 @@ class PID(Block):
       reverse: If :obj:`True`, reverses the action of the PID.
       i_limit: A :obj:`tuple` containing respectively the lower and upper
         boundaries for the `I` term.
+
+        .. versionchanged:: 2.0.9 :obj:`None` replaced with `float('inf')` to
+          signal absence of limit
       send_terms: If :obj:`True`, returns the weight of each term in the output
         value. It adds ``'p_term', 'i_term', 'd_term'`` to the output labels.
         This is particularly useful to tweak the gains.
@@ -126,7 +129,7 @@ class PID(Block):
     # Setting the limits
     self._out_max = out_max
     self._out_min = out_min
-    self._i_min, self._i_max = i_limit
+    self._i_min, self._i_max = sorted(i_limit)
 
     # Setting the labels
     self._target_label = setpoint_label
@@ -199,10 +202,7 @@ class PID(Block):
     self._last_input = input_
 
     # Clamping the i term if required
-    if self._i_min is not None:
-      self._i_term = max(self._i_min, self._i_term)
-    if self._i_max is not None:
-      self._i_term = min(self._i_max, self._i_term)
+    self._i_term = min(max(self._i_min, self._i_term), self._i_max)
 
     # Clamping the output if required
     out = p_term + self._i_term + d_term

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -168,14 +168,14 @@ class PID(Block):
 
     # Updating the gains if provided
     if self._kp_label in data:
-      kp = data[self._kp_label]
-      self._kp = -abs(kp) if self._reverse else kp
+      kp = abs(data[self._kp_label])
+      self._kp = -kp if self._reverse else kp
     if self._ki_label in data:
-      ki = data[self._ki_label]
-      self._ki = -abs(ki) if self._reverse else ki
+      ki = abs(data[self._ki_label])
+      self._ki = -ki if self._reverse else ki
     if self._kd_label in data:
-      kd = data[self._kd_label]
-      self._kd = -abs(kd) if self._reverse else kd
+      kd = abs(data[self._kd_label])
+      self._kd = -kd if self._reverse else kd
 
     # Updating the target value if provided
     if self._target_label in data:

--- a/src/crappy/blocks/pid.py
+++ b/src/crappy/blocks/pid.py
@@ -147,6 +147,18 @@ class PID(Block):
     self._prev_t: float = 0.
     self._i_term: float = 0.
 
+  def prepare(self) -> None:
+    """Checks that there's at least one incoming and one output
+    :class:`~crappy.links.Link`.
+
+    .. versionadded:: 2.0.9
+    """
+
+    if not self.inputs:
+      raise IOError("No Link pointing towards the PID Block!")
+    if not self.outputs:
+      raise IOError("The PID Block has no output Link!")
+
   def loop(self) -> None:
     """Receives the latest target and input values, calculates the P, I and D
     terms and sends the output to the downstream Blocks."""

--- a/src/crappy/blocks/recorder.py
+++ b/src/crappy/blocks/recorder.py
@@ -139,6 +139,9 @@ class Recorder(Block):
     # Keeping only the data that needs to be saved
     data = {key: val for key, val in data.items() if key in self._labels}
 
+    if not all(label in data for label in self._labels):
+      raise IOError("Not all labels received from upstream Block")
+
     if data:
       with open(self._path, 'a', newline='') as file:
         writer = csv.writer(file, lineterminator='\n')

--- a/src/crappy/blocks/recorder.py
+++ b/src/crappy/blocks/recorder.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from pathlib import Path
+import csv
 import logging
 
 from .meta_block import Block
@@ -123,9 +124,10 @@ class Recorder(Block):
           self._labels = list(data.keys())
 
         # The first row of the file contains the names of the labels
-        with open(self._path, 'w') as file:
+        with open(self._path, 'w', newline='') as file:
           self.log(logging.INFO, f"Writing the header on file {self._path}")
-          file.write(f"{','.join(self._labels)}\n")
+          writer = csv.writer(file, lineterminator='\n')
+          writer.writerow(self._labels)
 
         self._file_initialized = True
       else:
@@ -138,11 +140,12 @@ class Recorder(Block):
     data = {key: val for key, val in data.items() if key in self._labels}
 
     if data:
-      with open(self._path, 'a') as file:
+      with open(self._path, 'a', newline='') as file:
+        writer = csv.writer(file, lineterminator='\n')
         # Sorting the lists of values in the same order as the labels
         sorted_data = [data[label] for label in self._labels]
         # Actually writing the values
         self.log(logging.DEBUG, f"Writing {sorted_data} to the file "
                                 f"{self._path}")
         for values in zip(*sorted_data):
-          file.write(f"{','.join(map(str, values))}\n")
+          writer.writerow(map(str, values))

--- a/src/crappy/blocks/recorder.py
+++ b/src/crappy/blocks/recorder.py
@@ -90,7 +90,7 @@ class Recorder(Block):
     if not self.inputs:
       raise ValueError('The Recorder block does not have inputs !')
     elif len(self.inputs) > 1:
-      raise ValueError('Cannot link more than one block to a Recorder block !')
+      raise ValueError('Cannot link more than one Block to a Recorder Block!')
 
     # Creating the folder for storing the data if it does not already exist
     if not Path.is_dir(parent_folder := self._path.parent):

--- a/src/crappy/blocks/sink.py
+++ b/src/crappy/blocks/sink.py
@@ -43,6 +43,15 @@ class Sink(Block):
     self.debug = debug
     self.pausable = False
 
+  def prepare(self) -> None:
+    """Checks that there's at least one incoming :class:`~crappy.links.Link`.
+
+    .. versionadded:: 2.0.9
+    """
+
+    if not self.inputs:
+      raise IOError("No Link pointing towards the Sink Block !")
+
   def loop(self) -> None:
     """Drops all the received data."""
 

--- a/src/crappy/blocks/synchronizer.py
+++ b/src/crappy/blocks/synchronizer.py
@@ -158,7 +158,7 @@ class Synchronizer(Block):
       (self._data[self._ref_label][0] <= max_t)]
 
     # Checking if there are values for the target label in the valid time range
-    if not np.any(interp_times):
+    if not interp_times.size:
       self.log(logging.DEBUG,
                "No value of the target label found between the minimum and "
                "maximum possible interpolation times")

--- a/src/crappy/blocks/synchronizer.py
+++ b/src/crappy/blocks/synchronizer.py
@@ -80,6 +80,18 @@ class Synchronizer(Block):
     else:
       self._to_sync = None
 
+  def prepare(self) -> None:
+    """Checks that there's at least one incoming and one output
+    :class:`~crappy.links.Link`.
+
+    .. versionadded:: 2.0.9
+    """
+
+    if not self.inputs:
+      raise IOError("No Link pointing towards the Multiplexer Block!")
+    if not self.outputs:
+      raise IOError("The Multiplexer Block has no output Link!")
+
   def loop(self) -> None:
     """Receives data, interpolates it, and sends it to the downstream
     Blocks."""

--- a/src/crappy/blocks/synchronizer.py
+++ b/src/crappy/blocks/synchronizer.py
@@ -153,9 +153,9 @@ class Synchronizer(Block):
       return
 
     # The array containing the timestamps for interpolating
-    interp_times = self._data[self._ref_label][0,
-      (self._data[self._ref_label][0] >= min_t) &
-      (self._data[self._ref_label][0] <= max_t)]
+    ref_times = self._data[self._ref_label][0]
+    interp_mask = (ref_times >= min_t) & (ref_times <= max_t)
+    interp_times = ref_times[interp_mask]
 
     # Checking if there are values for the target label in the valid time range
     if not interp_times.size:
@@ -171,7 +171,7 @@ class Synchronizer(Block):
 
       # Keeping the values of the reference label as they are
       if label == self._ref_label:
-        to_send[label] = values[1, :]
+        to_send[label] = list(values[1, interp_mask])
       # For all the other labels, performing interpolation
       else:
         to_send[label] = list(np.interp(interp_times, values[0], values[1]))

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -98,7 +98,8 @@ class UController(Block):
       raise TypeError("display_freq should be either True or False !")
     self.display_freq = display_freq
 
-    if not isinstance(freq, float) and not isinstance(freq, int) or freq <= 0:
+    if (freq is not None and
+        (not isinstance(freq, (float, int)) or freq <= 0)):
       raise TypeError("freq should be a positive float !")
     self.freq = freq
 

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -178,6 +178,10 @@ class UController(Block):
       raise IOError("labels are specified but there's no output link !")
     if self._cmd_labels is not None and not self.inputs:
       raise IOError("cmd_labels are specified but there's no input link !")
+    if self._cmd_labels is None and self.inputs:
+      raise IOError("No cmd_label specified although there are input Links!")
+    if self._labels is None and self.outputs:
+      raise IOError("No label specified although there are output Links!")
 
     # Buffer for storing the received bytes
     if self._labels is not None:

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -13,7 +13,9 @@ try:
   from serial.serialutil import SerialException
 except (ModuleNotFoundError, ImportError):
   Serial = OptionalModule("pyserial")
-  SerialException = OptionalModule("pyserial")
+
+  class SerialException(Exception):
+    """Fallback exception used when pyserial is not installed."""
 
 
 class UController(Block):

--- a/src/crappy/blocks/ucontroller.py
+++ b/src/crappy/blocks/ucontroller.py
@@ -123,6 +123,10 @@ class UController(Block):
     else:
       self._labels = None
 
+    if self._t_device and self._labels is not None and len(self._labels) > 8:
+      raise ValueError("Cannot manage more than 8 labels when t_device is "
+                       "True")
+
     # Forcing the cmd_labels into a list
     if cmd_labels is not None and isinstance(cmd_labels, str):
       self._cmd_labels = [cmd_labels]


### PR DESCRIPTION
This PR fixes various bugs, mostly medium- to low-criticity, and a few critical ones.

Main changes:
- Enforce a proper check of the consistency of input and output Links on the modified Blocks.
- Modify the behavior of LinkReader to force displaying all individual incoming messages
- Compute the time label of the MeanBlock more accurately from input data
- Fix incorrect handling of edge cases in Multiplexer Block timing
- Fix inconsistent behavior of the PID Block on the first loop
- Fix incorrect calculation of interpolation times in the Synchronizer Block
- Prevent oversleeping in the recv_all_data and recv_all_data_raw methods of Block
